### PR TITLE
sanitize() now removes unusual character instead of the first

### DIFF
--- a/rasa/core/training/visualization.py
+++ b/rasa/core/training/visualization.py
@@ -361,7 +361,7 @@ def _create_graph(fontsize: int = 12) -> "networkx.MultiDiGraph":
 
 def sanitize(s):
     if s:
-        return re.sub(r"""^[a-zA-Z0-9\s_-]""", "", s)
+        return re.sub(r"""[^a-zA-Z0-9\s,.'!@?_-]""", "", s)
     else:
         return s
 


### PR DESCRIPTION
A typo in the sanitize function caused it to always remove the first
character (alphanumerical or _ - or whitespace) from messages before they
would be used to label the graph.
This has been changed to remove any characters from the message other than alphanumerical, white space or ,.'@!?-_