### PR TITLE
fix `in AnySlotDict` behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,8 @@ Fixed
 -----
 - all temporal model files are now deleted after stopping the Rasa server
 - ``rasa shell nlu`` now outputs unicode characters instead of ``\uxxxx`` codes
-- ``x in AnySlotDicw`` is now True for any x
+- ``x in AnySlotDicw`` is now True for any x, which fixes empty slot warning in
+  interactive learning
 
 
 [1.1.4] - 2019-06-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 -----
 - all temporal model files are now deleted after stopping the Rasa server
 - ``rasa shell nlu`` now outputs unicode characters instead of ``\uxxxx`` codes
+- ``x in AnySlotDicw`` is now True for any x
 
 
 [1.1.4] - 2019-06-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Fixed
 -----
 - all temporal model files are now deleted after stopping the Rasa server
 - ``rasa shell nlu`` now outputs unicode characters instead of ``\uxxxx`` codes
-- ``x in AnySlotDicw`` is now True for any x, which fixes empty slot warning in
+- ``x in AnySlotDict`` is now ``True`` for any ``x``, which fixes empty slot warnings in
   interactive learning
 
 

--- a/rasa/core/trackers.py
+++ b/rasa/core/trackers.py
@@ -53,6 +53,9 @@ class AnySlotDict(dict):
         value = self[key] = Slot(key)
         return value
 
+    def __contains__(self, key):
+        return True
+
 
 class DialogueStateTracker(object):
     """Maintains the state of a conversation.

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -572,8 +572,7 @@ def test_last_executed_has_not_name():
     assert tracker.last_executed_action_has("another") is False
 
 
-@pytest.mark.parametrize("key, value", [("asfa", 1),
-                                          ("htb", None)])
+@pytest.mark.parametrize("key, value", [("asfa", 1), ("htb", None)])
 def test_tracker_without_slots(key, value, caplog):
     event = SlotSet(key, value)
     tracker = DialogueStateTracker.from_dict("any", [])

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -9,6 +9,7 @@ import os
 import rasa.utils.io
 from rasa.core import training, restore
 from rasa.core import utils
+from rasa.core.slots import Slot
 from rasa.core.actions.action import ACTION_LISTEN_NAME
 from rasa.core.domain import Domain
 from rasa.core.events import (
@@ -567,3 +568,13 @@ def test_last_executed_has_not_name():
     tracker = get_tracker(events)
 
     assert tracker.last_executed_action_has("another") is False
+
+
+@pytest.mark.parametrize("key", ["asfa", "htb", "2"])
+def test_tracker_without_slots(key):
+    tracker = DialogueStateTracker.from_dict("any", [])
+    assert key in tracker.slots
+    assert key not in tracker.slots.keys()
+    v = tracker.slots[key]
+    assert isinstance(v, Slot)
+    assert key in tracker.slots.keys()

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -572,12 +572,14 @@ def test_last_executed_has_not_name():
     assert tracker.last_executed_action_has("another") is False
 
 
-@pytest.mark.parametrize("key", ["asfa", "htb", "2"])
-def test_tracker_without_slots(key, caplog):
-    event = SlotSet(key)
+@pytest.mark.parametrize("key, value", [("asfa", 1),
+                                          ("htb", None)])
+def test_tracker_without_slots(key, value, caplog):
+    event = SlotSet(key, value)
     tracker = DialogueStateTracker.from_dict("any", [])
     assert key in tracker.slots
-    event.apply_to(tracker)
     with caplog.at_level(logging.INFO):
-        tracker.get_slot(key)
+        event.apply_to(tracker)
+        v = tracker.get_slot(key)
+        assert v == value
     assert len(caplog.records) == 0


### PR DESCRIPTION
**Proposed changes**:
- Fixes #3803 
The problem is a new tracker that is created in interactive learning but does not get passed the domain. It defaults to use `AnySlotDict` which should act as if it contains are slot.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
