### PR TITLE
Fix duplicated events in SQLTrackerStore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Fixed
 -----
 - slack notifications from bots correctly render text
 - fixed usage of ``--log-file`` argument for ``rasa run`` and ``rasa shell``
+- duplicated events when using ``training.interactive`` with ``SQLTrackerStore``
 
 
 [1.0.6] - 2019-06-03


### PR DESCRIPTION
**Proposed changes**:
- `SQLTrackerStore.save` now replaces all events for a `sender_id` rather than just appending events that occur after the latest event in the DB
 - This matches behavior of `InMemoryTrackerStore` (https://github.com/RasaHQ/rasa/blob/master/rasa/core/tracker_store.py#L131) and allows `training.interactive.replace_events` (https://github.com/RasaHQ/rasa/blob/master/rasa/core/training/interactive.py#L235) to replace past events
 - Fixes https://github.com/RasaHQ/rasa/issues/3676

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
