### PR TITLE
Max number of predictions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 Added
 -----
 - support for specifying full database urls in the ``SQLTrackerStore`` configuration
+- maximum number of predictions can be set via the environment variable ``MAX_NUMBER_OF_PREDICTIONS`` (default is 10)
 
 Changed
 -------

--- a/docs/core/policies.rst
+++ b/docs/core/policies.rst
@@ -63,6 +63,13 @@ every turn, the policy which predicts the next action with the
 highest confidence will be used. If two policies predict with equal
 confidence, the policy with the higher priority will be used.
 
+.. note::
+
+    Per default a maximum of 10 next actions can be predicted
+    by the agent after every user message. To update this value
+    you can set the environment variable ``MAX_NUMBER_OF_PREDICTIONS``
+    to the desired number of maximum predictions.
+
 
 Your project's ``config.yml`` file takes a ``policies`` key
 which you can use to customize the policies your assistant uses.

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from types import LambdaType
 from typing import Any, Dict, List, Optional, Text, Tuple
 
@@ -40,6 +41,9 @@ from rasa.utils.endpoints import EndpointConfig
 logger = logging.getLogger(__name__)
 
 
+MAX_NUMBER_OF_PREDICTIONS = int(os.environ.get("MAX_NUMBER_OF_PREDICTIONS", "10"))
+
+
 class MessageProcessor(object):
     def __init__(
         self,
@@ -49,7 +53,7 @@ class MessageProcessor(object):
         tracker_store: TrackerStore,
         generator: NaturalLanguageGenerator,
         action_endpoint: Optional[EndpointConfig] = None,
-        max_number_of_predictions: int = 10,
+        max_number_of_predictions: int = MAX_NUMBER_OF_PREDICTIONS,
         message_preprocessor: Optional[LambdaType] = None,
         on_circuit_break: Optional[LambdaType] = None,
     ):


### PR DESCRIPTION
**Proposed changes**:
Currently, the agent can predict a maximum number of 10 next action. This number is hard coded and cannot be updated.
After merging, the number of maximum predictions can be updated via an environment variable called `MAX_NUMBER_OF_PREDICTIONS`. 

closes https://github.com/RasaHQ/rasa/issues/3664

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
