### PR TITLE
Cleanup all temporary directories after training

### DIFF
--- a/rasa/model.py
+++ b/rasa/model.py
@@ -3,8 +3,7 @@ import logging
 import os
 import shutil
 import tempfile
-from typing import Text, Tuple, Union, Optional, List, Dict, Type
-from types import TracebackType
+from typing import Text, Tuple, Union, Optional, List, Dict
 
 import yaml.parser
 
@@ -19,6 +18,7 @@ from rasa.constants import (
 from rasa.core.domain import Domain
 from rasa.core.utils import get_dict_hash
 from rasa.exceptions import ModelNotFound
+from rasa.utils.common import TempDirectoryPath
 
 # Type alias for the fingerprint
 Fingerprint = Dict[Text, Union[Text, List[Text], int, float]]
@@ -37,25 +37,7 @@ FINGERPRINT_NLU_DATA_KEY = "messages"
 FINGERPRINT_TRAINED_AT_KEY = "trained_at"
 
 
-class UnpackedModelPath(str):
-    """Represents a path to an unpacked model on disk. When used as a context
-    manager, it erases the unpacked model files after the context is exited.
-
-    """
-
-    def __enter__(self) -> "UnpackedModelPath":
-        return self
-
-    def __exit__(
-        self,
-        _exc: Optional[Type[BaseException]],
-        _value: Optional[Exception],
-        _tb: Optional[TracebackType],
-    ) -> bool:
-        shutil.rmtree(self)
-
-
-def get_model(model_path: Text = DEFAULT_MODELS_PATH) -> UnpackedModelPath:
+def get_model(model_path: Text = DEFAULT_MODELS_PATH) -> TempDirectoryPath:
     """Gets a model and unpacks it. Raises a `ModelNotFound` exception if
     no model could be found at the provided path.
 
@@ -109,7 +91,7 @@ def get_latest_model(model_path: Text = DEFAULT_MODELS_PATH) -> Optional[Text]:
 
 def unpack_model(
     model_file: Text, working_directory: Optional[Text] = None
-) -> UnpackedModelPath:
+) -> TempDirectoryPath:
     """Unpacks a zipped Rasa model.
 
     Args:
@@ -136,7 +118,7 @@ def unpack_model(
     tar.close()
     logger.debug("Extracted model to '{}'.".format(working_directory))
 
-    return UnpackedModelPath(working_directory)
+    return TempDirectoryPath(working_directory)
 
 
 def get_model_subdirectories(unpacked_model_path: Text) -> Tuple[Text, Text]:
@@ -398,17 +380,17 @@ def should_retrain(new_fingerprint: Fingerprint, old_model: Text, train_path: Te
     if old_model is None or not os.path.exists(old_model):
         return retrain_core, retrain_nlu
 
-    unpacked = unpack_model(old_model)
-    last_fingerprint = fingerprint_from_path(unpacked)
+    with unpack_model(old_model) as unpacked:
+        last_fingerprint = fingerprint_from_path(unpacked)
 
-    old_core, old_nlu = get_model_subdirectories(unpacked)
+        old_core, old_nlu = get_model_subdirectories(unpacked)
 
-    if not core_fingerprint_changed(last_fingerprint, new_fingerprint):
-        target_path = os.path.join(train_path, "core")
-        retrain_core = not merge_model(old_core, target_path)
+        if not core_fingerprint_changed(last_fingerprint, new_fingerprint):
+            target_path = os.path.join(train_path, "core")
+            retrain_core = not merge_model(old_core, target_path)
 
-    if not nlu_fingerprint_changed(last_fingerprint, new_fingerprint):
-        target_path = os.path.join(train_path, "nlu")
-        retrain_nlu = not merge_model(old_nlu, target_path)
+        if not nlu_fingerprint_changed(last_fingerprint, new_fingerprint):
+            target_path = os.path.join(train_path, "nlu")
+            retrain_nlu = not merge_model(old_nlu, target_path)
 
-    return retrain_core, retrain_nlu
+        return retrain_core, retrain_nlu

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -1,6 +1,8 @@
 import logging
 import os
-from typing import Any, Callable, Dict, List, Text, Optional
+import shutil
+from typing import Any, Callable, Dict, List, Text, Optional, Type
+from types import TracebackType
 
 import rasa.core.utils
 import rasa.utils.io
@@ -13,6 +15,25 @@ from rasa.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class TempDirectoryPath(str):
+    """Represents a path to an temporary directory. When used as a context
+    manager, it erases the contents of the directory on exit.
+
+    """
+
+    def __enter__(self) -> "TempDirectoryPath":
+        return self
+
+    def __exit__(
+        self,
+        _exc: Optional[Type[BaseException]],
+        _value: Optional[Exception],
+        _tb: Optional[TracebackType],
+    ) -> bool:
+        if os.path.exists(self):
+            shutil.rmtree(self)
 
 
 def arguments_of(func: Callable) -> List[Text]:

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -118,6 +118,26 @@ def test_train_core(run_in_default_project):
     assert os.path.isfile("train_rasa_models/rasa-model.tar.gz")
 
 
+def count_rasa_temp_files():
+    count = 0
+    with os.scandir(tempfile.gettempdir()) as it:
+        for entry in it:
+            if not entry.is_dir():
+                continue
+
+            for f in os.listdir(entry.path):
+                if f.endswith('_nlu.md') or f.endswith('_stories.md'):
+                    count += 1
+
+    return count
+
+
+def test_train_core_temp_files(run_in_default_project):
+    count = count_rasa_temp_files()
+    run_in_default_project("train", "core")
+    assert count == count_rasa_temp_files()
+
+
 def test_train_nlu(run_in_default_project):
     run_in_default_project(
         "train",
@@ -134,6 +154,12 @@ def test_train_nlu(run_in_default_project):
     files = list_files("train_models")
     assert len(files) == 1
     assert os.path.basename(files[0]).startswith("nlu-")
+
+
+def test_train_nlu_temp_files(run_in_default_project):
+    count = count_rasa_temp_files()
+    run_in_default_project("train", "nlu")
+    assert count == count_rasa_temp_files()
 
 
 def test_train_help(run):

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -126,7 +126,7 @@ def count_rasa_temp_files():
                 continue
 
             for f in os.listdir(entry.path):
-                if f.endswith('_nlu.md') or f.endswith('_stories.md'):
+                if f.endswith("_nlu.md") or f.endswith("_stories.md"):
                     count += 1
 
     return count

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -120,14 +120,13 @@ def test_train_core(run_in_default_project):
 
 def count_rasa_temp_files():
     count = 0
-    with os.scandir(tempfile.gettempdir()) as it:
-        for entry in it:
-            if not entry.is_dir():
-                continue
+    for entry in os.scandir(tempfile.gettempdir()):
+        if not entry.is_dir():
+            continue
 
-            for f in os.listdir(entry.path):
-                if f.endswith("_nlu.md") or f.endswith("_stories.md"):
-                    count += 1
+        for f in os.listdir(entry.path):
+            if f.endswith("_nlu.md") or f.endswith("_stories.md"):
+                count += 1
 
     return count
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,12 +1,15 @@
 import tempfile
 import os
+import shutil
 
 import pytest
 
 from rasa.model import unpack_model
 
-from rasa.train import _package_model
+from rasa.train import _package_model, train
 from tests.core.test_model import _fingerprint
+
+TEST_TEMP = "test_tmp"
 
 
 @pytest.mark.parametrize(
@@ -40,3 +43,40 @@ def test_package_model(trained_rasa_model, parameters):
         assert parameters["prefix"] in file_name
 
     assert file_name.endswith(".tar.gz")
+
+
+@pytest.fixture
+def move_tempdir():
+    # Create a new *empty* tmp directory
+    shutil.rmtree(TEST_TEMP, ignore_errors=True)
+    os.mkdir(TEST_TEMP)
+    tempfile.tempdir = TEST_TEMP
+    yield
+    tempfile.tempdir = None
+    shutil.rmtree(TEST_TEMP)
+
+
+def test_train_temp_files(
+    move_tempdir,
+    default_domain_path,
+    default_stories_file,
+    default_stack_config,
+    default_nlu_data,
+):
+    train(
+        default_domain_path,
+        default_stack_config,
+        [default_stories_file, default_nlu_data],
+        force_training=True,
+    )
+
+    # After training the model, try to do it again. This shouldn't try to train
+    # a new model because nothing has been changed. It also shouldn't create
+    # any temp files.
+    train(
+        default_domain_path,
+        default_stack_config,
+        [default_stories_file, default_nlu_data],
+    )
+
+    assert len(os.listdir(TEST_TEMP)) == 0

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -70,6 +70,8 @@ def test_train_temp_files(
         force_training=True,
     )
 
+    assert len(os.listdir(TEST_TEMP)) == 0
+
     # After training the model, try to do it again. This shouldn't try to train
     # a new model because nothing has been changed. It also shouldn't create
     # any temp files.


### PR DESCRIPTION
**Proposed changes**:
This PR modifies the train function so that it always deletes all temporary files and directories it creates. Fixes https://github.com/RasaHQ/rasa/issues/3851.

The following cases **should not** leave behind any temp files or directories:
- `rasa train`, without an existing model already trained
- `rasa train`, with an existing model already trained and nothing else modified
- `rasa train`, interrupted by pressing Ctrl-C at any moment
- `rasa train --force`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
