### PR TITLE
update docker-walkthrough docs

### DIFF
--- a/docs/core/docker_walkthrough.rst
+++ b/docs/core/docker_walkthrough.rst
@@ -394,7 +394,7 @@ your ``docker-compose.yml`` it should have the following content:
         - --endpoints
         - config/endpoints.yml
         - -u
-        - current/
+        - default/
     rasa_nlu:
       image: rasa/rasa_nlu:latest-spacy
       volumes:


### PR DESCRIPTION
**Proposed changes**:

I got this error when running docker-compose up : "No project found with name 'current'."
I fixed it by changing “current” to “default”
