### PR TITLE
create rasa credentials if not given

### DIFF
--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -92,7 +92,7 @@ def is_metrics_collection_enabled(args: argparse.Namespace) -> bool:
     return allow_metrics
 
 
- def _rasa_service(args: argparse.Namespace, endpoints: "AvailableEndpoints" = None):
+def _rasa_service(args: argparse.Namespace, endpoints: "AvailableEndpoints" = None):
     """Starts the Rasa application."""
     from rasa.core.run import serve_application
     from rasa.nlu.utils import configure_colored_logging
@@ -146,7 +146,7 @@ def _prepare_credentials_for_rasa_x(credentials_path: Optional[Text]) -> Text:
     return credentials_path
 
 
-def start_core_for_local_platform(args: argparse.Namespace, rasa_x_token: Text):
+def start_rasa_for_local_platform(args: argparse.Namespace, rasa_x_token: Text):
     """Starts the Rasa X API with Rasa as a background process."""
 
     from rasa.core.utils import AvailableEndpoints
@@ -172,7 +172,7 @@ def start_core_for_local_platform(args: argparse.Namespace, rasa_x_token: Text):
     )
 
     ctx = get_context("spawn")
-    p = ctx.Process(target=_core_service, args=(args, endpoints))
+    p = ctx.Process(target=_rasa_service, args=(args, endpoints))
     p.start()
 
 
@@ -218,7 +218,7 @@ def rasa_x(args: argparse.Namespace):
 
     if args.production:
         print_success("Starting Rasa X in production mode... 🚀")
-        _core_service(args)
+        _rasa_service(args)
     else:
         print_success("Starting Rasa X in local mode... 🚀")
         if not is_rasa_x_installed():
@@ -235,7 +235,7 @@ def rasa_x(args: argparse.Namespace):
 
         rasa_x_token = generate_rasa_x_token()
 
-        start_core_for_local_platform(args, rasa_x_token=rasa_x_token)
+        start_rasa_for_local_platform(args, rasa_x_token=rasa_x_token)
 
         main_local(
             args.project_path, args.data_path, token=rasa_x_token, metrics=metrics

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -92,7 +92,7 @@ def is_metrics_collection_enabled(args: argparse.Namespace) -> bool:
     return allow_metrics
 
 
-def _core_service(args: argparse.Namespace, endpoints: "AvailableEndpoints" = None):
+ def _rasa_service(args: argparse.Namespace, endpoints: "AvailableEndpoints" = None):
     """Starts the Rasa application."""
     from rasa.core.run import serve_application
     from rasa.nlu.utils import configure_colored_logging

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -163,7 +163,6 @@ def start_rasa_for_local_platform(args: argparse.Namespace, rasa_x_token: Text):
     vars(args).update(
         dict(
             nlu_model=None,
-            credentials=DEFAULT_CREDENTIALS_PATH,
             cors="*",
             auth_token=args.auth_token,
             enable_api=True,

--- a/tests/cli/test_rasa_x.py
+++ b/tests/cli/test_rasa_x.py
@@ -1,3 +1,7 @@
+import rasa.utils.io as io_utils
+from rasa.cli import x
+
+
 def test_x_help(run):
     output = run("x", "--help")
 
@@ -15,3 +19,33 @@ def test_x_help(run):
 
     for i, line in enumerate(lines):
         assert output.outlines[i] == line
+
+
+def test_prepare_credentials_for_rasa_x_if_rasa_channel_not_given(tmpdir_factory):
+    directory = tmpdir_factory.mktemp("directory")
+    credentials_path = str(directory / "credentials.yml")
+
+    io_utils.write_yaml_file({}, credentials_path)
+
+    x._prepare_credentials_for_rasa_x(credentials_path)
+
+    actual = io_utils.read_yaml_file(credentials_path)
+
+    assert actual["rasa"]["url"] == "http://localhost:5002"
+
+
+def test_prepare_credentials_if_already_valid(tmpdir_factory):
+    directory = tmpdir_factory.mktemp("directory")
+    credentials_path = str(directory / "credentials.yml")
+
+    credentials = {
+        "rasa": {"url": "my-custom-url"},
+        "another-channel": {"url": "some-url"},
+    }
+    io_utils.write_yaml_file(credentials, credentials_path)
+
+    x._prepare_credentials_for_rasa_x(credentials_path)
+
+    actual = io_utils.read_yaml_file(credentials_path)
+
+    assert actual == credentials


### PR DESCRIPTION
**Proposed changes**:
- fixes the "Input is not to a terminal (fd=4)." error if no credentials are given
- automatically inserts `rasa` channel credentials if none are present

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
