### PR TITLE
Update docker_walkthrough.rst

### DIFF
--- a/docs/core/docker_walkthrough.rst
+++ b/docs/core/docker_walkthrough.rst
@@ -251,7 +251,7 @@ the trained Rasa model:
   docker run \
     -v $(pwd):/app/project \
     -v $(pwd)/models/:/app/models \
-    rasa/rasa:latest-spacy \
+    rasa/rasa_nlu:latest-spacy \
     run \
       python3 -m rasa.train \
       -c config.yml \


### PR DESCRIPTION
Fixed the command in 3.1 to read rasa/rasa_nlu:latest-spacy (Note the inclusion of the NLU)
This now matches the later references and also allows a walk though to succeed :) [edit - fixed typo]

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
