### PR TITLE
Fix creation of RasaNLUHttpInterpreter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Removed
 
 Fixed
 -----
+- fixed creation of ``RasaNLUHttpInterpreter``
+
 
 [1.0.9] - 2019-06-10
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -61,7 +61,7 @@ class RegexInterpreter(NaturalLanguageInterpreter):
         return INTENT_MESSAGE_PREFIX
 
     @staticmethod
-    def _create_entities(parsed_entities: Dict, sidx: int, eidx: int):
+    def _create_entities(parsed_entities: Dict[Text, Union[Text, List[Text]]], sidx: int, eidx: int) -> List[Dict[Text, Any]]:
         entities = []
         for k, vs in parsed_entities.items():
             if not isinstance(vs, list):

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -5,7 +5,7 @@ import logging
 import re
 
 import os
-from typing import Text, List, Dict, Any
+from typing import Text, List, Dict, Any, Union, Optional
 
 from rasa.core import constants
 from rasa.core.constants import INTENT_MESSAGE_PREFIX
@@ -15,13 +15,19 @@ logger = logging.getLogger(__name__)
 
 
 class NaturalLanguageInterpreter(object):
-    async def parse(self, text, message_id=None):
+    async def parse(
+        self, text: Text, message_id: Optional[Text] = None
+    ) -> Dict[Text, Any]:
         raise NotImplementedError(
             "Interpreter needs to be able to parse messages into structured output."
         )
 
     @staticmethod
-    def create(obj, endpoint=None):
+    def create(
+        obj: Union[Text, "NaturalLanguageInterpreter"],
+        endpoint: Optional[EndpointConfig] = None,
+    ) -> "NaturalLanguageInterpreter":
+
         if isinstance(obj, NaturalLanguageInterpreter):
             return obj
 
@@ -33,31 +39,20 @@ class NaturalLanguageInterpreter(object):
                     "Using RegexInterpreter instead."
                     "".format(obj)
                 )
-            return RegexInterpreter()  # default interpreter
+            return RegexInterpreter()
 
-        if not os.path.exists(obj):
-            logger.warning(
-                "No NLU model found. Using RegexInterpreter instead.".format(obj)
-            )
-            return RegexInterpreter()  # default interpreter
+        if endpoint is None:
+            if not os.path.exists(obj):
+                logger.warning(
+                    "No local NLU model '{}' found. Using RegexInterpreter instead.".format(
+                        obj
+                    )
+                )
+                return RegexInterpreter()
+            else:
+                return RasaNLUInterpreter(model_directory=obj)
 
-        if not endpoint:
-            return RasaNLUInterpreter(model_directory=obj)
-
-        name_parts = os.path.split(obj)
-
-        if len(name_parts) == 1:
-            # using the default project name
-            return RasaNLUHttpInterpreter(name_parts[0], endpoint)
-        elif len(name_parts) == 2:
-            return RasaNLUHttpInterpreter(name_parts[1], endpoint, name_parts[0])
-        else:
-            raise Exception(
-                "You have configured an endpoint to use for "
-                "the NLU model. To use it, you need to "
-                "specify the model to use with "
-                "`--nlu model`."
-            )
+        return RasaNLUHttpInterpreter(endpoint)
 
 
 class RegexInterpreter(NaturalLanguageInterpreter):
@@ -66,7 +61,7 @@ class RegexInterpreter(NaturalLanguageInterpreter):
         return INTENT_MESSAGE_PREFIX
 
     @staticmethod
-    def _create_entities(parsed_entities, sidx, eidx):
+    def _create_entities(parsed_entities: Dict, sidx: int, eidx: int):
         entities = []
         for k, vs in parsed_entities.items():
             if not isinstance(vs, list):
@@ -126,7 +121,7 @@ class RegexInterpreter(NaturalLanguageInterpreter):
             )
             return 0.0
 
-    def _starts_with_intent_prefix(self, text):
+    def _starts_with_intent_prefix(self, text: Text) -> bool:
         for c in self.allowed_prefixes():
             if text.startswith(c):
                 return True
@@ -153,7 +148,9 @@ class RegexInterpreter(NaturalLanguageInterpreter):
             )
             return None, 0.0, []
 
-    async def parse(self, text, message_id=None):
+    async def parse(
+        self, text: Text, message_id: Optional[Text] = None
+    ) -> Dict[Text, Any]:
         """Parse a text message."""
 
         intent, confidence, entities = self.extract_intent_and_entities(text)
@@ -172,18 +169,15 @@ class RegexInterpreter(NaturalLanguageInterpreter):
 
 
 class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
-    def __init__(
-        self, model_name: Text = None, endpoint: EndpointConfig = None
-    ) -> None:
-
-        self.model_name = model_name
-
+    def __init__(self, endpoint: EndpointConfig = None) -> None:
         if endpoint:
             self.endpoint = endpoint
         else:
             self.endpoint = EndpointConfig(constants.DEFAULT_SERVER_URL)
 
-    async def parse(self, text, message_id=None):
+    async def parse(
+        self, text: Text, message_id: Optional[int] = None
+    ) -> Dict[Text, Any]:
         """Parse a text message.
 
         Return a default value if the parsing of the text failed."""
@@ -193,14 +187,14 @@ class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
             "entities": [],
             "text": "",
         }
-        result = await self._rasa_http_parse(text, message_id)
+        result = await self._rasa_http_parse(text)
 
         return result if result is not None else default_return
 
-    async def _rasa_http_parse(self, text, message_id=None):
+    async def _rasa_http_parse(self, text: Text) -> Optional[Dict[Text, Any]]:
         """Send a text message to a running rasa NLU http server.
-
         Return `None` on failure."""
+        from requests.compat import urljoin
 
         if not self.endpoint:
             logger.error(
@@ -209,14 +203,10 @@ class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
             )
             return None
 
-        params = {
-            "token": self.endpoint.token,
-            "model": self.model_name,
-            "text": text,
-            "message_id": message_id,
-        }
+        params = {"token": self.endpoint.token, "text": text}
 
-        url = "{}/parse".format(self.endpoint.url)
+        url = urljoin(self.endpoint.url, "/model/parse")
+
         # noinspection PyBroadException
         try:
             async with aiohttp.ClientSession() as session:
@@ -237,7 +227,12 @@ class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
 
 
 class RasaNLUInterpreter(NaturalLanguageInterpreter):
-    def __init__(self, model_directory, config_file=None, lazy_init=False):
+    def __init__(
+        self,
+        model_directory: Text,
+        config_file: Optional[Text] = None,
+        lazy_init: bool = False,
+    ):
         self.model_directory = model_directory
         self.lazy_init = lazy_init
         self.config_file = config_file
@@ -247,7 +242,9 @@ class RasaNLUInterpreter(NaturalLanguageInterpreter):
         else:
             self.interpreter = None
 
-    async def parse(self, text, message_id=None):
+    async def parse(
+        self, text: Text, message_id: Optional[Text] = None
+    ) -> Dict[Text, Any]:
         """Parse a text message.
 
         Return a default value if the parsing of the text failed."""

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -61,7 +61,9 @@ class RegexInterpreter(NaturalLanguageInterpreter):
         return INTENT_MESSAGE_PREFIX
 
     @staticmethod
-    def _create_entities(parsed_entities: Dict[Text, Union[Text, List[Text]]], sidx: int, eidx: int) -> List[Dict[Text, Any]]:
+    def _create_entities(
+        parsed_entities: Dict[Text, Union[Text, List[Text]]], sidx: int, eidx: int
+    ) -> List[Dict[Text, Any]]:
         entities = []
         for k, vs in parsed_entities.items():
             if not isinstance(vs, list):

--- a/tests/core/test_interpreter.py
+++ b/tests/core/test_interpreter.py
@@ -91,20 +91,15 @@ async def test_regex_interpreter_adds_intent_prefix(regex_interpreter):
 
 async def test_http_interpreter():
     with aioresponses() as mocked:
-        mocked.post("https://example.com/parse")
+        mocked.post("https://example.com/model/parse")
 
         endpoint = EndpointConfig("https://example.com")
         interpreter = RasaNLUHttpInterpreter(endpoint=endpoint)
-        await interpreter.parse(text="message_text", message_id="1134")
+        await interpreter.parse(text="message_text")
 
-        r = latest_request(mocked, "POST", "https://example.com/parse")
+        r = latest_request(mocked, "POST", "https://example.com/model/parse")
 
         query = json_of_latest_request(r)
-        response = {
-            "text": "message_text",
-            "message_id": "1134",
-            "model": None,
-            "token": None,
-        }
+        response = {"text": "message_text", "token": None}
 
         assert query == response

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -67,7 +67,7 @@ async def test_http_parsing():
 
     endpoint = EndpointConfig("https://interpreter.com")
     with aioresponses() as mocked:
-        mocked.post("https://interpreter.com/parse", repeat=True, status=200)
+        mocked.post("https://interpreter.com/model/parse", repeat=True, status=200)
 
         inter = RasaNLUHttpInterpreter(endpoint=endpoint)
         try:
@@ -77,10 +77,9 @@ async def test_http_parsing():
         except KeyError:
             pass  # logger looks for intent and entities, so we except
 
-        r = latest_request(mocked, "POST", "https://interpreter.com/parse")
+        r = latest_request(mocked, "POST", "https://interpreter.com/model/parse")
 
         assert r
-        assert json_of_latest_request(r)["message_id"] == message.message_id
 
 
 async def test_reminder_scheduled(


### PR DESCRIPTION
**Proposed changes**:
Fix creation of `RasaNLUHttpInterpreter`:
* if an endpoint is provided, a `RasaNLUHttpInterpreter` is created
* if no endpoint is provided, but a valid path to a NLU model is given, a `RasaNLUInterpreter` is created
* otherwise a `RegexInterpreter` is created

fixes https://github.com/RasaHQ/rasa/issues/3672

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
