### PR TITLE
fix call to request.values

### DIFF
--- a/rasa/core/channels/botframework.py
+++ b/rasa/core/channels/botframework.py
@@ -188,7 +188,7 @@ class BotFrameworkInput(InputChannel):
         botframework_webhook = Blueprint("botframework_webhook", __name__)
 
         @botframework_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @botframework_webhook.route("/webhook", methods=["POST"])

--- a/rasa/core/channels/callback.py
+++ b/rasa/core/channels/callback.py
@@ -1,5 +1,6 @@
 import logging
 from sanic import Blueprint, response
+from sanic.request import Request
 
 from rasa.core.channels import CollectingOutputChannel, UserMessage, RestInput
 from rasa.utils.endpoints import EndpointConfig, ClientResponseError
@@ -53,11 +54,11 @@ class CallbackInput(RestInput):
         callback_webhook = Blueprint("callback_webhook", __name__)
 
         @callback_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @callback_webhook.route("/webhook", methods=["POST"])
-        async def webhook(request):
+        async def webhook(request: Request):
             sender_id = self._extract_sender(request)
             text = self._extract_message(request)
 

--- a/rasa/core/channels/channel.py
+++ b/rasa/core/channels/channel.py
@@ -5,6 +5,7 @@ import logging
 import uuid
 from asyncio import Queue, CancelledError
 from sanic import Sanic, Blueprint, response
+from sanic.request import Request
 from typing import Text, List, Dict, Any, Optional, Callable, Iterable, Awaitable
 
 import rasa.utils.endpoints
@@ -421,11 +422,11 @@ class RestInput(InputChannel):
 
         # noinspection PyUnusedLocal
         @custom_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @custom_webhook.route("/webhook", methods=["POST"])
-        async def receive(request):
+        async def receive(request: Request):
             sender_id = await self._extract_sender(request)
             text = self._extract_message(request)
             should_use_stream = rasa.utils.endpoints.bool_arg(

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -5,6 +5,7 @@ from fbmessenger import MessengerClient
 from fbmessenger.attachments import Image
 from fbmessenger.elements import Text as FBText
 from sanic import Blueprint, response
+from sanic.request import Request
 from typing import Text, List, Dict, Any, Callable, Awaitable, Iterable
 
 from rasa.core.channels.channel import UserMessage, OutputChannel, InputChannel
@@ -263,11 +264,11 @@ class FacebookInput(InputChannel):
         fb_webhook = Blueprint("fb_webhook", __name__)
 
         @fb_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @fb_webhook.route("/webhook", methods=["GET"])
-        async def token_verification(request):
+        async def token_verification(request: Request):
             if request.args.get("hub.verify_token") == self.fb_verify:
                 return response.text(request.args.get("hub.challenge"))
             else:
@@ -278,7 +279,7 @@ class FacebookInput(InputChannel):
                 return response.text("failure, invalid token")
 
         @fb_webhook.route("/webhook", methods=["POST"])
-        async def webhook(request):
+        async def webhook(request: Request):
             signature = request.headers.get("X-Hub-Signature") or ""
             if not self.validate_hub_signature(self.fb_secret, request.body, signature):
                 logger.warning(

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -1,6 +1,7 @@
 import logging
 from mattermostwrapper import MattermostAPI
 from sanic import Blueprint, response
+from sanic.request import Request
 from typing import Text, Dict, Any
 
 from rasa.core.channels.channel import UserMessage, OutputChannel, InputChannel
@@ -79,11 +80,11 @@ class MattermostInput(InputChannel):
         mattermost_webhook = Blueprint("mattermost_webhook", __name__)
 
         @mattermost_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @mattermost_webhook.route("/webhook", methods=["POST"])
-        async def webhook(request):
+        async def webhook(request: Request):
             output = request.json
             if output:
                 # splitting to get rid of the @botmention

--- a/rasa/core/channels/rocketchat.py
+++ b/rasa/core/channels/rocketchat.py
@@ -1,5 +1,6 @@
 import logging
 from sanic import Blueprint, response
+from sanic.request import Request
 from typing import Text, Dict, Any, List, Iterable
 
 from rasa.core.channels.channel import UserMessage, OutputChannel, InputChannel
@@ -130,11 +131,11 @@ class RocketChatInput(InputChannel):
         rocketchat_webhook = Blueprint("rocketchat_webhook", __name__)
 
         @rocketchat_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @rocketchat_webhook.route("/webhook", methods=["GET", "POST"])
-        async def webhook(request):
+        async def webhook(request: Request):
             output = request.json
             if output:
                 if "visitor" not in output:

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -260,13 +260,13 @@ class SlackInput(InputChannel):
         slack_webhook = Blueprint("slack_webhook", __name__)
 
         @slack_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @slack_webhook.route("/webhook", methods=["GET", "POST"])
         async def webhook(request: Request):
             if request.form:
-                output = dict(request.form)
+                output = request.form
                 if self._is_button_reply(output):
                     sender_id = json.loads(output["payload"])["user"]["id"]
                     return await self.process_message(

--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from sanic import Blueprint, response
+from sanic.request import Request
 from socketio import AsyncServer
 from typing import Optional, Text, Any, List, Dict, Iterable
 
@@ -137,7 +138,7 @@ class SocketIOInput(InputChannel):
         )
 
         @socketio_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @sio.on("connect", namespace=self.namespace)

--- a/rasa/core/channels/telegram.py
+++ b/rasa/core/channels/telegram.py
@@ -1,5 +1,6 @@
 import logging
 from sanic import Blueprint, response
+from sanic.request import Request
 from telegram import (
     Bot,
     InlineKeyboardButton,
@@ -171,11 +172,11 @@ class TelegramInput(InputChannel):
         out_channel = TelegramOutput(self.access_token)
 
         @telegram_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @telegram_webhook.route("/set_webhook", methods=["GET", "POST"])
-        async def set_webhook(request):
+        async def set_webhook(request: Request):
             s = out_channel.setWebhook(self.webhook_url)
             if s:
                 logger.info("Webhook Setup Successful")
@@ -185,7 +186,7 @@ class TelegramInput(InputChannel):
                 return response.text("Invalid webhook")
 
         @telegram_webhook.route("/webhook", methods=["GET", "POST"])
-        async def message(request):
+        async def message(request: Request):
             if request.method == "POST":
 
                 if not out_channel.get_me()["username"] == self.verify:

--- a/rasa/core/channels/twilio.py
+++ b/rasa/core/channels/twilio.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from sanic import Blueprint, response
+from sanic.request import Request
 from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client
 from typing import Dict, Text, Any
@@ -92,13 +93,13 @@ class TwilioInput(InputChannel):
         twilio_webhook = Blueprint("twilio_webhook", __name__)
 
         @twilio_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @twilio_webhook.route("/webhook", methods=["POST"])
-        async def message(request):
-            sender = request.values.get("From", None)
-            text = request.values.get("Body", None)
+        async def message(request: Request):
+            sender = request.form.get("From", None)
+            text = request.form.get("Body", None)
 
             out_channel = TwilioOutput(
                 self.account_sid, self.auth_token, self.twilio_number

--- a/rasa/core/channels/webexteams.py
+++ b/rasa/core/channels/webexteams.py
@@ -1,5 +1,6 @@
 import logging
 from sanic import Blueprint, response
+from sanic.request import Request
 from typing import Text, Optional, Dict, Any
 from webexteamssdk import WebexTeamsAPI, Webhook
 
@@ -84,11 +85,11 @@ class WebexTeamsInput(InputChannel):
         webexteams_webhook = Blueprint("webexteams_webhook", __name__)
 
         @webexteams_webhook.route("/", methods=["GET"])
-        async def health(request):
+        async def health(request: Request):
             return response.json({"status": "ok"})
 
         @webexteams_webhook.route("/webhook", methods=["POST"])
-        async def webhook(request):
+        async def webhook(request: Request):
             """Respond to inbound webhook HTTP POST from Webex Teams."""
 
             logger.debug("Received webex webhook call")


### PR DESCRIPTION
**Proposed changes**:
- call `request.form` instead of `request.values` -- as far as I can see the sanic `Response` class doesn't have this functionality 
- typing

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
