### PR TITLE
Interactive learning: Fix  "No such file or directory: 'data/core/stories.md'"

### DIFF
--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -57,6 +57,7 @@ from rasa.nlu.training_data.message import Message
 # automatically. If you change anything in here, please make sure to
 # run the interactive learning and check if your part of the "ui"
 # still works.
+from rasa.utils.io import create_path
 
 logger = logging.getLogger(__name__)
 
@@ -752,6 +753,8 @@ async def _write_stories_to_file(
 
     sub_conversations = _split_conversation_at_restarts(evts)
 
+    create_path(export_story_path)
+
     if os.path.exists(export_story_path):
         append_write = "a"  # append if already exists
     else:
@@ -825,6 +828,8 @@ async def _write_domain_to_file(
     domain_path: Text, evts: List[Dict[Text, Any]], endpoint: EndpointConfig
 ) -> None:
     """Write an updated domain file to the file path."""
+
+    create_path(domain_path)
 
     domain = await retrieve_domain(endpoint)
     old_domain = Domain.from_dict(domain)

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -188,3 +188,11 @@ def create_temporary_file(data: Any, suffix: Text = "", mode: Text = "w+") -> Te
 
     f.close()
     return f.name
+
+
+def create_path(file_path: Text):
+    """Makes sure all directories in the 'file_path' exists."""
+
+    parent_dir = os.path.dirname(os.path.abspath(file_path))
+    if not os.path.exists(parent_dir):
+        os.makedirs(parent_dir)


### PR DESCRIPTION
**Proposed changes**:
- Create output paths for `stories.md` and `domain.yml` file if path not exists.

related to http://github.com/RasaHQ/rasa/issues/3504

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
