### PR TITLE
enable-api does not need a model.

### DIFF
--- a/rasa/cli/run.py
+++ b/rasa/cli/run.py
@@ -4,7 +4,7 @@ import os
 from typing import List
 
 from rasa.cli.arguments import run as arguments
-from rasa.cli.utils import get_validated_path
+from rasa.cli.utils import get_validated_path, print_error
 from rasa.constants import (
     DEFAULT_ACTIONS_PATH,
     DEFAULT_CREDENTIALS_PATH,
@@ -60,6 +60,20 @@ def run(args: argparse.Namespace):
     import rasa.run
 
     args.model = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
+
+    if not args.enable_api:
+        # if the API is enabled you can start without a model as you can train a
+        # model via the API once the server is up and running
+        from rasa.model import get_model
+
+        model_path = get_model(args.model)
+        if not model_path:
+            print_error(
+                "No model found. Train a model before running the "
+                "server using `rasa train`."
+            )
+            return
+
     args.endpoints = get_validated_path(
         args.endpoints, "endpoints", DEFAULT_ENDPOINTS_PATH, True
     )

--- a/rasa/cli/run.py
+++ b/rasa/cli/run.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import os
-from typing import List
+from typing import List, Text, Optional
 
 from rasa.cli.arguments import run as arguments
 from rasa.cli.utils import get_validated_path, print_error
@@ -56,10 +56,27 @@ def run_actions(args: argparse.Namespace):
     sdk.main_from_args(args)
 
 
+def _validate_model_path(model_path: Text, parameter: Text, default: Text):
+
+    if model_path is not None and not os.path.exists(model_path):
+        reason_str = "'{}' not found.".format(model_path)
+        if model_path is None:
+            reason_str = "Parameter '{}' not set.".format(parameter)
+
+        logger.debug(
+            "{} Using default location '{}' instead.".format(reason_str, default)
+        )
+
+        os.makedirs(default, exist_ok=True)
+        model_path = default
+
+    return model_path
+
+
 def run(args: argparse.Namespace):
     import rasa.run
 
-    args.model = get_validated_path(args.model, "model", DEFAULT_MODELS_PATH)
+    args.model = _validate_model_path(args.model, "model", DEFAULT_MODELS_PATH)
 
     if not args.enable_api:
         # if the API is enabled you can start without a model as you can train a

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -258,7 +258,7 @@ async def load_agent(
             )
 
         else:
-            logger.error("No valid configuration given to load agent.")
+            logger.warning("No valid configuration given to load agent.")
             return None
 
     except Exception as e:

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -208,8 +208,8 @@ async def load_agent_on_start(
     )
 
     if not app.agent:
-        logger.error(
-            "Agent could not be loaded with the provided configuration."
+        logger.warning(
+            "Agent could not be loaded with the provided configuration. "
             "Load default agent without any model."
         )
         app.agent = Agent(

--- a/rasa/model.py
+++ b/rasa/model.py
@@ -49,6 +49,8 @@ def get_model(model_path: Text = DEFAULT_MODELS_PATH) -> Optional[Text]:
     """
     if not model_path:
         return None
+    elif not os.path.exists(model_path):
+        return None
     elif os.path.isdir(model_path):
         model_path = get_latest_model(model_path)
 

--- a/rasa/run.py
+++ b/rasa/run.py
@@ -38,12 +38,6 @@ def run(
     from rasa.core.utils import AvailableEndpoints
 
     model_path = get_model(model)
-    if not model_path:
-        print_error(
-            "No model found. Train a model before running the "
-            "server using `rasa train`."
-        )
-        return
 
     _endpoints = AvailableEndpoints.read_endpoints(endpoints)
 
@@ -65,7 +59,8 @@ def run(
         **kwargs
     )
 
-    shutil.rmtree(model_path)
+    if model_path is not None:
+        shutil.rmtree(model_path)
 
 
 def create_agent(model: Text, endpoints: Text = None) -> "Agent":


### PR DESCRIPTION
**Proposed changes**:
`rasa run --enable-api` does not need a model. The server can start without any model as you are able to train a model via the API once the server is up and running.

closes https://github.com/RasaHQ/rasa/issues/3588

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
