### PR TITLE
changing persist to work more smoothly with markdown

### DIFF
--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -149,7 +149,7 @@ class TrainingData(object):
                 "and 'md'."
             )
 
-        return {"training_data": DEFAULT_TRAINING_DATA_OUTPUT_PATH}
+        return {"training_data": data_file}
 
     def sorted_entities(self) -> List[Any]:
         """Extract all entities from examples and sorts them by entity type."""

--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -129,10 +129,7 @@ class TrainingData(object):
         return MarkdownWriter().dumps(self)
 
     def persist(
-        self,
-        dir_name: Text,
-        filename: Text = DEFAULT_TRAINING_DATA_OUTPUT_PATH,
-        fformat: Text = "json",
+        self, dir_name: Text, filename: Text = DEFAULT_TRAINING_DATA_OUTPUT_PATH
     ) -> Dict[Text, Any]:
         """Persists this training data to disk and returns necessary
         information to load it again."""
@@ -142,9 +139,9 @@ class TrainingData(object):
 
         data_file = os.path.join(dir_name, filename)
 
-        if fformat == "json":
+        if data_file.endswith("json"):
             write_to_file(data_file, self.as_json(indent=2))
-        elif fformat == "md":
+        elif data_file.endswith("md"):
             write_to_file(data_file, self.as_markdown())
         else:
             ValueError(


### PR DESCRIPTION
**Proposed changes**:
- Changing `rasa.nlu.training_data.training_data.TrainingData.persist()` to work more smoothly. Previously, there were `filename` and `fformat` parameters. This meant that you could specify a file called `filename.md` and a file format `json`. and you would get a markdown file with a json file extension. I think it makes more sense to just add the filename and then check the extension of that filename.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
