### PR TITLE
Cli rasa interactive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Added
 - you can now choose actions previously created in the same session
 in ``interactive learning``
 - add formatter 'black'
+- add ``rasa interactive core`` to command line interface
 
 
 Changed
@@ -43,7 +44,8 @@ Changed
 - removed ``--pre_load`` from run command (Rasa NLU server will just have a maximum of one model and that model will be loaded by default)
 - changed file format of a stored trained model from the Rasa NLU server to ``tar.gz``
 - ``rasa train`` uses fallback config if an invalid config is given
-- ``rasa test core`` compares multiple models if a list of model files is provided for the argument ``--model`
+- ``rasa test core`` compares multiple models if a list of model files is provided for the argument ``--model``
+- ``rasa train`` fails if either nlu or story data are missing
 
 Removed
 -------

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -4,6 +4,7 @@ from typing import List
 
 import rasa.cli.run as run
 import rasa.cli.train as train
+import rasa.core.cli.train as core_cli
 from rasa import data, model
 
 
@@ -17,24 +18,23 @@ def add_subparser(
         parents=parents,
         help="Teach the bot with interactive learning",
     )
+
     run.add_run_arguments(interactive_parser)
     train.add_general_arguments(interactive_parser)
     train.add_domain_param(interactive_parser)
     train.add_joint_parser_arguments(interactive_parser)
     _add_interactive_arguments(interactive_parser)
+
     interactive_parser.set_defaults(func=interactive)
 
-    interactive_core_subparsers = interactive_parser.add_subparsers()
-    interactive_core_parser = interactive_core_subparsers.add_parser(
+    interactive_subparsers = interactive_parser.add_subparsers()
+    interactive_core_parser = interactive_subparsers.add_parser(
         "core",
         conflict_handler="resolve",
         parents=parents,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         help="Train a Rasa Core model with interactive learning",
     )
-    interactive_core_parser.set_defaults(func=interactive_core)
-
-    import rasa.core.cli.train as core_cli
 
     train.add_domain_param(interactive_core_parser)
     core_cli.add_general_args(interactive_core_parser)
@@ -43,6 +43,8 @@ def add_subparser(
     run.add_run_arguments(interactive_core_parser)
     _add_interactive_arguments(interactive_core_parser)
     train.add_general_arguments(interactive_core_parser)
+
+    interactive_core_parser.set_defaults(func=interactive_core)
 
 
 def _add_interactive_arguments(parser: argparse.ArgumentParser):

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -17,13 +17,32 @@ def add_subparser(
         parents=parents,
         help="Teach the bot with interactive learning",
     )
-
     run.add_run_arguments(interactive_parser)
     train.add_general_arguments(interactive_parser)
     train.add_domain_param(interactive_parser)
     train.add_joint_parser_arguments(interactive_parser)
     _add_interactive_arguments(interactive_parser)
     interactive_parser.set_defaults(func=interactive)
+
+    interactive_core_subparsers = interactive_parser.add_subparsers()
+    interactive_core_parser = interactive_core_subparsers.add_parser(
+        "core",
+        conflict_handler="resolve",
+        parents=parents,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Train a Rasa Core model with interactive learning",
+    )
+    interactive_core_parser.set_defaults(func=interactive_core)
+
+    import rasa.core.cli.train as core_cli
+
+    train.add_domain_param(interactive_core_parser)
+    core_cli.add_general_args(interactive_core_parser)
+    train.add_stories_param(interactive_core_parser)
+    train.add_domain_param(interactive_core_parser)
+    run.add_run_arguments(interactive_core_parser)
+    _add_interactive_arguments(interactive_core_parser)
+    train.add_general_arguments(interactive_core_parser)
 
 
 def _add_interactive_arguments(parser: argparse.ArgumentParser):
@@ -41,6 +60,23 @@ def interactive(args: argparse.Namespace):
     args.finetune = False  # Don't support finetuning
 
     zipped_model = train.train(args)
+
+    if zipped_model:
+        model_path = model.unpack_model(zipped_model)
+        args.core, args.nlu = model.get_model_subdirectories(model_path)
+        stories_directory = data.get_core_directory(args.data)
+
+        do_interactive_learning(args, stories_directory)
+
+        shutil.rmtree(model_path)
+
+
+def interactive_core(args: argparse.Namespace):
+    from rasa.core.train import do_interactive_learning
+
+    args.finetune = False  # Don't support finetuning
+
+    zipped_model = train.train_core(args)
 
     if zipped_model:
         model_path = model.unpack_model(zipped_model)

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -41,10 +41,12 @@ def interactive(args: argparse.Namespace):
     args.finetune = False  # Don't support finetuning
 
     zipped_model = train.train(args)
-    model_path = model.unpack_model(zipped_model)
-    args.core, args.nlu = model.get_model_subdirectories(model_path)
-    stories_directory = data.get_core_directory(args.data)
 
-    do_interactive_learning(args, stories_directory)
+    if zipped_model:
+        model_path = model.unpack_model(zipped_model)
+        args.core, args.nlu = model.get_model_subdirectories(model_path)
+        stories_directory = data.get_core_directory(args.data)
 
-    shutil.rmtree(model_path)
+        do_interactive_learning(args, stories_directory)
+
+        shutil.rmtree(model_path)

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import shutil
 from typing import List
 
@@ -9,6 +10,10 @@ from rasa import data, model
 
 
 # noinspection PyProtectedMember
+from rasa.cli.utils import get_validated_path, print_error
+from rasa.constants import DEFAULT_DATA_PATH
+
+
 def add_subparser(
     subparsers: argparse._SubParsersAction, parents: List[argparse.ArgumentParser]
 ):
@@ -60,6 +65,17 @@ def interactive(args: argparse.Namespace):
     from rasa.core.train import do_interactive_learning
 
     args.finetune = False  # Don't support finetuning
+
+    training_files = [
+        get_validated_path(f, "data", DEFAULT_DATA_PATH) for f in args.data
+    ]
+    story_directory, nlu_data_directory = data.get_core_nlu_directories(training_files)
+
+    if not os.listdir(story_directory) or not os.listdir(nlu_data_directory):
+        print_error(
+            "Cannot train initial Rasa model. Please provide NLU data and Core data."
+        )
+        return
 
     zipped_model = train.train(args)
 

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -167,7 +167,7 @@ def train_core(
 
 def train_nlu(
     args: argparse.Namespace, train_path: Optional[Text] = None
-) -> Optional["Interpreter"]:
+) -> Optional[Text]:
     from rasa.train import train_nlu
 
     output = train_path or args.out

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -186,7 +186,7 @@ async def train_core_async(
         return
 
     # normal (not compare) training
-    core_model = await rasa.core.train(
+    await rasa.core.train(
         domain_file=domain,
         stories_file=story_directory,
         output_path=os.path.join(_train_path, "core"),
@@ -205,12 +205,14 @@ async def train_core_async(
             "Your Rasa Core model is trained and saved at '{}'.".format(output_path)
         )
 
-    return core_model
+        return output_path
+
+    return _train_path
 
 
 def train_nlu(
     config: Text, nlu_data: Text, output: Text, train_path: Optional[Text]
-) -> Optional["Interpreter"]:
+) -> Optional[Text]:
     """Trains a NLU model.
 
     Args:
@@ -251,7 +253,9 @@ def train_nlu(
             "Your Rasa NLU model is trained and saved at '{}'.".format(output_path)
         )
 
-    return nlu_model
+        return output_path
+
+    return _train_path
 
 
 def enrich_config(config_path, missing_keys, FALLBACK_CONFIG_PATH):

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -72,19 +72,27 @@ async def train_async(
         config, domain, nlu_data_directory, story_directory
     )
 
-    if not os.listdir(story_directory):
+    dialogue_data_not_present = not os.listdir(story_directory)
+    nlu_data_not_present = not os.listdir(nlu_data_directory)
+
+    if dialogue_data_not_present and nlu_data_not_present:
         print_error(
-            "No dialogue data given. Please provide dialogue and NLU data in order to "
-            "train a Rasa model."
+            "No training data given. Please provide dialogue and NLU data in "
+            "order to train a Rasa model."
         )
         return
 
-    if not os.listdir(nlu_data_directory):
-        print_error(
-            "No NLU data given. Please provide dialogue and NLU data in order to train "
-            "a Rasa model."
+    if dialogue_data_not_present:
+        print_warning(
+            "No dialogue data present. Just a Rasa NLU model will be trained."
         )
-        return
+        return train_nlu(config, nlu_data_directory, output, None)
+
+    if nlu_data_not_present:
+        print_warning("No NLU data present. Just a Rasa Core model will be trained.")
+        return await train_core_async(
+            domain, config, story_directory, output, None, kwargs
+        )
 
     if not force_training and old_model:
         unpacked = model.unpack_model(old_model)

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -21,9 +21,6 @@ from rasa.constants import (
     FALLBACK_CONFIG_PATH,
 )
 
-if typing.TYPE_CHECKING:
-    from rasa.nlu.model import Interpreter
-
 
 def train(
     domain: Text,
@@ -112,7 +109,7 @@ async def train_async(
             domain, config, story_directory, output, train_path, kwargs
         )
     else:
-        print_warning(
+        print (
             "Dialogue data / configuration did not change. "
             "No need to retrain dialogue model."
         )
@@ -120,9 +117,7 @@ async def train_async(
     if force_training or retrain_nlu:
         train_nlu(config, nlu_data_directory, output, train_path)
     else:
-        print_warning(
-            "NLU data / configuration did not change. No need to retrain NLU model."
-        )
+        print ("NLU data / configuration did not change. No need to retrain NLU model.")
 
     if retrain_core or retrain_nlu:
         output = create_output_path(output)
@@ -133,7 +128,7 @@ async def train_async(
         return output
     else:
         print_success(
-            "Nothing changed. You can use the old model stored at {}"
+            "Nothing changed. You can use the old model stored at '{}'"
             "".format(os.path.abspath(old_model))
         )
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -194,7 +194,10 @@ async def trained_stack_model(
     trained_stack_model_path = await train_async(
         domain=default_domain_path,
         config=default_stack_config,
-        training_files=[default_nlu_data, default_stories_file],
+        training_files=[
+            os.path.dirname(default_nlu_data),
+            os.path.dirname(default_stories_file),
+        ],
     )
 
     return trained_stack_model_path

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -191,13 +191,11 @@ def moodbot_metadata():
 async def trained_stack_model(
     default_domain_path, default_stack_config, default_nlu_data, default_stories_file
 ):
+
     trained_stack_model_path = await train_async(
         domain=default_domain_path,
         config=default_stack_config,
-        training_files=[
-            os.path.dirname(default_nlu_data),
-            os.path.dirname(default_stories_file),
-        ],
+        training_files=[default_nlu_data, default_stories_file],
     )
 
     return trained_stack_model_path


### PR DESCRIPTION
**Proposed changes**:
- `rasa train` fails if only `nlu.data` or `stories.md` are provided. Both data types need to be there in order to execute `rasa train`
- `rasa train core` and `rasa train nlu` will also fail if data is missing
- add `rasa interactive core` to train a core model in interactive mode (regex interpreter will be used for the nlu part - no nlu model is trained)
- `rasa interactive` fails if only `stories.md` data are provided.

related to #3272 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
