### PR TITLE
Add flake8 linting, update Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,10 @@ before_script:
 jobs:
   include:
   - stage: test
-    name: "Black Formatting"
+    name: "Code Formatting"
     python: 3.6
     script:
-    - pip install black
-    - black --check .
+    - make lint
   - stage: test
     name: "Type Check"
     python: 3.6
@@ -52,7 +51,7 @@ jobs:
     name: "Test 3.5"
     python: "3.5"
     script:
-      - py.test tests --cov rasa -v
+      - make test
   - <<: *run-tests
     name: "Test 3.6"
     python: '3.6'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 - debug logging now tells you which tracker store is connected
 - the response of ``/model/train`` now includes a response header for the trained model filename
 - ``Validator`` class to help developing by checking if the files have any errors
+- project's code is now linted using flake8
 
 Changed
 -------

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ clean:
 formatter:
 	black rasa tests
 
-# TODO: Remove '--exit-zero'
 lint:
 	flake8 rasa tests
 	black --check rasa tests

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,18 @@
 .PHONY: clean test lint init check-readme
 
-TEST_PATH=./
-
 help:
 	@echo "    clean"
 	@echo "        Remove python artifacts and build artifacts."
+	@echo "    formatter"
+	@echo "        Apply black formatting to code."
 	@echo "    lint"
 	@echo "        Check style with flake8."
+	@echo "    types"
+	@echo "        Check for type errors using pytype."
 	@echo "    test"
 	@echo "        Run py.test"
 	@echo "    check-readme"
 	@echo "        Check if the readme can be converted from md to rst for pypi"
-	@echo "    init"
-	@echo "        Install Rasa Core"
-
-init:
-	pip install -r requirements.txt
 
 clean:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -24,15 +21,21 @@ clean:
 	rm -rf build/
 	rm -rf .pytype/
 	rm -rf dist/
-	rm -rf *.egg-info
 	rm -rf docs/_build
 
+formatter:
+	black rasa tests
+
+# TODO: Remove '--exit-zero'
 lint:
-	black .
+	flake8 rasa tests --exit-zero
+	black --check rasa tests
+
+types:
+	pytype --keep-going rasa
 
 test: clean
-	py.test tests --verbose --color=yes $(TEST_PATH)
-	black --check .
+	py.test tests --cov rasa
 
 doctest: clean
 	cd docs && make doctest
@@ -40,6 +43,6 @@ doctest: clean
 livedocs:
 	cd docs && make livehtml
 
+# if this runs through we can be sure the readme is properly shown on pypi
 check-readme:
-	# if this runs through we can be sure the readme is properly shown on pypi
 	python setup.py check --restructuredtext --strict

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,21 @@
 
 help:
 	@echo "    clean"
-	@echo "        Remove python artifacts and build artifacts."
+	@echo "        Remove Python/build artifacts."
 	@echo "    formatter"
 	@echo "        Apply black formatting to code."
 	@echo "    lint"
-	@echo "        Check style with flake8."
+	@echo "        Lint code with flake8, and check if black formatter should be applied."
 	@echo "    types"
 	@echo "        Check for type errors using pytype."
 	@echo "    test"
-	@echo "        Run py.test"
+	@echo "        Run pytest on tests/."
 	@echo "    check-readme"
-	@echo "        Check if the readme can be converted from md to rst for pypi"
+	@echo "        Check if the README can be converted from .md to .rst for PyPI."
+	@echo "    doctest"
+	@echo "        Run all doctests embedded in the documentation."
+	@echo "    livedocs"
+	@echo "        Build the docs locally."
 
 clean:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -28,7 +32,7 @@ formatter:
 
 # TODO: Remove '--exit-zero'
 lint:
-	flake8 rasa tests --exit-zero
+	flake8 rasa tests
 	black --check rasa tests
 
 types:

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -101,8 +101,6 @@ def train_core(
         args.stories, "stories", DEFAULT_DATA_PATH, none_is_valid=True
     )
 
-    _train_path = train_path or tempfile.mkdtemp()
-
     # Policies might be a list for the compare training. Do normal training
     # if only list item was passed.
     if not isinstance(args.config, list) or len(args.config) == 1:
@@ -116,7 +114,7 @@ def train_core(
             config=config,
             stories=stories,
             output=output,
-            train_path=_train_path,
+            train_path=train_path,
             fixed_model_name=args.fixed_model_name,
             kwargs=extract_additional_arguments(args),
         )

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -116,7 +116,7 @@ def train_core(
             config=config,
             stories=stories,
             output=output,
-            train_path=train_path,
+            train_path=_train_path,
             fixed_model_name=args.fixed_model_name,
             kwargs=extract_additional_arguments(args),
         )

--- a/rasa/core/training/dsl.py
+++ b/rasa/core/training/dsl.py
@@ -188,7 +188,7 @@ class StoryFileReader(object):
             story_steps.extend(steps)
 
         # if exclusion percentage is not 100
-        if exclusion_percentage and exclusion_percentage is not 100:
+        if exclusion_percentage and exclusion_percentage != 100:
             import random
 
             idx = int(round(exclusion_percentage / 100.0 * len(story_steps)))

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -28,7 +28,7 @@ class Validator(object):
         """Create an instance from the domain, nlu and story files."""
 
         domain = Domain.load(domain_file)
-        loop = asyncio.new_event_loop()
+        asyncio.new_event_loop()
         stories = await StoryFileReader.read_from_folder(story_data, domain)
         intents = load_data(nlu_data)
 

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -104,7 +104,7 @@ def read_yaml(content: Text) -> Union[List[Any], Dict[Text, Any]]:
     # noinspection PyUnresolvedReferences
     try:
         return yaml_parser.load(content) or {}
-    except yaml.scanner.ScannerError as _:
+    except yaml.scanner.ScannerError:
         # A `ruamel.yaml.scanner.ScannerError` might happen due to escaped
         # unicode sequences that form surrogate pairs. Try converting the input
         # to a parsable format based on

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,10 @@ nbsphinx==0.3.2
 aioresponses==0.6.0
 moto==1.3.8
 
+# lint/format
+black==19.3b0; python_version>='3.6'
+flake8==3.7.7
+
 # pipeline dependencies
 spacy==2.1.4
 jieba==0.39

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ license_file = LICENSE.txt
 
 [flake8]
 max-line-length = 88
-ignore = W503, E121, E126, E211, E225, E501, E203, W391, E402
+ignore = W503, E121, E126, E211, E225, E501, E203, W391, E402, F401, F811, F405, F403

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,7 @@ log_cli_level = DEBUG
 [metadata]
 description-file = README.md
 license_file = LICENSE.txt
+
+[flake8]
+max-line-length = 88
+ignore = W503, E121, E126, E211, E225, E501, E203, W391, E402

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -77,7 +77,7 @@ async def test_agent_train(tmpdir, default_domain):
     assert [s.name for s in loaded.domain.slots] == [s.name for s in agent.domain.slots]
 
     # test policies
-    assert type(loaded.policy_ensemble) is type(agent.policy_ensemble)  # nopep8
+    assert isinstance(loaded.policy_ensemble, type(agent.policy_ensemble))
     assert [type(p) for p in loaded.policy_ensemble.policies] == [
         type(p) for p in agent.policy_ensemble.policies
     ]

--- a/tests/nlu/base/test_utils.py
+++ b/tests/nlu/base/test_utils.py
@@ -107,7 +107,7 @@ def test_remove_model_invalid(empty_model_dir):
     test_file_path = os.path.join(empty_model_dir, test_file)
     write_to_file(test_file_path, test_content)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         remove_model(empty_model_dir)
 
     os.remove(test_file_path)


### PR DESCRIPTION
**Proposed changes**:
This PR adds flake8 to the project. Initially, flake8 will be ran with the `--exit-zero` flag enabled, so that all checks can be fixed incrementally.

Additionally:
- The `.travis.yml` was modified so that it uses `Makefile` recipes. `Makefile` recipes can be now used to lint, format and test the code correctly.
- `pip install black` was removed from `.travis.yml` and added to `requirements-dev.txt`, with a pinned version.

The following `Makefile` recipes were modified:
- `formatter`: Applies black formatting to the code.
- `lint`: Runs flake8 and black checks on the code (does not modify it).
- `types`: Runs pytypes checks on the code.
- `test`: Runs all tests.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
