### PR TITLE
Pass query string args to the pipeline components + support those params in the ner_duckling component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 Added
 -----
 - query strings arguments passed to the pipeline components
+- `ner_duckling_http` can take timezone and reference_time from the query string
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 
 Added
 -----
+- query strings arguments passed to the pipeline components
 
 Changed
 -------

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -239,7 +239,9 @@ class DataRouter(object):
     def extract(self, data: Dict[Text, Any]) -> Dict[Text, Any]:
         return self.emulator.normalise_request_json(data)
 
-    def parse(self, data: Dict[Text, Any], request_params: Optional[Dict[Text, Text]]=None) -> Dict[Text, Any]:
+    def parse(self, data: Dict[Text, Any],
+              request_params: Optional[Dict[Text, Text]] = None) \
+            -> Dict[Text, Any]:
         project = data.get("project", RasaNLUModelConfig.DEFAULT_PROJECT_NAME)
         model = data.get("model")
 
@@ -264,7 +266,8 @@ class DataRouter(object):
 
         time = data.get('time')
         response = self.project_store[project].parse(data['text'], time,
-                                                     model, request_params=request_params)
+                                                 model,
+                                                 request_params=request_params)
 
         if self.responses:
             self.responses.info('', user_input=response, project=project,

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -239,7 +239,7 @@ class DataRouter(object):
     def extract(self, data: Dict[Text, Any]) -> Dict[Text, Any]:
         return self.emulator.normalise_request_json(data)
 
-    def parse(self, data: Dict[Text, Any]) -> Dict[Text, Any]:
+    def parse(self, data: Dict[Text, Any], request_params: Optional[Dict[Text, Text]]=None) -> Dict[Text, Any]:
         project = data.get("project", RasaNLUModelConfig.DEFAULT_PROJECT_NAME)
         model = data.get("model")
 
@@ -264,7 +264,7 @@ class DataRouter(object):
 
         time = data.get('time')
         response = self.project_store[project].parse(data['text'], time,
-                                                     model)
+                                                     model, request_params=request_params)
 
         if self.responses:
             self.responses.info('', user_input=response, project=project,

--- a/rasa_nlu/emulators/__init__.py
+++ b/rasa_nlu/emulators/__init__.py
@@ -14,16 +14,24 @@ class NoEmulator(object):
             _data["project"] = "default"
         elif type(data["project"]) == list:
             _data["project"] = data["project"][0]
+            del data["project"]
         else:
             _data["project"] = data["project"]
+            del data["project"]
 
         if data.get("model"):
             if type(data["model"]) == list:
                 _data["model"] = data["model"][0]
             else:
                 _data["model"] = data["model"]
+            del data["model"]
 
-        _data['time'] = data["time"] if "time" in data else None
+        if "time" in data:
+            _data['time'] = data["time"]
+            del data["time"]
+
+        for key in data.keys():
+            _data[key] = data[key]
         return _data
 
     def normalise_response_json(self, data: Dict[Text, Any]) -> Dict[Text, Any]:

--- a/rasa_nlu/emulators/__init__.py
+++ b/rasa_nlu/emulators/__init__.py
@@ -7,28 +7,22 @@ class NoEmulator(object):
 
     def normalise_request_json(self, data: Dict[Text, Any]) -> Dict[Text, Any]:
 
-        _data = {}
-        _data["text"] = data["q"][0] if type(data["q"]) == list else data["q"]
-
+        _data = {"text": data["q"][0] if type(data["q"]) == list else data["q"]}
         if not data.get("project"):
             _data["project"] = "default"
         elif type(data["project"]) == list:
             _data["project"] = data["project"][0]
-            del data["project"]
         else:
             _data["project"] = data["project"]
-            del data["project"]
 
         if data.get("model"):
             if type(data["model"]) == list:
                 _data["model"] = data["model"][0]
             else:
                 _data["model"] = data["model"]
-            del data["model"]
 
         if "time" in data:
             _data['time'] = data["time"]
-            del data["time"]
 
         for key in data.keys():
             _data[key] = data[key]

--- a/rasa_nlu/extractors/duckling_http_extractor.py
+++ b/rasa_nlu/extractors/duckling_http_extractor.py
@@ -101,12 +101,11 @@ class DucklingHTTPExtractor(EntityExtractor):
 
     def _url(self):
         """Return url of the duckling service. Environment var will override."""
-        if os.environ.get("RASA_DUCKLING_HTTP_URL"):    
+        if os.environ.get("RASA_DUCKLING_HTTP_URL"):
             return os.environ["RASA_DUCKLING_HTTP_URL"]
 
         return self.component_config.get("url")
 
-    
     def _payload(self, text, reference_time, timezone):
         return {
             "text": text,
@@ -172,9 +171,12 @@ class DucklingHTTPExtractor(EntityExtractor):
 
         if self._url() is not None:
             params = kwargs.get('request_params', None)
-            timezone = self._timezone_from_config_or_request(self.component_config, params.get("timezone", None))
-            reference_time = self._reference_time_from_message_or_request(message, params.get("reference_time", None))
-            matches = self._duckling_parse(message.text, reference_time, timezone)
+            timezone = self._timezone_from_config_or_request(
+                self.component_config, params.get("timezone", None))
+            reference_time = self._reference_time_from_message_or_request(
+                message, params.get("reference_time", None))
+            matches = self._duckling_parse(message.text, reference_time,
+                                           timezone)
             dimensions = self.component_config["dimensions"]
             relevant_matches = filter_irrelevant_matches(matches, dimensions)
             extracted = convert_duckling_format_to_rasa(relevant_matches)

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -337,6 +337,7 @@ class Interpreter(object):
         self.model_metadata = model_metadata
 
     def parse(self, text: Text, time: Optional[datetime.datetime] = None,
+              request_params: Optional[Dict[Text, Text]]=None,
               only_output_properties: bool = True) -> Dict[Text, Any]:
         """Parse the input text, classify it and return pipeline result.
 
@@ -354,7 +355,7 @@ class Interpreter(object):
         message = Message(text, self.default_output_attributes(), time=time)
 
         for component in self.pipeline:
-            component.process(message, **self.context)
+            component.process(message, **self.context, request_params=request_params)
 
         output = self.default_output_attributes()
         output.update(message.as_dict(

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -355,7 +355,8 @@ class Interpreter(object):
         message = Message(text, self.default_output_attributes(), time=time)
 
         for component in self.pipeline:
-            component.process(message, **self.context, request_params=request_params)
+            component.process(message, **self.context,
+                              request_params=request_params)
 
         output = self.default_output_attributes()
         output.update(message.as_dict(

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -244,7 +244,8 @@ class Project(object):
         logger.warning("Invalid model requested. Using default")
         return self._latest_project_model()
 
-    def parse(self, text, parsing_time=None, requested_model_name=None, request_params=None):
+    def parse(self, text, parsing_time=None, requested_model_name=None,
+              request_params=None):
         self._begin_read()
 
         model_name = self._dynamic_load_model(requested_model_name)
@@ -257,7 +258,8 @@ class Project(object):
         finally:
             self._loader_lock.release()
 
-        response = self._models[model_name].parse(text, parsing_time, request_params=request_params)
+        response = self._models[model_name].parse(text, parsing_time,
+                                                  request_params=request_params)
         response['project'] = self._project
         response['model'] = model_name
 

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -244,7 +244,7 @@ class Project(object):
         logger.warning("Invalid model requested. Using default")
         return self._latest_project_model()
 
-    def parse(self, text, parsing_time=None, requested_model_name=None):
+    def parse(self, text, parsing_time=None, requested_model_name=None, request_params=None):
         self._begin_read()
 
         model_name = self._dynamic_load_model(requested_model_name)
@@ -257,7 +257,7 @@ class Project(object):
         finally:
             self._loader_lock.release()
 
-        response = self._models[model_name].parse(text, parsing_time)
+        response = self._models[model_name].parse(text, parsing_time, request_params=request_params)
         response['project'] = self._project
         response['model'] = model_name
 

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -240,7 +240,8 @@ class RasaNLU(object):
             data = self.data_router.extract(request_params)
             try:
                 request.setResponseCode(200)
-                response = yield (self.data_router.parse(data, request_params) if self._testing
+                response = yield (self.data_router.parse(data, request_params)
+                                  if self._testing
                                   else threads.deferToThread(
                         self.data_router.parse, data, request_params))
                 returnValue(json_to_string(response))

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -240,9 +240,9 @@ class RasaNLU(object):
             data = self.data_router.extract(request_params)
             try:
                 request.setResponseCode(200)
-                response = yield (self.data_router.parse(data) if self._testing
+                response = yield (self.data_router.parse(data, request_params) if self._testing
                                   else threads.deferToThread(
-                    self.data_router.parse, data))
+                        self.data_router.parse, data, request_params))
                 returnValue(json_to_string(response))
             except InvalidProjectError as e:
                 request.setResponseCode(404)


### PR DESCRIPTION
**Proposed changes**:
Sometimes passing the query string arguments to the components is necessary. One example is passing the timezone to Duckling: the timezone depends on the user, not the config. 

**Status (please check what you already did)**:
- [x ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x ] updated the changelog
