### PR TITLE
'rasa test' use RegexInterpreter by default

### DIFF
--- a/rasa/test.py
+++ b/rasa/test.py
@@ -76,7 +76,7 @@ def test_core(
 
     if not os.path.exists(core_path):
         print_error(
-            "Not able to test: Could not find any Core model. Use 'rasa train' to "
+            "Unable to test: could not find a Core model. Use 'rasa train' to "
             "train a model."
         )
 

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -67,7 +67,7 @@ def test_core(
     unpacked_model = get_model(model)
     if unpacked_model is None:
         print_error(
-            "Not able to test: Could not find any model. Use 'rasa train' to train a "
+            "Unable to test: could not find a model. Use 'rasa train' to train a "
             "Rasa model."
         )
         return

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -88,7 +88,7 @@ def test_core(
             _interpreter = NaturalLanguageInterpreter.create(nlu_path, _endpoints.nlu)
         else:
             print_warning(
-                "No NLU model found. Use default 'RegexInterpreter' for end-to-end "
+                "No NLU model found. Using default 'RegexInterpreter' for end-to-end "
                 "evaluation."
             )
 

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -4,9 +4,11 @@ import tempfile
 from typing import Text, Dict, Optional, List
 import os
 
+from rasa.core.interpreter import RegexInterpreter
+
 from rasa.constants import DEFAULT_RESULTS_PATH
 from rasa.model import get_model, get_model_subdirectories, unpack_model
-from rasa.cli.utils import minimal_kwargs, print_error
+from rasa.cli.utils import minimal_kwargs, print_error, print_warning
 
 logger = logging.getLogger(__name__)
 
@@ -62,24 +64,42 @@ def test_core(
     if output:
         nlu_utils.create_dir(output)
 
-    loop = asyncio.get_event_loop()
-    model_path = get_model(model)
-    core_path, nlu_path = get_model_subdirectories(model_path)
-
-    if os.path.exists(core_path) and os.path.exists(nlu_path):
-        _interpreter = NaturalLanguageInterpreter.create(nlu_path, _endpoints.nlu)
-
-        _agent = Agent.load(model_path, interpreter=_interpreter)
-
-        kwargs = minimal_kwargs(kwargs, rasa.core.test, ["stories", "agent"])
-
-        loop.run_until_complete(
-            rasa.core.test(stories, _agent, out_directory=output, **kwargs)
-        )
-    else:
+    unpacked_model = get_model(model)
+    if unpacked_model is None:
         print_error(
-            "Not able to test. Make sure both models - core and nlu - are available."
+            "Not able to test: Could not find any model. Use 'rasa train' to train a "
+            "Rasa model."
         )
+        return
+
+    core_path, nlu_path = get_model_subdirectories(unpacked_model)
+
+    if not os.path.exists(core_path):
+        print_error(
+            "Not able to test: Could not find any Core model. Use 'rasa train' to "
+            "train a model."
+        )
+
+    use_e2e = kwargs["e2e"] if "e2e" in kwargs else False
+
+    _interpreter = RegexInterpreter()
+    if use_e2e:
+        if os.path.exists(nlu_path):
+            _interpreter = NaturalLanguageInterpreter.create(nlu_path, _endpoints.nlu)
+        else:
+            print_warning(
+                "No NLU model found. Use default 'RegexInterpreter' for end-to-end "
+                "evaluation."
+            )
+
+    _agent = Agent.load(unpacked_model, interpreter=_interpreter)
+
+    kwargs = minimal_kwargs(kwargs, rasa.core.test, ["stories", "agent"])
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(
+        rasa.core.test(stories, _agent, out_directory=output, **kwargs)
+    )
 
 
 def test_nlu(model: Optional[Text], nlu_data: Optional[Text], kwargs: Optional[Dict]):


### PR DESCRIPTION
**Proposed changes**:
`rasa test`/ `rasa test core`: Per default use a `RegexInterpreter` for the evaluation. Only when the user runs a `e2e` evaluation, the NLU model gets loaded for the evaluation it it is present.

Fixes `WARNING  rasa.core.training.dsl  - Found unknown intent 'None' on line 22. Please, make sure that all intents are listed in your domain yaml.`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
