### PR TITLE
Don't log warning per default.

### DIFF
--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -806,7 +806,9 @@ class Agent(object):
     def _create_domain(domain: Union[None, Domain, Text]) -> Domain:
 
         if isinstance(domain, str):
-            return Domain.load(domain)
+            domain = Domain.load(domain)
+            domain.check_missing_templates()
+            return domain
         elif isinstance(domain, Domain):
             return domain
         elif domain is not None:

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -812,29 +812,6 @@ class Domain(object):
                     )
             return message
 
-        def warn_missing_templates(
-            action_names: List[Text], templates: Dict[Text, Any]
-        ) -> None:
-            """Warn user of utterance names which have no specified template."""
-
-            utterances = [
-                act for act in action_names if act.startswith(action.UTTER_PREFIX)
-            ]
-
-            missing_templates = [t for t in utterances if t not in templates.keys()]
-
-            if missing_templates:
-                message = ""
-                for template in missing_templates:
-                    message += (
-                        "\nUtterance '{}' is listed as an "
-                        "action in the domain file, but there is "
-                        "no matching utterance template. Please "
-                        "check your domain."
-                    ).format(template)
-                print_warning(message)
-
-        warn_missing_templates(self.action_names, self.templates)
         duplicate_actions = get_duplicates(self.action_names)
         duplicate_slots = get_duplicates([s.name for s in self.slots])
         duplicate_entities = get_duplicates(self.entities)
@@ -856,6 +833,24 @@ class Domain(object):
                     incorrect_mappings,
                 )
             )
+
+    def check_missing_templates(self) -> None:
+        """Warn user of utterance names which have no specified template."""
+
+        utterances = [
+            act for act in self.action_names if act.startswith(action.UTTER_PREFIX)
+        ]
+
+        missing_templates = [t for t in utterances if t not in self.templates.keys()]
+
+        if missing_templates:
+            for template in missing_templates:
+                logger.warning(
+                    "Utterance '{}' is listed as an "
+                    "action in the domain file, but there is "
+                    "no matching utterance template. Please "
+                    "check your domain.".format(template)
+                )
 
 
 class TemplateDomain(Domain):

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -837,9 +837,7 @@ class Domain(object):
     def check_missing_templates(self) -> None:
         """Warn user of utterance names which have no specified template."""
 
-        utterances = [
-            a for a in self.action_names if a.startswith(action.UTTER_PREFIX)
-        ]
+        utterances = [a for a in self.action_names if a.startswith(action.UTTER_PREFIX)]
 
         missing_templates = [t for t in utterances if t not in self.templates.keys()]
 

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -838,7 +838,7 @@ class Domain(object):
         """Warn user of utterance names which have no specified template."""
 
         utterances = [
-            act for act in self.action_names if act.startswith(action.UTTER_PREFIX)
+            a for a in self.action_names if a.startswith(action.UTTER_PREFIX)
         ]
 
         missing_templates = [t for t in utterances if t not in self.templates.keys()]

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -79,6 +79,7 @@ async def train_async(
     skill_imports = SkillSelector.load(config)
     try:
         domain = Domain.load(domain, skill_imports)
+        domain.check_missing_templates()
     except InvalidDomain as e:
         print_error(
             "Could not load domain due to error: {} \nTo specify a valid domain "
@@ -259,6 +260,7 @@ async def train_core_async(
     if isinstance(domain, str):
         try:
             domain = Domain.load(domain, skill_imports)
+            domain.check_missing_templates()
         except InvalidDomain as e:
             print_error(
                 "Could not load domain due to: '{}'. To specify a valid domain path "


### PR DESCRIPTION
**Proposed changes**:
Move method `warn_missing_templates` out of `_check_domain_sanity`. If warning should be printed separate method needs to be called.

closes https://github.com/RasaHQ/rasa/issues/3706

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
