### PR TITLE
Standardized command line arguments

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -61,6 +61,7 @@ Script parameters
   documentation https://sanic.readthedocs.io/en/latest/sanic/deploying.html#running-via-gunicorn
 
 - To avoid conflicts in the script parameter names, connectors in the ``run`` command now need to be specified with
-  ``--connector``. ``-c`` is no longer supported. The maximum history in the ``rasa visualize`` command needs to be
-  defined with ``--max-history``. Output paths and log files cannot be specified with ``-o`` anymore. ``--output`` and
-  ``--log-file`` should be used.
+  ``--connector``. ``-c`` is no longer supported. The maximum history in the ``rasa visualize`` command need to be
+  defined with ``--max-history``. Output paths and log files cannot be specified with ``-o`` anymore. ``--out`` and
+  ``--log-file`` should be used. Furthermore, we standardized the name of NLU data to be ``--nlu`` and the name of
+  any kind of data files or directory to be ``--data``.

--- a/rasa/cli/arguments/data.py
+++ b/rasa/cli/arguments/data.py
@@ -1,16 +1,17 @@
 import argparse
 
-from rasa.cli.arguments.default_arguments import add_nlu_data_param
+from rasa.cli.arguments.default_arguments import add_nlu_data_param, add_out_param
 
 
 def set_convert_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
-        "--data-file", required=True, help="File or directory containing training data."
+        "--data", required=True, help="File or directory containing NLU data."
     )
 
-    parser.add_argument(
-        "--out-file",
+    add_out_param(
+        parser,
         required=True,
+        default=None,
         help="File where to save training data in Rasa format.",
     )
 
@@ -35,9 +36,8 @@ def set_split_arguments(parser: argparse.ArgumentParser):
         help="Percentage of the data which should be in the training data.",
     )
 
-    parser.add_argument(
-        "--out",
-        type=str,
+    add_out_param(
+        parser,
         default="train_test_split",
         help="Directory where the split files should be stored.",
     )

--- a/rasa/cli/arguments/data.py
+++ b/rasa/cli/arguments/data.py
@@ -1,12 +1,14 @@
 import argparse
 
-from rasa.cli.arguments.default_arguments import add_nlu_data_param, add_out_param
+from rasa.cli.arguments.default_arguments import (
+    add_nlu_data_param,
+    add_out_param,
+    add_data_param,
+)
 
 
 def set_convert_arguments(parser: argparse.ArgumentParser):
-    parser.add_argument(
-        "--data", required=True, help="File or directory containing NLU data."
-    )
+    add_data_param(parser, required=True, default=None, data_type="Rasa NLU ")
 
     add_out_param(
         parser,

--- a/rasa/cli/arguments/data.py
+++ b/rasa/cli/arguments/data.py
@@ -14,7 +14,7 @@ def set_convert_arguments(parser: argparse.ArgumentParser):
         parser,
         required=True,
         default=None,
-        help="File where to save training data in Rasa format.",
+        help_text="File where to save training data in Rasa format.",
     )
 
     parser.add_argument("-l", "--language", default="en", help="Language of data.")
@@ -29,7 +29,7 @@ def set_convert_arguments(parser: argparse.ArgumentParser):
 
 
 def set_split_arguments(parser: argparse.ArgumentParser):
-    add_nlu_data_param(parser)
+    add_nlu_data_param(parser, help_text="File or folder containing your NLU data.")
 
     parser.add_argument(
         "--training-fraction",
@@ -41,5 +41,5 @@ def set_split_arguments(parser: argparse.ArgumentParser):
     add_out_param(
         parser,
         default="train_test_split",
-        help="Directory where the split files should be stored.",
+        help_text="Directory where the split files should be stored.",
     )

--- a/rasa/cli/arguments/default_arguments.py
+++ b/rasa/cli/arguments/default_arguments.py
@@ -41,15 +41,11 @@ def add_stories_param(
 
 
 def add_nlu_data_param(
-    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer]
+    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer],
+    default: Optional[Text] = DEFAULT_DATA_PATH,
+    help: Text = "File or folder containing your NLU data.",
 ):
-    parser.add_argument(
-        "-u",
-        "--nlu",
-        type=str,
-        default=DEFAULT_DATA_PATH,
-        help="File or folder containing your NLU data.",
-    )
+    parser.add_argument("-u", "--nlu", type=str, default=default, help=help)
 
 
 def add_domain_param(
@@ -92,6 +88,21 @@ def add_endpoint_param(
     help_text="Configuration file for the connectors as a yml file.",
 ):
     parser.add_argument("--endpoints", type=str, default=None, help=help_text)
+
+
+def add_data_param(
+    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer],
+    default: Optional[Text] = DEFAULT_MODELS_PATH,
+    required: bool = False,
+    data_type: Text = "Rasa ",
+):
+    parser.add_argument(
+        "--data",
+        type=str,
+        default=default,
+        help="Path to the file or directory containing {}data.".format(data_type),
+        required=required,
+    )
 
 
 def add_logging_options(parser: argparse.ArgumentParser):

--- a/rasa/cli/arguments/default_arguments.py
+++ b/rasa/cli/arguments/default_arguments.py
@@ -42,10 +42,10 @@ def add_stories_param(
 
 def add_nlu_data_param(
     parser: Union[argparse.ArgumentParser, argparse._ActionsContainer],
+    help_text: Text,
     default: Optional[Text] = DEFAULT_DATA_PATH,
-    help: Text = "File or folder containing your NLU data.",
 ):
-    parser.add_argument("-u", "--nlu", type=str, default=default, help=help)
+    parser.add_argument("-u", "--nlu", type=str, default=default, help=help_text)
 
 
 def add_domain_param(
@@ -74,18 +74,17 @@ def add_config_param(
 
 def add_out_param(
     parser: Union[argparse.ArgumentParser, argparse._ActionsContainer],
+    help_text: Text,
     default: Optional[Text] = DEFAULT_MODELS_PATH,
-    help: Text = "Directory where your models should be stored.",
     required: bool = False,
 ):
     parser.add_argument(
-        "--out", type=str, default=default, help=help, required=required
+        "--out", type=str, default=default, help=help_text, required=required
     )
 
 
 def add_endpoint_param(
-    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer],
-    help_text="Configuration file for the connectors as a yml file.",
+    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer], help_text: Text
 ):
     parser.add_argument("--endpoints", type=str, default=None, help=help_text)
 

--- a/rasa/cli/arguments/default_arguments.py
+++ b/rasa/cli/arguments/default_arguments.py
@@ -76,12 +76,14 @@ def add_config_param(
     )
 
 
-def add_out_param(parser: Union[argparse.ArgumentParser, argparse._ActionsContainer]):
+def add_out_param(
+    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer],
+    default: Optional[Text] = DEFAULT_MODELS_PATH,
+    help: Text = "Directory where your models should be stored.",
+    required: bool = False,
+):
     parser.add_argument(
-        "--out",
-        type=str,
-        default=DEFAULT_MODELS_PATH,
-        help="Directory where your models should be stored.",
+        "--out", type=str, default=default, help=help, required=required
     )
 
 

--- a/rasa/cli/arguments/interactive.py
+++ b/rasa/cli/arguments/interactive.py
@@ -31,7 +31,9 @@ def set_interactive_arguments(parser: argparse.ArgumentParser):
     train_arguments = parser.add_argument_group("Train Arguments")
     add_config_param(train_arguments)
     add_domain_param(train_arguments)
-    add_out_param(train_arguments)
+    add_out_param(
+        train_arguments, help_text="Directory where your models should be stored."
+    )
     add_augmentation_param(train_arguments)
     add_debug_plots_param(train_arguments)
     add_dump_stories_param(train_arguments)
@@ -52,7 +54,9 @@ def set_interactive_core_arguments(parser: argparse.ArgumentParser):
     train_arguments = parser.add_argument_group("Train Arguments")
     add_config_param(train_arguments)
     add_domain_param(train_arguments)
-    add_out_param(train_arguments)
+    add_out_param(
+        train_arguments, help_text="Directory where your models should be stored."
+    )
     add_augmentation_param(train_arguments)
     add_debug_plots_param(train_arguments)
     add_dump_stories_param(train_arguments)

--- a/rasa/cli/arguments/run.py
+++ b/rasa/cli/arguments/run.py
@@ -24,7 +24,8 @@ def add_server_arguments(parser: argparse.ArgumentParser):
     )
     add_endpoint_param(
         parser,
-        help_text="Configuration file for the model server and the connectors as a yml file.",
+        help_text="Configuration file for the model server and the connectors as a "
+        "yml file.",
     )
 
     server_arguments = parser.add_argument_group("Server Settings")

--- a/rasa/cli/arguments/test.py
+++ b/rasa/cli/arguments/test.py
@@ -43,7 +43,7 @@ def add_test_core_argument_group(
     add_out_param(
         parser,
         default="results",
-        help="Output path for any files created during the evaluation.",
+        help_text="Output path for any files created during the evaluation.",
     )
     parser.add_argument(
         "--e2e",
@@ -53,7 +53,9 @@ def add_test_core_argument_group(
         "intent prediction. Requires a story file in end-to-end "
         "format.",
     )
-    add_endpoint_param(parser)
+    add_endpoint_param(
+        parser, help_text="Configuration file for the connectors as a yml file."
+    )
     parser.add_argument(
         "--fail-on-prediction-errors",
         action="store_true",
@@ -73,7 +75,7 @@ def add_test_core_argument_group(
 def add_test_nlu_argument_group(
     parser: Union[argparse.ArgumentParser, argparse._ActionsContainer]
 ):
-    add_nlu_data_param(parser)
+    add_nlu_data_param(parser, help_text="File or folder containing your NLU data.")
     parser.add_argument(
         "--report",
         required=False,

--- a/rasa/cli/arguments/test.py
+++ b/rasa/cli/arguments/test.py
@@ -8,6 +8,7 @@ from rasa.cli.arguments.default_arguments import (
     add_model_param,
     add_nlu_data_param,
     add_endpoint_param,
+    add_out_param,
 )
 from rasa.model import get_latest_model
 
@@ -39,9 +40,8 @@ def add_test_core_argument_group(
     parser.add_argument(
         "--max-stories", type=int, help="Maximum number of stories to test on."
     )
-    parser.add_argument(
-        "--output",
-        type=str,
+    add_out_param(
+        parser,
         default="results",
         help="Output path for any files created during the evaluation.",
     )

--- a/rasa/cli/arguments/train.py
+++ b/rasa/cli/arguments/train.py
@@ -15,7 +15,7 @@ def set_train_arguments(parser: argparse.ArgumentParser):
     add_data_param(parser)
     add_config_param(parser)
     add_domain_param(parser)
-    add_out_param(parser)
+    add_out_param(parser, help_text="Directory where your models should be stored.")
 
     add_augmentation_param(parser)
     add_debug_plots_param(parser)
@@ -30,7 +30,7 @@ def set_train_core_arguments(parser: argparse.ArgumentParser):
     add_stories_param(parser)
     add_domain_param(parser)
     add_core_config_param(parser)
-    add_out_param(parser)
+    add_out_param(parser, help_text="Directory where your models should be stored.")
 
     add_augmentation_param(parser)
     add_debug_plots_param(parser)
@@ -47,9 +47,9 @@ def set_train_core_arguments(parser: argparse.ArgumentParser):
 
 def set_train_nlu_arguments(parser: argparse.ArgumentParser):
     add_config_param(parser)
-    add_out_param(parser)
+    add_out_param(parser, help_text="Directory where your models should be stored.")
 
-    add_nlu_data_param(parser)
+    add_nlu_data_param(parser, help_text="File or folder containing your NLU data.")
 
     add_model_name_param(parser)
     add_compress_param(parser)

--- a/rasa/cli/arguments/visualize.py
+++ b/rasa/cli/arguments/visualize.py
@@ -17,7 +17,7 @@ def set_visualize_stories_arguments(parser: argparse.ArgumentParser):
     add_out_param(
         parser,
         default="graph.html",
-        help="Filename of the output path, e.g. 'graph.html'.",
+        help_text="Filename of the output path, e.g. 'graph.html'.",
     )
 
     parser.add_argument(
@@ -30,6 +30,6 @@ def set_visualize_stories_arguments(parser: argparse.ArgumentParser):
     add_nlu_data_param(
         parser,
         default=None,
-        help="File or folder containing your NLU data, "
+        help_text="File or folder containing your NLU data, "
         "used to insert example messages into the graph.",
     )

--- a/rasa/cli/arguments/visualize.py
+++ b/rasa/cli/arguments/visualize.py
@@ -4,6 +4,7 @@ from rasa.cli.arguments.default_arguments import (
     add_config_param,
     add_domain_param,
     add_stories_param,
+    add_out_param,
 )
 
 
@@ -12,10 +13,9 @@ def set_visualize_stories_arguments(parser: argparse.ArgumentParser):
     add_stories_param(parser)
     add_config_param(parser)
 
-    parser.add_argument(
-        "--output",
+    add_out_param(
+        parser,
         default="graph.html",
-        type=str,
         help="Filename of the output path, e.g. 'graph.html'.",
     )
 

--- a/rasa/cli/arguments/visualize.py
+++ b/rasa/cli/arguments/visualize.py
@@ -5,6 +5,7 @@ from rasa.cli.arguments.default_arguments import (
     add_domain_param,
     add_stories_param,
     add_out_param,
+    add_nlu_data_param,
 )
 
 
@@ -26,11 +27,9 @@ def set_visualize_stories_arguments(parser: argparse.ArgumentParser):
         help="Max history to consider when merging paths in the output graph.",
     )
 
-    parser.add_argument(
-        "-u",
-        "--nlu",
+    add_nlu_data_param(
+        parser,
         default=None,
-        type=str,
         help="File or folder containing your NLU data, "
         "used to insert example messages into the graph.",
     )

--- a/rasa/cli/arguments/visualize.py
+++ b/rasa/cli/arguments/visualize.py
@@ -27,10 +27,10 @@ def set_visualize_stories_arguments(parser: argparse.ArgumentParser):
     )
 
     parser.add_argument(
-        "-nlu",
-        "--nlu-data",
+        "-u",
+        "--nlu",
         default=None,
         type=str,
-        help="Path of the Rasa NLU training data, "
+        help="File or folder containing your NLU data, "
         "used to insert example messages into the graph.",
     )

--- a/rasa/cli/arguments/x.py
+++ b/rasa/cli/arguments/x.py
@@ -1,53 +1,47 @@
 import argparse
 
-from rasa.cli.arguments.default_arguments import add_model_param
+from rasa.constants import DEFAULT_DATA_PATH
+
+from rasa.cli.arguments.default_arguments import add_model_param, add_data_param
 from rasa.cli.arguments.run import add_server_arguments
 
 
-def set_x_arguments(shell_parser: argparse.ArgumentParser):
-    add_model_param(shell_parser, add_positional_arg=False)
+def set_x_arguments(parser: argparse.ArgumentParser):
+    add_model_param(parser, add_positional_arg=False)
 
-    shell_parser.add_argument(
+    parser.add_argument(
         "--no-prompt",
         action="store_true",
         help="Automatic yes or default options to prompts and oppressed warnings.",
     )
 
-    shell_parser.add_argument(
+    parser.add_argument(
         "--production",
         action="store_true",
         help="Run Rasa X in a production environment.",
     )
 
-    shell_parser.add_argument(
+    parser.add_argument(
         "--nlg",
         type=str,
         default="http://localhost:5002/api/nlg",
         help="Rasa NLG endpoint.",
     )
 
-    shell_parser.add_argument(
+    parser.add_argument(
         "--model-endpoint-url",
         type=str,
         default="http://localhost:5002/api/projects/default/models/tags/production",
         help="Rasa model endpoint URL.",
     )
 
-    shell_parser.add_argument(
+    parser.add_argument(
         "--project-path",
         type=str,
         default=".",
         help="Path to the Rasa project directory.",
     )
 
-    shell_parser.add_argument(
-        "--data",
-        type=str,
-        default="data",
-        help=(
-            "Path to the directory containing Rasa NLU training data "
-            "and Rasa Core stories."
-        ),
-    )
+    add_data_param(parser, default=DEFAULT_DATA_PATH, data_type="stories and Rasa NLU ")
 
-    add_server_arguments(shell_parser)
+    add_server_arguments(parser)

--- a/rasa/cli/arguments/x.py
+++ b/rasa/cli/arguments/x.py
@@ -41,7 +41,7 @@ def set_x_arguments(shell_parser: argparse.ArgumentParser):
     )
 
     shell_parser.add_argument(
-        "--data-path",
+        "--data",
         type=str,
         default="data",
         help=(

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -63,7 +63,7 @@ def test_core(args: argparse.Namespace) -> None:
     )
     stories = get_validated_path(args.stories, "stories", DEFAULT_DATA_PATH)
     stories = data.get_core_directory(stories)
-    output = args.output or DEFAULT_RESULTS_PATH
+    output = args.out or DEFAULT_RESULTS_PATH
 
     if not os.path.exists(output):
         os.makedirs(output)

--- a/rasa/cli/visualize.py
+++ b/rasa/cli/visualize.py
@@ -30,8 +30,8 @@ def visualize_stories(args: argparse.Namespace):
     loop = asyncio.get_event_loop()
 
     args.stories = data.get_core_directory(args.stories)
-    if args.nlu_data is None and os.path.exists(DEFAULT_DATA_PATH):
-        args.nlu_data = data.get_nlu_directory(DEFAULT_DATA_PATH)
+    if args.nlu is None and os.path.exists(DEFAULT_DATA_PATH):
+        args.nlu = data.get_nlu_directory(DEFAULT_DATA_PATH)
 
     loop.run_until_complete(
         rasa.core.visualize(

--- a/rasa/cli/visualize.py
+++ b/rasa/cli/visualize.py
@@ -35,11 +35,6 @@ def visualize_stories(args: argparse.Namespace):
 
     loop.run_until_complete(
         rasa.core.visualize(
-            args.config,
-            args.domain,
-            args.stories,
-            args.nlu_data,
-            args.output,
-            args.max_history,
+            args.config, args.domain, args.stories, args.nlu, args.out, args.max_history
         )
     )

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 import importlib.util
 import logging
 import signal
@@ -209,6 +208,4 @@ def rasa_x(args: argparse.Namespace):
         # noinspection PyUnresolvedReferences
         from rasax.community.api.local import main_local
 
-        main_local(
-            args.project_path, args.data_path, token=rasa_x_token, metrics=metrics
-        )
+        main_local(args.project_path, args.data, token=rasa_x_token, metrics=metrics)

--- a/rasa/nlu/convert.py
+++ b/rasa/nlu/convert.py
@@ -14,7 +14,7 @@ def convert_training_data(
     if not os.path.exists(data_file):
         print_error(
             "Data file '{}' does not exist. Provide a valid NLU data file using "
-            "the '--data-file' argument.".format(data_file)
+            "the '--data' argument.".format(data_file)
         )
         return
 

--- a/rasa/nlu/convert.py
+++ b/rasa/nlu/convert.py
@@ -35,7 +35,7 @@ def convert_training_data(
 
 
 def main(args: argparse.Namespace):
-    convert_training_data(args.data_file, args.out_file, args.format, args.language)
+    convert_training_data(args.data, args.out, args.format, args.language)
 
 
 if __name__ == "__main__":

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -192,9 +192,7 @@ async def _do_training(
             kwargs=kwargs,
         )
     else:
-        print (
-            "Stories / configuration did not change. " "No need to retrain Core model."
-        )
+        print ("Stories / configuration did not change. No need to retrain Core model.")
 
     if force_training or retrain_nlu:
         _train_nlu_with_validated_data(

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -3,7 +3,7 @@ import os
 
 def test_data_split_nlu(run_in_default_project):
     run_in_default_project(
-        "data", "split", "nlu", "--nlu", "data/nlu.md", "--training-fraction", "0.75"
+        "data", "split", "nlu", "-u", "data/nlu.md", "--training-fraction", "0.75"
     )
 
     assert os.path.exists("train_test_split")
@@ -16,9 +16,9 @@ def test_data_convert_nlu(run_in_default_project):
         "data",
         "convert",
         "nlu",
-        "--data-file",
+        "--data",
         "data/nlu.md",
-        "--out-file",
+        "--out",
         "out_nlu_data.json",
         "-f",
         "json",
@@ -42,8 +42,8 @@ def test_data_split_help(run):
 def test_data_convert_help(run):
     output = run("data", "convert", "nlu", "--help")
 
-    help_text = """usage: rasa data convert nlu [-h] [-v] [-vv] [--quiet] --data-file DATA_FILE
-                             --out-file OUT_FILE [-l LANGUAGE] -f {json,md}"""
+    help_text = """usage: rasa data convert nlu [-h] [-v] [-vv] [--quiet] --data DATA --out OUT
+                             [-l LANGUAGE] -f {json,md}"""
 
     lines = help_text.split("\n")
 

--- a/tests/cli/test_rasa_test.py
+++ b/tests/cli/test_rasa_test.py
@@ -11,7 +11,7 @@ def test_test_help(run):
     output = run("test", "--help")
 
     help_text = """usage: rasa test [-h] [-v] [-vv] [--quiet] [-m MODEL] [-s STORIES]
-                 [--max-stories MAX_STORIES] [--output OUTPUT] [--e2e]
+                 [--max-stories MAX_STORIES] [--out OUT] [--e2e]
                  [--endpoints ENDPOINTS] [--fail-on-prediction-errors]
                  [--url URL] [-u NLU] [--report [REPORT]]
                  [--successes [SUCCESSES]] [--errors ERRORS]
@@ -44,8 +44,8 @@ def test_test_core_help(run):
     output = run("test", "core", "--help")
 
     help_text = """usage: rasa test core [-h] [-v] [-vv] [--quiet] [-m MODEL [MODEL ...]]
-                      [-s STORIES] [--max-stories MAX_STORIES]
-                      [--output OUTPUT] [--e2e] [--endpoints ENDPOINTS]
+                      [-s STORIES] [--max-stories MAX_STORIES] [--out OUT]
+                      [--e2e] [--endpoints ENDPOINTS]
                       [--fail-on-prediction-errors] [--url URL]"""
 
     lines = help_text.split("\n")

--- a/tests/cli/test_rasa_visualize.py
+++ b/tests/cli/test_rasa_visualize.py
@@ -1,9 +1,9 @@
-def test_show_stories_help(run):
+def test_visualize_help(run):
     output = run("visualize", "--help")
 
     help_text = """usage: rasa visualize [-h] [-v] [-vv] [--quiet] [-d DOMAIN] [-s STORIES]
-                      [-c CONFIG] [--output OUTPUT]
-                      [--max-history MAX_HISTORY] [-nlu NLU_DATA]"""
+                      [-c CONFIG] [--out OUT] [--max-history MAX_HISTORY]
+                      [-u NLU]"""
 
     lines = help_text.split("\n")
 

--- a/tests/cli/test_rasa_x.py
+++ b/tests/cli/test_rasa_x.py
@@ -8,7 +8,7 @@ def test_x_help(run):
     help_text = """usage: rasa x [-h] [-v] [-vv] [--quiet] [-m MODEL] [--no-prompt]
               [--production] [--nlg NLG]
               [--model-endpoint-url MODEL_ENDPOINT_URL]
-              [--project-path PROJECT_PATH] [--data-path DATA_PATH]
+              [--project-path PROJECT_PATH] [--data DATA]
               [--log-file LOG_FILE] [--endpoints ENDPOINTS] [-p PORT]
               [-t AUTH_TOKEN] [--cors [CORS [CORS ...]]] [--enable-api]
               [--remote-storage REMOTE_STORAGE] [--credentials CREDENTIALS]


### PR DESCRIPTION
**Proposed changes**:
- Use `--out` for all kind of output files/directories (before `--out`, `--output`, `--out-file`).
- Use `--nlu` for specifying NLU data (before `--nlu`, `--nlu-data`).
- Use `--data` for specifying data files/data directory (before `--data`, `--data-file`, `--data-path`).

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation (different PR)
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
