### PR TITLE
/model/train: add filename to response header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 Added
 -----
 - debug logging now tells you which tracker store is connected
+- the response of ``/model/train`` now includes a response header for the trained model filename
 
 Changed
 -------

--- a/docs/_static/spec/rasa.yml
+++ b/docs/_static/spec/rasa.yml
@@ -375,6 +375,11 @@ paths:
       responses:
         200:
           description: Zipped Rasa model
+          headers:
+            filename:
+              schema:
+                type: string
+              description: File name of the trained model.
           content:
             application/octet-stream:
               schema:

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -624,7 +624,12 @@ def create_app(
                 output_path=rjs.get("out", DEFAULT_MODELS_PATH),
                 force_training=rjs.get("force", False),
             )
-            return await response.file(model_path)
+
+            filename = os.path.basename(model_path) if model_path else None
+
+            return await response.file(
+                model_path, filename=filename, headers={"filename": filename}
+            )
         except InvalidDomain as e:
             raise ErrorResponse(
                 400,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -216,6 +216,9 @@ def test_train_stack_success(
     _, response = rasa_app.post("/model/train", json=payload)
     assert response.status == 200
 
+    assert "filename" in response.headers
+    assert response.headers["filename"] is not None
+
     # save model to temporary file
     tempdir = tempfile.mkdtemp()
     model_path = os.path.join(tempdir, "model.tar.gz")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -216,7 +216,6 @@ def test_train_stack_success(
     _, response = rasa_app.post("/model/train", json=payload)
     assert response.status == 200
 
-    assert "filename" in response.headers
     assert response.headers["filename"] is not None
 
     # save model to temporary file


### PR DESCRIPTION
**Proposed changes**:
- /model/train: add the filename of the trained model to the response header

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
