### PR TITLE
Issue 3819 - pass message_id to _rasa_http_parse

### DIFF
--- a/docs/_static/spec/rasa.yml
+++ b/docs/_static/spec/rasa.yml
@@ -532,6 +532,10 @@ paths:
                   type: string
                   description: Message to be parsed
                   example: "Hello, I am Rasa!"
+                message_id:
+                  type: string
+                  description: Optional ID for message to be parsed
+                  example: "b2831e73-1407-4ba0-a861-0f30a42a2a5a"
       responses:
         200:
           description: Success

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -180,7 +180,7 @@ class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
             self.endpoint = EndpointConfig(constants.DEFAULT_SERVER_URL)
 
     async def parse(
-        self, text: Text, message_id: Optional[int] = None
+        self, text: Text, message_id: Optional[Text] = None
     ) -> Dict[Text, Any]:
         """Parse a text message.
 
@@ -191,11 +191,13 @@ class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
             "entities": [],
             "text": "",
         }
-        result = await self._rasa_http_parse(text)
+        result = await self._rasa_http_parse(text, message_id)
 
         return result if result is not None else default_return
 
-    async def _rasa_http_parse(self, text: Text) -> Optional[Dict[Text, Any]]:
+    async def _rasa_http_parse(
+        self, text: Text, message_id: Optional[Text] = None
+    ) -> Optional[Dict[Text, Any]]:
         """Send a text message to a running rasa NLU http server.
         Return `None` on failure."""
         from requests.compat import urljoin  # pytype: disable=import-error
@@ -207,7 +209,7 @@ class RasaNLUHttpInterpreter(NaturalLanguageInterpreter):
             )
             return None
 
-        params = {"token": self.endpoint.token, "text": text}
+        params = {"token": self.endpoint.token, "text": text, "message_id": message_id}
 
         url = urljoin(self.endpoint.url, "/model/parse")
 

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -257,7 +257,7 @@ class RasaNLUInterpreter(NaturalLanguageInterpreter):
 
         if self.lazy_init and self.interpreter is None:
             self._load_interpreter()
-        result = self.interpreter.parse(text)
+        result = self.interpreter.parse(text, message_id)
 
         return result
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -799,7 +799,9 @@ def create_app(
 
         try:
             data = emulator.normalise_request_json(request.json)
-            parse_data = await app.agent.interpreter.parse(data.get("text"))
+            parse_data = await app.agent.interpreter.parse(
+                data.get("text"), data.get("message_id")
+            )
             response_data = emulator.normalise_response_json(parse_data)
 
             return response.json(response_data)

--- a/tests/core/test_interpreter.py
+++ b/tests/core/test_interpreter.py
@@ -95,11 +95,11 @@ async def test_http_interpreter():
 
         endpoint = EndpointConfig("https://example.com")
         interpreter = RasaNLUHttpInterpreter(endpoint=endpoint)
-        await interpreter.parse(text="message_text")
+        await interpreter.parse(text="message_text", message_id="message_id")
 
         r = latest_request(mocked, "POST", "https://example.com/model/parse")
 
         query = json_of_latest_request(r)
-        response = {"text": "message_text", "token": None}
+        response = {"text": "message_text", "token": None, "message_id": "message_id"}
 
         assert query == response


### PR DESCRIPTION
**Proposed changes**:
-  Pass "message_id" to _rasa_http_parse method in RasaNLUHttpInterpreter
- fixes #3819 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality (updated the current test actually)
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
