### PR TITLE
Fix a bug in the count vectors featuriser

### DIFF
--- a/rasa/nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/count_vectors_featurizer.py
@@ -172,7 +172,7 @@ class CountVectorsFeaturizer(Featurizer):
         if self.lowercase:
             text = text.lower()
 
-        if self.OOV_token:
+        if self.OOV_token and self.analyzer == "word":
             text_tokens = text.split()
             if hasattr(self.vectorizer, "vocabulary_"):
                 # CountVectorizer is trained, process for prediction


### PR DESCRIPTION
**Proposed changes**:
- Disable OOV substitution in `char_wb` and `char` analyser mode in the count vector featuriser. This bug was causing most words to be replaced by the OOV token at test time if the configuration specified a character-level analyser mode (i.e. `char_wb` or `char`) _and_  `OOV_token` was specified.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
