### PR TITLE
insert current path in syspath whenever cli invoked [WIP]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Fixed
 -----
 - all temporal model files are now deleted after stopping the Rasa server
 - ``rasa shell nlu`` now outputs unicode characters instead of ``\uxxxx`` codes
+- custom files, e.g. custom components and channels, load correctly when using
+  the command line interface
 
 
 [1.1.4] - 2019-06-18

--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -56,6 +56,9 @@ def print_version() -> None:
 
 def main() -> None:
     # Running as standalone python application
+    import os
+    import sys
+
     parse_last_positional_argument_as_model_path()
     arg_parser = create_argument_parser()
     cmdline_arguments = arg_parser.parse_args()
@@ -64,6 +67,9 @@ def main() -> None:
         cmdline_arguments.loglevel if hasattr(cmdline_arguments, "loglevel") else None
     )
     set_log_level(log_level)
+
+    # insert current path in syspath so custom modules are found
+    sys.path.insert(1, os.getcwd())
 
     if hasattr(cmdline_arguments, "func"):
         rasa.utils.io.configure_colored_logging(log_level)

--- a/rasa/cli/__init__.py
+++ b/rasa/cli/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# insert current path in syspath so module is found
+sys.path.insert(1, os.getcwd())

--- a/rasa/cli/__init__.py
+++ b/rasa/cli/__init__.py
@@ -1,5 +1,0 @@
-import os
-import sys
-
-# insert current path in syspath so module is found
-sys.path.insert(1, os.getcwd())

--- a/rasa/cli/run.py
+++ b/rasa/cli/run.py
@@ -49,8 +49,6 @@ def run_actions(args: argparse.Namespace):
 
     args.actions = args.actions or DEFAULT_ACTIONS_PATH
 
-    # insert current path in syspath so module is found
-    sys.path.insert(1, os.getcwd())
     path = args.actions.replace(".", os.sep) + ".py"
     _ = get_validated_path(path, "action", DEFAULT_ACTIONS_PATH)
 


### PR DESCRIPTION
**Proposed changes**:
- always include current path in syspath for CLI so that custom channels, policies, and components can be found
- fix https://github.com/RasaHQ/rasa/issues/3883

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
