### PR TITLE
Re-train only NLU/Core model if corresponding config parameters changed

### DIFF
--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -426,8 +426,13 @@ def get_file_hash(path: Text) -> Text:
 
 
 def get_text_hash(text: Text, encoding: Text = "utf-8") -> Text:
-    """Calculate the md5 hash of a file."""
+    """Calculate the md5 hash for a text."""
     return md5(text.encode(encoding)).hexdigest()
+
+
+def get_dict_hash(data: Dict, encoding: Text = "utf-8") -> Text:
+    """Calculate the md5 hash of a dictionary."""
+    return md5(json.dumps(data, sort_keys=True).encode(encoding)).hexdigest()
 
 
 async def download_file_from_url(url: Text) -> Text:

--- a/rasa/model.py
+++ b/rasa/model.py
@@ -344,7 +344,7 @@ def core_fingerprint_changed(
 
     for k in relevant_keys:
         if fingerprint1.get(k) != fingerprint2.get(k):
-            logger.info("Data ({}) for dialogue model changed.".format(k))
+            logger.info("Data ({}) for Core model changed.".format(k))
             return True
     return False
 

--- a/rasa/model.py
+++ b/rasa/model.py
@@ -5,13 +5,23 @@ import os
 import shutil
 import tarfile
 import tempfile
+from _md5 import md5
 from typing import Text, Tuple, Union, Optional, List, Dict, Any
 
+import yaml.parser
+
 import rasa.utils.io
-from rasa.constants import DEFAULT_MODELS_PATH
+from rasa.constants import (
+    DEFAULT_MODELS_PATH,
+    CONFIG_MANDATORY_KEYS_CORE,
+    CONFIG_MANDATORY_KEYS_NLU,
+    CONFIG_MANDATORY_KEYS,
+)
 
 # Type alias for the fingerprint
+from rasa.core import config
 from rasa.core.domain import Domain
+from rasa.core.utils import get_dict_hash
 
 Fingerprint = Dict[Text, Union[Text, List[Text]]]
 
@@ -20,6 +30,8 @@ logger = logging.getLogger(__name__)
 FINGERPRINT_FILE_PATH = "fingerprint.json"
 
 FINGERPRINT_CONFIG_KEY = "config"
+FINGERPRINT_CONFIG_CORE_KEY = "core-config"
+FINGERPRINT_CONFIG_NLU_KEY = "nlu-config"
 FINGERPRINT_DOMAIN_KEY = "domain"
 FINGERPRINT_RASA_VERSION_KEY = "version"
 FINGERPRINT_STORIES_KEY = "stories"
@@ -219,7 +231,15 @@ def model_fingerprint(
         domain_hash = _get_hashes_for_paths(domain)
 
     return {
-        FINGERPRINT_CONFIG_KEY: _get_hashes_for_paths(config_file),
+        FINGERPRINT_CONFIG_KEY: _get_hash_of_config(
+            config_file, exclude_keys=CONFIG_MANDATORY_KEYS
+        ),
+        FINGERPRINT_CONFIG_CORE_KEY: _get_hash_of_config(
+            config_file, include_keys=CONFIG_MANDATORY_KEYS_CORE
+        ),
+        FINGERPRINT_CONFIG_NLU_KEY: _get_hash_of_config(
+            config_file, include_keys=CONFIG_MANDATORY_KEYS_NLU
+        ),
         FINGERPRINT_DOMAIN_KEY: domain_hash,
         FINGERPRINT_NLU_DATA_KEY: _get_hashes_for_paths(nlu_data),
         FINGERPRINT_STORIES_KEY: _get_hashes_for_paths(stories),
@@ -240,6 +260,31 @@ def _get_hashes_for_paths(path: Text) -> List[Text]:
         files = [path]
 
     return sorted([get_file_hash(f) for f in files])
+
+
+def _get_hash_of_config(
+    config_path: Text,
+    include_keys: Optional[List[Text]] = None,
+    exclude_keys: Optional[List[Text]] = None,
+) -> Text:
+    if not config_path or not os.path.exists(config_path):
+        return ""
+
+    try:
+        config_dict = rasa.utils.io.read_yaml_file(config_path)
+    except yaml.parser.ParserError as e:
+        logger.debug(
+            "Failed to read config file '{}'. Error: {}".format(config_path, e)
+        )
+        return ""
+
+    keys = include_keys or list(
+        filter(lambda k: k not in exclude_keys, config_dict.keys())
+    )
+
+    sub_config = dict((k, config_dict[k]) for k in keys if k in config_dict)
+
+    return get_dict_hash(sub_config)
 
 
 def fingerprint_from_path(model_path: Text) -> Fingerprint:
@@ -291,6 +336,7 @@ def core_fingerprint_changed(
     """
     relevant_keys = [
         FINGERPRINT_CONFIG_KEY,
+        FINGERPRINT_CONFIG_CORE_KEY,
         FINGERPRINT_DOMAIN_KEY,
         FINGERPRINT_STORIES_KEY,
         FINGERPRINT_RASA_VERSION_KEY,
@@ -319,6 +365,7 @@ def nlu_fingerprint_changed(
 
     relevant_keys = [
         FINGERPRINT_CONFIG_KEY,
+        FINGERPRINT_CONFIG_NLU_KEY,
         FINGERPRINT_NLU_DATA_KEY,
         FINGERPRINT_RASA_VERSION_KEY,
     ]

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -183,7 +183,10 @@ async def _do_training(
             kwargs=kwargs,
         )
     else:
-        print ("Stories / configuration did not change. No need to retrain Core model.")
+        print_color(
+            "Core stories/configuration did not change. No need to retrain Core model.",
+            color=bcolors.OKBLUE,
+        )
 
     if force_training or retrain_nlu:
         _train_nlu_with_validated_data(
@@ -194,7 +197,10 @@ async def _do_training(
             fixed_model_name=fixed_model_name,
         )
     else:
-        print ("NLU data / configuration did not change. No need to retrain NLU model.")
+        print_color(
+            "NLU data/configuration did not change. No need to retrain NLU model.",
+            color=bcolors.OKBLUE,
+        )
 
 
 def train_core(
@@ -297,7 +303,7 @@ async def _train_core_with_validated_data(
     _train_path = train_path or tempfile.mkdtemp()
 
     # normal (not compare) training
-    print_color("Start training dialogue model ...", color=bcolors.OKBLUE)
+    print_color("Training Core model...", color=bcolors.OKBLUE)
     await rasa.core.train(
         domain_file=domain,
         stories_file=story_directory,
@@ -305,7 +311,7 @@ async def _train_core_with_validated_data(
         policy_config=config,
         kwargs=kwargs,
     )
-    print_color("Done.", color=bcolors.OKBLUE)
+    print_color("Core model training completed.", color=bcolors.OKBLUE)
 
     if train_path is None:
         # Only Core was trained.
@@ -381,11 +387,11 @@ def _train_nlu_with_validated_data(
 
     _train_path = train_path or tempfile.mkdtemp()
 
-    print_color("Start training NLU model ...", color=bcolors.OKBLUE)
+    print_color("Training NLU model...", color=bcolors.OKBLUE)
     _, nlu_model, _ = rasa.nlu.train(
         config, nlu_data_directory, _train_path, fixed_model_name="nlu"
     )
-    print_color("Done.", color=bcolors.OKBLUE)
+    print_color("NLU model training completed.", color=bcolors.OKBLUE)
 
     if train_path is None:
         # Only NLU was trained

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import time
-from typing import Text
+from typing import Text, Optional, List
 
 import pytest
 
@@ -28,6 +28,8 @@ from rasa.model import (
     nlu_fingerprint_changed,
     Fingerprint,
     should_retrain,
+    FINGERPRINT_CONFIG_CORE_KEY,
+    FINGERPRINT_CONFIG_NLU_KEY,
 )
 
 
@@ -57,9 +59,21 @@ def test_get_model_from_directory_with_subdirectories(trained_model):
     assert os.path.exists(unpacked_nlu)
 
 
-def _fingerprint(config=None, domain=None, rasa_version="1.0", stories=None, nlu=None):
+def _fingerprint(
+    config: Optional[Text] = None,
+    config_nlu: Optional[Text] = None,
+    config_core: Optional[Text] = None,
+    domain: Optional[List[Text]] = None,
+    rasa_version: Text = "1.0",
+    stories: Optional[List[Text]] = None,
+    nlu: Optional[List[Text]] = None,
+):
     return {
         FINGERPRINT_CONFIG_KEY: config if config is not None else ["test"],
+        FINGERPRINT_CONFIG_CORE_KEY: config_core
+        if config_core is not None
+        else ["test"],
+        FINGERPRINT_CONFIG_NLU_KEY: config_nlu if config_nlu is not None else ["test"],
         FINGERPRINT_DOMAIN_KEY: domain if domain is not None else ["test"],
         FINGERPRINT_TRAINED_AT_KEY: time.time(),
         FINGERPRINT_RASA_VERSION_KEY: rasa_version,
@@ -146,7 +160,15 @@ def test_create_fingerprint_from_paths(project):
 def test_create_fingerprint_from_invalid_paths(project, project_files):
     project_files = _project_files(project, *project_files)
 
-    expected = _fingerprint([], [], rasa_version=rasa.__version__, stories=[], nlu=[])
+    expected = _fingerprint(
+        config="",
+        config_nlu="",
+        config_core="",
+        domain=[],
+        rasa_version=rasa.__version__,
+        stories=[],
+        nlu=[],
+    )
 
     actual = model_fingerprint(**project_files)
     assert actual[FINGERPRINT_TRAINED_AT_KEY] is not None
@@ -199,9 +221,21 @@ def test_rasa_packaging(trained_model, project, use_fingerprint):
             "retrain_nlu": True,
         },
         {
-            "new": _fingerprint(config=["others"]),
+            "new": _fingerprint(config="others"),
             "old": _fingerprint(),
             "retrain_core": True,
+            "retrain_nlu": True,
+        },
+        {
+            "new": _fingerprint(config_core="others"),
+            "old": _fingerprint(),
+            "retrain_core": True,
+            "retrain_nlu": False,
+        },
+        {
+            "new": _fingerprint(),
+            "old": _fingerprint(config_nlu="others"),
+            "retrain_core": False,
             "retrain_nlu": True,
         },
         {


### PR DESCRIPTION
**Proposed changes**:
- Divide fingerprint of `config.yml` into three parts: core config, nlu config, remaining config
- Re-train NLU model if remaining config or nlu config changed
- Re-train Core model if remaining config or core config changed

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
