### PR TITLE
Make TravisCI builds less verbose and skip PyPI stage when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
     name: "Test 3.5"
     python: "3.5"
     script:
-      - py.test tests --cov rasa -v
+      - py.test tests --cov rasa
   - <<: *run-tests
     name: "Test 3.6"
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,7 @@ jobs:
     - git commit --allow-empty -m "trigger rasa docs update"
     - git push origin master
   - stage: deploy
+    if: branch = "master" AND tag IS present
     name: "Deploy to PyPI"
     python: 3.6
     install: skip
@@ -150,8 +151,5 @@ jobs:
       user: amn41
       # server: https://test.pypi.org/legacy/
       distributions: "sdist bdist_wheel"
-      on:
-        branch: master
-        tags: true
       password:
         secure: "MeL1Ve97eBY+VbNWuQNuLzkPs0TPc+Zh8OfZkhw69ez5imsiWpvp0LrUOLVW3CcC0vNTANEBOVX/n1kHxfcqkf/cChNqAkZ6zTMmvR9zHDwQxXVGZ3jEQSQM+fHdQpjwtH7BwojyxaCIC/5iza7DFMcca/Q6Xr+atdTd0V8Q7Nc5jFHEQf3/4oIIm6YeCUiHcEu981LRdS04+jvuFUN0Ejy+KLukGVyIWyYDjjGjs880Mj4J1mgmCihvVkJ1ujB65rYBdTjls3JpP3eTk63+xH8aHilIuvqB8TDYih8ovE/Vv6YwLI+u2HoEHAtBD4Ez3r71Ju6JKJM7DhWb5aurN4M7K6DC8AvpUl+PsJbNP4ZeW2jXMH6lT6qXKVaSw7lhZ0XY3wunyVcAbArX4RS0B9pb1nHBYUBWZjxXtr8lhkpGFu7H43hw63Y19qb8z4+1cGnijgz1mqXSAssuc+3r0W0cSr+OsCjmOs7cwT6HMQvPEKxLohwBOS/I3EbuKQOYMjFN5BWP5JXbsG45awV9tquxEW8zxjMetR+AOcYoyrDeiR8sAnj1/F99DE0bL1KyW/G5VNu2Xi/c+0M3KvP3+F8XTCuUY/5zTvqh1Qz1jcdiwsiAhO4eBQzQnjeFlxdiVeue2kmD5qsh+VLKKuKLfyVoaV7b1kBlAtBDu7+hDpA="

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,8 @@ codestyle_exclude =
 filterwarnings =
     ignore::ResourceWarning:ruamel[.*]
 
-log_cli = 1
-log_cli_level = DEBUG
+log_cli = true
+log_cli_level = WARNING
 
 [metadata]
 description-file = README.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from rasa import server
 from rasa.core import config
@@ -22,6 +23,14 @@ DEFAULT_CONFIG_PATH = "rasa/cli/default_config.yml"
 # we reuse a bit of pytest's own testing machinery, this should eventually come
 # from a separatedly installable pytest-cli plugin.
 pytest_plugins = ["pytester"]
+
+
+@pytest.fixture(autouse=True)
+def set_log_level_debug(caplog):
+    # Set the post-test log level to DEBUG for failing tests.  For all tests
+    # (failing and successful), the live log level can be additionally set in
+    # `setup.cfg`. It should be set to WARNING.
+    caplog.set_level(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -29,8 +29,6 @@ from rasa.train import train_async
 
 matplotlib.use("Agg")
 
-logging.basicConfig(level="DEBUG")
-
 DEFAULT_DOMAIN_PATH = "data/test_domains/default_with_slots.yml"
 
 DEFAULT_STORIES_FILE = "data/test_stories/stories_defaultdomain.md"

--- a/tests/nlu/base/test_evaluation.py
+++ b/tests/nlu/base/test_evaluation.py
@@ -39,8 +39,6 @@ from rasa.nlu import training_data, config
 from tests.nlu import utilities
 from tests.nlu.conftest import DEFAULT_DATA_PATH, NLU_DEFAULT_CONFIG_PATH
 
-logging.basicConfig(level="DEBUG")
-
 
 @pytest.fixture(scope="session")
 def pretrained_interpreter(component_builder, tmpdir_factory):

--- a/tests/nlu/conftest.py
+++ b/tests/nlu/conftest.py
@@ -6,8 +6,6 @@ import pytest
 from rasa.nlu import config, train
 from rasa.nlu.components import ComponentBuilder
 
-logging.basicConfig(level="DEBUG")
-
 CONFIG_DEFAULTS_PATH = "sample_configs/config_defaults.yml"
 
 NLU_DEFAULT_CONFIG_PATH = "sample_configs/config_pretrained_embeddings_mitie.yml"


### PR DESCRIPTION
**Proposed changes**:
- Skip the PyPI job entirely if conditions are not met. Before, the job was always started and then would end with "Skipping a deployment with the pypi provider because this is not a tagged commit".
- Make testing less verbose: show only warnings and errors. Went from 7800 lines of output to 3300 in this commit.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
