### PR TITLE
rasa test: make use of additional arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,5 +59,5 @@ Fixed
   Store
 - ``rasa nlu test`` doesn't error anymore when a test file is passed with ``-u``
 - in interactive learning: only updates entity values if user changes annotation
-- ``rasa train core`` actually uses additional arguments, such as ``augmentation`
+- ``rasa train core`` actually uses additional arguments, such as ``augmentation``
 - ``rasa test`` actually considers additional arguments, such as ``e2e``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,4 +59,5 @@ Fixed
   Store
 - ``rasa nlu test`` doesn't error anymore when a test file is passed with ``-u``
 - in interactive learning: only updates entity values if user changes annotation
-- ``rasa train core`` actually uses additional arguments, such as `augmentation`
+- ``rasa train core`` actually uses additional arguments, such as ``augmentation`
+- ``rasa test`` actually considers additional arguments, such as ``e2e``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,4 +60,4 @@ Fixed
 - ``rasa nlu test`` doesn't error anymore when a test file is passed with ``-u``
 - in interactive learning: only updates entity values if user changes annotation
 - ``rasa train core`` actually uses additional arguments, such as ``augmentation``
-- ``rasa test`` actually considers additional arguments, such as ``e2e``
+- ``rasa test`` actually considers additional arguments, such as ``e2e`` or ``successes``

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -99,7 +99,7 @@ def _add_nlu_arguments(
         "-u",
         "--nlu",
         type=str,
-        default="data/nlu",
+        default=DEFAULT_DATA_PATH,
         help="file containing training/evaluation data",
     )
 
@@ -194,7 +194,7 @@ def test_nlu(args: argparse.Namespace, model_path: Optional[Text] = None) -> Non
     model_path = model_path or args.model
 
     if model_path:
-        test_nlu(nlu_data=nlu_data, **vars(args))
+        test_nlu(model_path, nlu_data, vars(args))
     else:
         print ("No model specified. Model will be trained using cross validation.")
         config = get_validated_path(args.config, "config", DEFAULT_CONFIG_PATH)
@@ -207,4 +207,4 @@ def test(args: argparse.Namespace):
     unpacked_model = get_model(model_path)
 
     test_core(args, unpacked_model)
-    test_nlu(args, unpacked_model)
+    test_nlu(args, model_path)

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -11,6 +11,7 @@ from rasa.constants import (
     DEFAULT_DATA_PATH,
     DEFAULT_ENDPOINTS_PATH,
     DEFAULT_MODELS_PATH,
+    DEFAULT_RESULTS_PATH,
 )
 from rasa.model import get_latest_model, get_model
 
@@ -172,26 +173,33 @@ def _add_nlu_subparser_arguments(parser: argparse.ArgumentParser):
 def test_core(args: argparse.Namespace, model_path: Optional[Text] = None) -> None:
     from rasa.test import test_core
 
-    args.model = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
-    args.endpoints = get_validated_path(
+    model = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
+    endpoints = get_validated_path(
         args.endpoints, "endpoints", DEFAULT_ENDPOINTS_PATH, True
     )
-    args.config = get_validated_path(args.config, "config", DEFAULT_CONFIG_PATH)
-    args.stories = get_validated_path(args.stories, "stories", DEFAULT_DATA_PATH)
+    stories = get_validated_path(args.stories, "stories", DEFAULT_DATA_PATH)
+    stories = data.get_core_directory(stories)
+    out = get_validated_path(args.output, "output", DEFAULT_RESULTS_PATH)
 
-    args.stories = data.get_core_directory(args.stories)
-
-    test_core(model_path=model_path, **vars(args))
+    test_core(
+        model=model,
+        stories=stories,
+        endpoints=endpoints,
+        model_path=model_path,
+        output=out,
+        kwargs=vars(args),
+    )
 
 
 def test_nlu(args: argparse.Namespace, model_path: Optional[Text] = None) -> None:
     from rasa.test import test_nlu, test_nlu_with_cross_validation
 
     args.model = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
+    model_path = model_path or args.model
+
     nlu_data = get_validated_path(args.nlu, "nlu", DEFAULT_DATA_PATH)
     if os.path.isdir(nlu_data):
         nlu_data = data.get_nlu_directory(nlu_data)
-    model_path = model_path or args.model
 
     if model_path:
         test_nlu(model_path, nlu_data, vars(args))

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -179,7 +179,7 @@ def test_core(args: argparse.Namespace, model_path: Optional[Text] = None) -> No
     )
     stories = get_validated_path(args.stories, "stories", DEFAULT_DATA_PATH)
     stories = data.get_core_directory(stories)
-    output = get_validated_path(args.output, "output", DEFAULT_RESULTS_PATH)
+    output = args.output or DEFAULT_RESULTS_PATH
     args.config = get_validated_path(args.config, "config", DEFAULT_CONFIG_PATH)
 
     test_core(
@@ -195,8 +195,8 @@ def test_core(args: argparse.Namespace, model_path: Optional[Text] = None) -> No
 def test_nlu(args: argparse.Namespace, model_path: Optional[Text] = None) -> None:
     from rasa.test import test_nlu, test_nlu_with_cross_validation
 
-    args.model = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
-    model_path = model_path or args.model
+    valid_model_path = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
+    model_path = model_path or valid_model_path
 
     nlu_data = get_validated_path(args.nlu, "nlu", DEFAULT_DATA_PATH)
     if os.path.isdir(nlu_data):

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -179,14 +179,15 @@ def test_core(args: argparse.Namespace, model_path: Optional[Text] = None) -> No
     )
     stories = get_validated_path(args.stories, "stories", DEFAULT_DATA_PATH)
     stories = data.get_core_directory(stories)
-    out = get_validated_path(args.output, "output", DEFAULT_RESULTS_PATH)
+    output = get_validated_path(args.output, "output", DEFAULT_RESULTS_PATH)
+    args.config = get_validated_path(args.config, "config", DEFAULT_CONFIG_PATH)
 
     test_core(
         model=model,
         stories=stories,
         endpoints=endpoints,
         model_path=model_path,
-        output=out,
+        output=output,
         kwargs=vars(args),
     )
 

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -187,9 +187,5 @@ def extract_additional_arguments(args: argparse.Namespace) -> typing.Dict:
         arguments["dump_stories"] = args.dump_stories
     if "debug_plots" in args:
         arguments["debug_plots"] = args.debug_plots
-    if "percentages" in args:
-        arguments["percentages"] = args.percentages
-    if "runs" in args:
-        arguments["runs"] = args.runs
 
     return arguments

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -1,7 +1,7 @@
 import argparse
 import tempfile
 import typing
-from typing import List, Optional, Text
+from typing import List, Optional, Text, Dict
 
 from rasa.cli.default_arguments import (
     add_config_param,
@@ -178,7 +178,7 @@ def train_nlu(
     return train_nlu(config, nlu_data, output, train_path)
 
 
-def extract_additional_arguments(args: argparse.Namespace) -> typing.Dict:
+def extract_additional_arguments(args: argparse.Namespace) -> Dict:
     arguments = {}
 
     if "augmentation" in args:

--- a/rasa/cli/utils.py
+++ b/rasa/cli/utils.py
@@ -27,9 +27,13 @@ def get_validated_path(
 
     if current is None or current is not None and not os.path.exists(current):
         if default is not None and os.path.exists(default):
+            not_found = (
+                "'{}' not found.".format(current)
+                if current is not None
+                else "Parameter '{}' not set.".format(parameter)
+            )
             print_warning(
-                "'{}' not found. Using default location '{}' instead."
-                "".format(current, default)
+                "{} Using default location '{}' instead." "".format(not_found, default)
             )
             current = default
         elif none_is_valid:

--- a/rasa/cli/utils.py
+++ b/rasa/cli/utils.py
@@ -27,13 +27,12 @@ def get_validated_path(
 
     if current is None or current is not None and not os.path.exists(current):
         if default is not None and os.path.exists(default):
-            not_found = (
-                "'{}' not found.".format(current)
-                if current is not None
-                else "Parameter '{}' not set.".format(parameter)
-            )
+            reason_str = "'{}' not found.".format(current)
+            if current is None:
+                reason_str = "Parameter '{}' not set.".format(parameter)
+
             print_warning(
-                "{} Using default location '{}' instead." "".format(not_found, default)
+                "{} Using default location '{}' instead." "".format(reason_str, default)
             )
             current = default
         elif none_is_valid:
@@ -114,7 +113,7 @@ def create_output_path(
 
 
 def minimal_kwargs(
-    kwargs: Dict[Text, Any], func: Callable, exception_keys: Optional[List] = None
+    kwargs: Dict[Text, Any], func: Callable, excluded_keys: Optional[List] = None
 ) -> Dict[Text, Any]:
     """Returns only the kwargs which are required by a function. Keys, contained in
     the exception list, are not included.
@@ -122,7 +121,7 @@ def minimal_kwargs(
     Args:
         kwargs: All available kwargs.
         func: The function which should be called.
-        exception_keys: Keys to exclude from the result.
+        excluded_keys: Keys to exclude from the result.
 
     Returns:
         Subset of kwargs which are accepted by `func`.
@@ -130,15 +129,14 @@ def minimal_kwargs(
     """
     from rasa.utils.common import arguments_of
 
-    if exception_keys is None:
-        exception_keys = []
+    excluded_keys = excluded_keys or []
 
     possible_arguments = arguments_of(func)
 
     return {
         k: v
         for k, v in kwargs.items()
-        if k in possible_arguments and k not in exception_keys
+        if k in possible_arguments and k not in excluded_keys
     }
 
 

--- a/rasa/cli/utils.py
+++ b/rasa/cli/utils.py
@@ -113,12 +113,16 @@ def create_output_path(
         return os.path.join(output_path, file_name)
 
 
-def minimal_kwargs(kwargs: Dict[Text, Any], func: Callable) -> Dict[Text, Any]:
-    """Returns only the kwargs which are required by a function.
+def minimal_kwargs(
+    kwargs: Dict[Text, Any], func: Callable, exception_keys: Optional[List] = None
+) -> Dict[Text, Any]:
+    """Returns only the kwargs which are required by a function. Keys, contained in
+    the exception list, are not included.
 
     Args:
         kwargs: All available kwargs.
         func: The function which should be called.
+        exception_keys: Keys to exclude from the result.
 
     Returns:
         Subset of kwargs which are accepted by `func`.
@@ -126,9 +130,16 @@ def minimal_kwargs(kwargs: Dict[Text, Any], func: Callable) -> Dict[Text, Any]:
     """
     from rasa.utils.common import arguments_of
 
+    if exception_keys is None:
+        exception_keys = []
+
     possible_arguments = arguments_of(func)
 
-    return {k: v for k, v in kwargs.items() if k in possible_arguments}
+    return {
+        k: v
+        for k, v in kwargs.items()
+        if k in possible_arguments and k not in exception_keys
+    }
 
 
 def print_success(*args: Any):

--- a/rasa/core/server.py
+++ b/rasa/core/server.py
@@ -594,7 +594,7 @@ def create_app(
         tmp_file = rasa.nlu.utils.create_temporary_file(request.body, mode="w+b")
         use_e2e = utils.bool_arg(request, "e2e", default=False)
         try:
-            evaluation = await test(tmp_file, app.agent, use_e2e=use_e2e)
+            evaluation = await test(tmp_file, app.agent, e2e=use_e2e)
             return response.json(evaluation)
         except ValueError as e:
             raise ErrorResponse(

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -506,15 +506,15 @@ async def test(
     max_stories: Optional[int] = None,
     out_directory: Optional[Text] = None,
     fail_on_prediction_errors: bool = False,
-    use_e2e: bool = False,
+    e2e: bool = False,
 ):
     """Run the evaluation of the stories, optionally plot the results."""
     from rasa.nlu.test import get_evaluation_metrics
 
-    completed_trackers = await _generate_trackers(stories, agent, max_stories, use_e2e)
+    completed_trackers = await _generate_trackers(stories, agent, max_stories, e2e)
 
     story_evaluation, _ = collect_story_predictions(
-        completed_trackers, agent, fail_on_prediction_errors, use_e2e
+        completed_trackers, agent, fail_on_prediction_errors, e2e
     )
 
     evaluation_store = story_evaluation.evaluation_store
@@ -549,7 +549,7 @@ async def test(
         "accuracy": accuracy,
         "actions": story_evaluation.action_list,
         "in_training_data_fraction": story_evaluation.in_training_data_fraction,
-        "is_end_to_end_evaluation": use_e2e,
+        "is_end_to_end_evaluation": e2e,
     }
 
 

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Text, Union, Dict
 from tqdm import tqdm
 
 from rasa.nlu import config, training_data, utils
+from rasa.nlu.components import ComponentBuilder
 from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.extractors.crf_entity_extractor import CRFEntityExtractor
 from rasa.nlu.model import Interpreter, Trainer, TrainingData
@@ -783,14 +784,27 @@ def remove_duckling_entities(entity_predictions):
 def run_evaluation(
     data_path: Text,
     model_path: Text,
-    report_folder: Text = None,
-    successes: Text = None,
-    errors: Text = "errors.json",
-    confmat: Text = None,
-    histogram: Text = None,
-    component_builder: Text = None,
+    report_folder: Optional[Text] = None,
+    successes: Optional[Text] = None,
+    errors: Optional[Text] = "errors.json",
+    confmat: Optional[Text] = None,
+    histogram: Optional[Text] = None,
+    component_builder: Optional[ComponentBuilder] = None,
 ) -> Dict:  # pragma: no cover
-    """Evaluate intent classification and entity extraction."""
+    """
+    Evaluate intent classification and entity extraction.
+
+    :param data_path: path to the test data
+    :param model: path to the model
+    :param report_folder: path to folder where reports are stored
+    :param successes: path to file that will contain success cases
+    :param errors: path to file that will contain error cases
+    :param confmat: path to file that will show the confusion matrix
+    :param histogram: path fo file that will show a histogram
+    :param component_builder: component builder
+
+    :return: dictionary containing evaluation results
+    """
 
     # get the metadata config from the package data
     interpreter = Interpreter.load(model_path, component_builder)

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -784,10 +784,10 @@ def run_evaluation(
     data_path: Text,
     model_path: Text,
     report_folder: Text = None,
-    successes_filename: Text = None,
-    errors_filename: Text = "errors.json",
-    confmat_filename: Text = None,
-    intent_hist_filename: Text = None,
+    successes: Text = None,
+    errors: Text = "errors.json",
+    confmat: Text = None,
+    histogram: Text = None,
     component_builder: Text = None,
 ) -> Dict:  # pragma: no cover
     """Evaluate intent classification and entity extraction."""
@@ -820,12 +820,7 @@ def run_evaluation(
 
         logger.info("Intent evaluation results:")
         result["intent_evaluation"] = evaluate_intents(
-            intent_results,
-            report_folder,
-            successes_filename,
-            errors_filename,
-            confmat_filename,
-            intent_hist_filename,
+            intent_results, report_folder, successes, errors, confmat, histogram
         )
 
     if extractors:

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Text, Dict
+from typing import Text, Dict, Optional
 import os
 
 from rasa.constants import DEFAULT_RESULTS_PATH
@@ -16,10 +16,10 @@ def test(
     nlu_data: Text,
     endpoints: Text = None,
     output: Text = DEFAULT_RESULTS_PATH,
-    **kwargs
+    kwargs: Optional[Dict] = Dict,
 ):
     test_core(model, stories, endpoints, output, **kwargs)
-    test_nlu(model, nlu_data, **kwargs)
+    test_nlu(model, nlu_data, kwargs)
 
 
 def test_core(
@@ -77,13 +77,20 @@ def test_core(
         plot_curve(output, number_of_stories)
 
 
-def test_nlu(model: Text, nlu_data: Text, **kwargs: Dict):
+def test_nlu(model: Optional[Text], nlu_data: Optional[Text], kwargs: Optional[Dict]):
     from rasa.nlu.test import run_evaluation
 
     unpacked_model = get_model(model)
     nlu_model = os.path.join(unpacked_model, "nlu")
+
     if os.path.exists(nlu_model):
         kwargs = minimal_kwargs(kwargs, run_evaluation)
+
+        if "data_path" in kwargs:
+            kwargs.pop("data_path")
+        if "model" in kwargs:
+            kwargs.pop("model")
+
         run_evaluation(nlu_data, nlu_model, **kwargs)
 
 

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -23,12 +23,12 @@ def test(
 
 
 def test_core(
-    model: Text,
-    stories: Text,
-    endpoints: Text = None,
+    model: Optional[Text] = None,
+    stories: Optional[Text] = None,
+    endpoints: Optional[Text] = None,
     output: Text = DEFAULT_RESULTS_PATH,
-    model_path: Text = None,
-    **kwargs: Dict
+    model_path: Optional[Text] = None,
+    kwargs: Optional[Dict] = Dict,
 ):
     import rasa.core.test
     import rasa.core.utils as core_utils
@@ -57,6 +57,10 @@ def test_core(
             _agent = Agent.load(core_path, interpreter=_interpreter)
 
             kwargs = minimal_kwargs(kwargs, rasa.core.test)
+
+            if "stories" in kwargs:
+                kwargs.pop("stories")
+
             loop.run_until_complete(
                 rasa.core.test(stories, _agent, out_directory=output, **kwargs)
             )

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -16,8 +16,11 @@ def test(
     nlu_data: Text,
     endpoints: Text = None,
     output: Text = DEFAULT_RESULTS_PATH,
-    kwargs: Optional[Dict] = Dict,
+    kwargs: Optional[Dict] = None,
 ):
+    if kwargs is None:
+        kwargs = {}
+
     test_core(model, stories, endpoints, output, **kwargs)
     test_nlu(model, nlu_data, kwargs)
 
@@ -28,7 +31,7 @@ def test_core(
     endpoints: Optional[Text] = None,
     output: Text = DEFAULT_RESULTS_PATH,
     model_path: Optional[Text] = None,
-    kwargs: Optional[Dict] = Dict,
+    kwargs: Optional[Dict] = None,
 ):
     import rasa.core.test
     import rasa.core.utils as core_utils
@@ -38,6 +41,9 @@ def test_core(
     from rasa.core.agent import Agent
 
     _endpoints = core_utils.AvailableEndpoints.read_endpoints(endpoints)
+
+    if kwargs is None:
+        kwargs = {}
 
     if output:
         nlu_utils.create_dir(output)
@@ -56,10 +62,7 @@ def test_core(
 
             _agent = Agent.load(core_path, interpreter=_interpreter)
 
-            kwargs = minimal_kwargs(kwargs, rasa.core.test)
-
-            if "stories" in kwargs:
-                kwargs.pop("stories")
+            kwargs = minimal_kwargs(kwargs, rasa.core.test, ["stories", "agent"])
 
             loop.run_until_complete(
                 rasa.core.test(stories, _agent, out_directory=output, **kwargs)
@@ -88,13 +91,7 @@ def test_nlu(model: Optional[Text], nlu_data: Optional[Text], kwargs: Optional[D
     nlu_model = os.path.join(unpacked_model, "nlu")
 
     if os.path.exists(nlu_model):
-        kwargs = minimal_kwargs(kwargs, run_evaluation)
-
-        if "data_path" in kwargs:
-            kwargs.pop("data_path")
-        if "model" in kwargs:
-            kwargs.pop("model")
-
+        kwargs = minimal_kwargs(kwargs, run_evaluation, ["data_path", "model"])
         run_evaluation(nlu_data, nlu_model, **kwargs)
 
 

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -14,7 +14,7 @@ def test(
     model: Text,
     stories: Text,
     nlu_data: Text,
-    endpoints: Text = None,
+    endpoints: Optional[Text] = None,
     output: Text = DEFAULT_RESULTS_PATH,
     kwargs: Optional[Dict] = None,
 ):

--- a/tests/core/test_evaluation.py
+++ b/tests/core/test_evaluation.py
@@ -23,7 +23,7 @@ async def test_evaluation_image_creation(tmpdir, default_agent):
         agent=default_agent,
         out_directory=tmpdir.strpath,
         max_stories=None,
-        use_e2e=False,
+        e2e=False,
     )
 
     assert os.path.isfile(img_path)


### PR DESCRIPTION
**Proposed changes**:
- ``rasa test`` was ignoring additional arguments, such as `e2e` or `successes`, before. now those arguments are considered and used during evaluation.

related to #3272 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
