### PR TITLE
Follow tensorflow logger deprecation warning

### DIFF
--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -104,15 +104,15 @@ def update_tensorflow_log_level():
 
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # disables AVX2 FMA warnings (CPU support)
     if log_level == "DEBUG":
-        tf_log_level = tf.logging.DEBUG
+        tf_log_level = tf.compat.v1.logging.DEBUG
     elif log_level == "INFO":
-        tf_log_level = tf.logging.INFO
+        tf_log_level = tf.compat.v1.logging.INFO
     elif log_level == "WARNING":
-        tf_log_level = tf.logging.WARN
+        tf_log_level = tf.compat.v1.logging.WARN
     else:
-        tf_log_level = tf.logging.ERROR
+        tf_log_level = tf.compat.v1.logging.ERROR
 
-    tf.logging.set_verbosity(tf_log_level)
+    tf.compat.v1.logging.set_verbosity(tf_log_level)
     logging.getLogger("tensorflow").propagate = False
 
 


### PR DESCRIPTION
Rasa run and run actions give the following warnings:
W0702 04:32:27.312059 140439586187072 deprecation_wrapper.py:119] From /srv/conda/envs/migliora/lib/python3.7/site-packages/rasa/utils/common.py:113: The name tf.logging.ERROR is deprecated. Please use tf.compat.v1.logging.ERROR instead.
W0702 04:32:27.312467 140439586187072 deprecation_wrapper.py:119] From /srv/conda/envs/migliora/lib/python3.7/site-packages/rasa/utils/common.py:115: The name tf.logging.set_verbosity is deprecated. Please use tf.compat.v1.logging.set_verbosity instead.
Thus, I edited the tensorflow logger references from tf.logging to tf.compat.v1.logging in the update_tensorflow_log_level function of the rasa.utils.common module.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [x ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
