### PR TITLE
template formatting from regex to built-in python

### DIFF
--- a/rasa/core/nlg/template.py
+++ b/rasa/core/nlg/template.py
@@ -106,13 +106,7 @@ class TemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
         # Filling the template variables in the template text
         if template_vars and "text" in template:
             try:
-                # transforming template tags from
-                # "{tag_name}" to "{0[tag_name]}"
-                # as described here:
-                # https://stackoverflow.com/questions/7934620/python-dots-in-the-name-of-variable-in-a-format-string#comment9695339_7934969
-                # assuming that slot_name do not contain newline character here
-                text = re.sub(r"{([^\n]+?)}", r"{0[\1]}", template["text"])
-                template["text"] = text.format(template_vars)
+                template["text"] = template["text"].format(**template_vars)
             except KeyError as e:
                 logger.exception(
                     "Failed to fill utterance template '{}'. "


### PR DESCRIPTION
The regex way of just replacing the parts in a string prevents the use of curly braces "{" & "}" in text. With this, curly braces can be added by a simple double brace "{{" as this is standard in python.
Note: this code snippet was copied from rasa_core 0.14

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
