### PR TITLE
#3863 added attachment handling to socketio channel

### DIFF
--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -98,6 +98,12 @@ class SocketIOOutput(OutputChannel):
 
         await self.sio.emit(self.bot_message_evt, **json_message)
 
+    async def send_attachment(
+        self, recipient_id: Text, attachment: Iterable[Dict[Text, Any]], **kwargs: Any
+    ) -> None:
+        """Sends attachment to the output."""        
+        await self._send_message(self.sid, {"attachment" : attachment})
+
 
 class SocketIOInput(InputChannel):
     """A socket.io input channel."""

--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -101,8 +101,8 @@ class SocketIOOutput(OutputChannel):
     async def send_attachment(
         self, recipient_id: Text, attachment: Iterable[Dict[Text, Any]], **kwargs: Any
     ) -> None:
-        """Sends attachment to the output."""        
-        await self._send_message(self.sid, {"attachment" : attachment})
+        """Sends attachment to the output."""
+        await self._send_message(self.sid, {"attachment": attachment})
 
 
 class SocketIOInput(InputChannel):


### PR DESCRIPTION
**Proposed changes**:
- added function to handle attachment sending in socketio channel, so that Webchat JS clients can handle those attachments, see feature request #3863 
- fixes #3863 
**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)

I executed the pytest tests locally (running _python3 -m pytest tests_), there is at least no increased rate of errors, warnings or failed tests (47 failed, 823 passed, 135 warnings, 25 error). Maybe you could add some documentation on how to prepare and execute tests, and I don't know if this failed rate is the expected result (disclaimer: I have only very few knowledge about the python ecosystem). I had a look at _tests/core/test_channels.py_ and found no tests on single use cases for socketio, so I decided to not begin with this yet. 
