### PR TITLE
Add nlu core about pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinxcontrib.httpdomain",
     "rasabaster.button",
     "rasabaster.card",
+    "rasabaster.chatbubble",
     "rasabaster.copyable",
     "rasabaster.runnable",
     "rasabaster.conversations",

--- a/docs/core/about.rst
+++ b/docs/core/about.rst
@@ -16,6 +16,10 @@ The Rasa Core dialogue engine
    :sender: bot
 
 .. chat-bubble::
+   :text: It's part of the open source Rasa framework.
+   :sender: bot
+
+.. chat-bubble::
    :text: What's cool about it?
    :sender: user
 
@@ -49,3 +53,4 @@ The Rasa Core dialogue engine
 .. chat-bubble::
    :text: Head over to the Rasa Tutorial for an interactive example.
    :sender: bot
+

--- a/docs/core/about.rst
+++ b/docs/core/about.rst
@@ -1,0 +1,22 @@
+:desc: Get started with machine learning dialogue management to scale your bot
+       development using Rasa Stack as a conversational AI platform.
+
+.. _about-rasa-core:
+
+The Rasa Core dialogue engine
+=============================
+
+.. conversations:: 
+   examples:
+     - 
+       - What am I looking at?
+       - ( Rasa Core is a dialogue engine for building AI assistants
+       - What's cool about it?
+       - ( Rather than a bunch of if/else statements, it uses a machine learning model trained on example conversations.
+       - That sounds harder than writing a few if statements.
+       - ( In the beginning of a project, it seems easier to just hard code some logic.
+       - ( Rasa helps you when you want to go past that, and let your assistant handle more complexity.
+       - Can I see it in action?
+       - ( We thought you'd never ask!
+       - ( Check out the tutorial for an interactive example.
+

--- a/docs/core/about.rst
+++ b/docs/core/about.rst
@@ -6,17 +6,46 @@
 The Rasa Core dialogue engine
 =============================
 
-.. conversations:: 
-   examples:
-     - 
-       - What am I looking at?
-       - ( Rasa Core is a dialogue engine for building AI assistants
-       - What's cool about it?
-       - ( Rather than a bunch of if/else statements, it uses a machine learning model trained on example conversations.
-       - That sounds harder than writing a few if statements.
-       - ( In the beginning of a project, it seems easier to just hard code some logic.
-       - ( Rasa helps you when you want to go past that, and let your assistant handle more complexity.
-       - Can I see it in action?
-       - ( We thought you'd never ask!
-       - ( Check out the tutorial for an interactive example.
+.. chat-bubble::
+   :text: What am I looking at?
+   :sender: user
 
+
+.. chat-bubble::
+   :text: Rasa Core is a dialogue engine for building AI assistants
+   :sender: bot
+
+.. chat-bubble::
+   :text: What's cool about it?
+   :sender: user
+
+.. chat-bubble::
+   :text: Rather than a bunch of if/else statements, it uses a machine learning model trained on example conversations.
+   :sender: bot
+
+.. chat-bubble::
+   :text: That sounds harder than writing a few if statements.
+   :sender: user
+
+
+.. chat-bubble::
+   :text: In the beginning of a project, it seems easier to just hard code some logic.
+   :sender: bot
+
+.. chat-bubble::
+   :text: Rasa helps you when you want to go past that and create a bot that can handle more complexity.
+      This <a href="https://medium.com/rasa-blog/a-new-approach-to-conversational-software-2e64a5d05f2a" target="_blank">blog post </a> explains the philosophy behind Rasa Core.
+   :sender: bot
+
+
+.. chat-bubble::
+   :text: Can I see it in action?
+   :sender: user
+
+.. chat-bubble::
+   :text: We thought you'd never ask!
+   :sender: bot
+
+.. chat-bubble::
+   :text: Head over to the Rasa Tutorial for an interactive example.
+   :sender: bot

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Understand messages, hold conversations, and connect to messaging channels and A
    :caption: NLU
    :hidden:
 
+   About <nlu/about>
    nlu/using-only-nlu
    nlu/data-format
    nlu/choosing-pipeline
@@ -48,6 +49,7 @@ Understand messages, hold conversations, and connect to messaging channels and A
    :caption: Core
    :hidden:
 
+   About <core/about>
    core/stories
    core/domains
    core/responses

--- a/docs/nlu/about.rst
+++ b/docs/nlu/about.rst
@@ -1,0 +1,28 @@
+:desc: Learn more about open-source natural language processing library Rasa NLU
+       for intent classification and entity extraction in on premise chatbots.
+
+.. _about-rasa-nlu:
+
+Rasa NLU: Language Understanding for chatbots and AI assistants
+===============================================================
+
+
+Rasa NLU is an open-source natural language processing tool for intent classification and entity extraction in chatbots. For example, taking a sentence like
+
+.. code-block:: console
+
+    "I am looking for a Mexican restaurant in the center of town"
+
+and returning structured data like
+
+.. code-block:: json
+
+    {
+      "intent": "search_restaurant",
+      "entities": {
+        "cuisine" : "Mexican",
+        "location" : "center"
+      }
+    }
+
+Rasa NLU used to be a separate library, but it is now part of the Rasa framework.


### PR DESCRIPTION
**Proposed changes**:
- add what used to be the landing pages of Core and NLU docs as nlu/about and core/about

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
