### PR TITLE
Updated link to pretrained fastText vectors

### DIFF
--- a/docs/nlu/languages.rst
+++ b/docs/nlu/languages.rst
@@ -81,7 +81,7 @@ Pre-trained Word Vectors
 ------------------------
 
 With the ``pretrained_embeddings_spacy`` pipeline you can also load fastText vectors, which are available 
-for `hundreds of languages <https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md>`_.
+for `hundreds of languages <https://github.com/facebookresearch/fastText/blob/master/docs/crawl-vectors.md>`_.
 
 
 =====================   =================================


### PR DESCRIPTION
**Proposed changes**:
- Updated link to pretrained fastText vectors since current link is dead (404).
**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
