### PR TITLE
Fixed crash when --domain not provided for rasa train command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,7 @@ Fixed
 - fixed bug where facebook quick replies were not rendering
 - take FB quick reply payload rather than text as input
 - fixed bug where `training_data` path in `metadata.json` was an absolute path
-
+- ``rasa train core`` no longer crashes without a ``--domain`` arg
 
 [1.1.3] - 2019-06-14
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 - ``x in AnySlotDict`` is now ``True`` for any ``x``, which fixes empty slot warnings in
   interactive learning
 - ``rasa train`` now also includes NLU files in other formats than the Rasa format
+- ``rasa train core`` no longer crashes without a ``--domain`` arg
 
 
 [1.1.4] - 2019-06-18
@@ -56,7 +57,6 @@ Fixed
 - fixed bug where facebook quick replies were not rendering
 - take FB quick reply payload rather than text as input
 - fixed bug where `training_data` path in `metadata.json` was an absolute path
-- ``rasa train core`` no longer crashes without a ``--domain`` arg
 
 [1.1.3] - 2019-06-14
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -247,6 +247,13 @@ async def train_core_async(
 
     skill_imports = SkillSelector.load(config, stories)
 
+    if isinstance(domain, type(None)):
+        print_error(
+            "Core training is skipped because no domain was found. "
+            "Please specify a valid domain using '--domain' argument or check if provided domain file does exists"
+        )
+        return None
+
     if isinstance(domain, str):
         try:
             domain = Domain.load(domain, skill_imports)

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -72,8 +72,8 @@ async def train_async(
         domain = Domain.load(domain, skill_imports)
         domain.check_missing_templates()
     except InvalidDomain as e:
-        domain=None
-    
+        domain = None
+
     story_directory, nlu_data_directory = data.get_core_nlu_directories(
         training_files, skill_imports
     )
@@ -84,7 +84,9 @@ async def train_async(
         story = stack.enter_context(TempDirectoryPath(story_directory))
 
         if domain is None:
-           return handle_domain_if_not_exists(config,nlu_data_directory,output_path,fixed_model_name)
+            return handle_domain_if_not_exists(
+                config, nlu_data_directory, output_path, fixed_model_name
+            )
 
         return await _train_async_internal(
             domain,
@@ -97,15 +99,19 @@ async def train_async(
             fixed_model_name,
             kwargs,
         )
-    
+
     if domain is None:
-       return handle_domain_if_not_exists(config,nlu_data_directory,output_path,fixed_model_name)
+        return handle_domain_if_not_exists(
+            config, nlu_data_directory, output_path, fixed_model_name
+        )
 
 
-def handle_domain_if_not_exists(config,nlu_data_directory,output_path,fixed_model_name):
+def handle_domain_if_not_exists(
+    config, nlu_data_directory, output_path, fixed_model_name
+):
     print_warning(
-    "Core training is skipped because no domain was found. "
-    "Please specify a valid domain using '--domain' argument or check if provided domain file does exists"
+        "Core training is skipped because no domain was found. "
+        "Please specify a valid domain using '--domain' argument or check if provided domain file does exists"
     )
     return _train_nlu_with_validated_data(
         config=config,

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -71,7 +71,7 @@ async def train_async(
     try:
         domain = Domain.load(domain, skill_imports)
         domain.check_missing_templates()
-    except InvalidDomain as e:
+    except InvalidDomain:
         domain = None
 
     story_directory, nlu_data_directory = data.get_core_nlu_directories(

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -109,16 +109,17 @@ async def train_async(
 def handle_domain_if_not_exists(
     config, nlu_data_directory, output_path, fixed_model_name
 ):
-    print_warning(
-        "Core training is skipped because no domain was found. "
-        "Please specify a valid domain using '--domain' argument or check if provided domain file does exists"
-    )
-    return _train_nlu_with_validated_data(
+    nlu_model_only = _train_nlu_with_validated_data(
         config=config,
         nlu_data_directory=nlu_data_directory,
         output=output_path,
         fixed_model_name=fixed_model_name,
     )
+    print_warning(
+        "Core training is skipped because no domain was found. "
+        "Please specify a valid domain using '--domain' argument or check if the provided domain file exists."
+    )
+    return nlu_model_only
 
 
 async def _train_async_internal(
@@ -320,7 +321,7 @@ async def train_core_async(
     except InvalidDomain:
         print_error(
             "Core training is skipped because no domain was found. "
-            "Please specify a valid domain using '--domain' argument or check if provided domain file does exists"
+            "Please specify a valid domain using '--domain' argument or check if the provided domain file exists."
         )
         return None
 

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -116,7 +116,7 @@ def handle_domain_if_not_exists(
         fixed_model_name=fixed_model_name,
     )
     print_warning(
-        "Core training is skipped because no domain was found. "
+        "Core training was skipped because no valid domain file was found. Only an nlu-model was created."
         "Please specify a valid domain using '--domain' argument or check if the provided domain file exists."
     )
     return nlu_model_only
@@ -320,7 +320,7 @@ async def train_core_async(
         domain.check_missing_templates()
     except InvalidDomain:
         print_error(
-            "Core training is skipped because no domain was found. "
+            "Core training was skipped because no valid domain file was found. "
             "Please specify a valid domain using '--domain' argument or check if the provided domain file exists."
         )
         return None

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -37,29 +37,6 @@ def test_train(run_in_default_project):
     assert os.path.basename(files[0]) == "test-model.tar.gz"
 
 
-def test_train(run_in_default_project):
-    temp_dir = os.getcwd()
-
-    run_in_default_project(
-        "train",
-        "-c",
-        "config.yml",
-        "-d",
-        "domain.yml",
-        "--data",
-        "data",
-        "--out",
-        "train_models",
-        "--fixed-model-name",
-        "test-model",
-    )
-
-    assert os.path.exists(os.path.join(temp_dir, "train_models"))
-    files = list_files(os.path.join(temp_dir, "train_models"))
-    assert len(files) == 1
-    assert os.path.basename(files[0]) == "test-model.tar.gz"
-
-
 def test_train_no_domain_exists(run_in_default_project):
     temp_dir = os.getcwd()
 
@@ -70,14 +47,14 @@ def test_train_no_domain_exists(run_in_default_project):
         "--data",
         "data",
         "--out",
-        "train_models",
+        "train_models_no_domain",
         "--fixed-model-name",
-        "test-model",
+        "nlu-model-only",
     )
-    assert os.path.exists("train_models")
-    files = list_files("train_models")
+    assert os.path.exists("train_models_no_domain")
+    files = list_files("train_models_no_domain")
     assert len(files) == 1
-    assert os.path.basename(files[0]).startswith("nlu-")
+    
 
 
 def test_train_skip_on_model_not_changed(run_in_default_project):
@@ -162,21 +139,25 @@ def test_train_core(run_in_default_project):
 
 
 def test_train_core_no_domain_exists(run_in_default_project):
+
+    os.remove("domain.yml"); 
     run_in_default_project(
         "train",
         "core",
-        "-c",
+        "--config",
         "config.yml",
+        "--domain",
+        "domain.yml",
         "--stories",
         "data",
         "--out",
-        "train_rasa_models",
+        "train_rasa_models_no_domain",
         "--fixed-model-name",
         "rasa-model",
     )
 
-    assert not os.path.exists("train_rasa_models/rasa-model.tar.gz")
-    assert not os.path.isfile("train_rasa_models/rasa-model.tar.gz")
+    assert not os.path.exists("train_rasa_models_no_domain/rasa-model.tar.gz")
+    assert not os.path.isfile("train_rasa_models_no_domain/rasa-model.tar.gz")
 
 
 def test_train_nlu(run_in_default_project):

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -4,6 +4,8 @@ import tempfile
 
 import pytest
 
+from rasa import model
+
 from rasa.cli.train import _get_valid_config
 from rasa.constants import (
     CONFIG_MANDATORY_KEYS_CORE,
@@ -38,8 +40,8 @@ def test_train(run_in_default_project):
 
 
 def test_train_no_domain_exists(run_in_default_project):
-    temp_dir = os.getcwd()
-
+    
+    os.remove("domain.yml")
     run_in_default_project(
         "train",
         "-c",
@@ -51,9 +53,18 @@ def test_train_no_domain_exists(run_in_default_project):
         "--fixed-model-name",
         "nlu-model-only",
     )
+
     assert os.path.exists("train_models_no_domain")
     files = list_files("train_models_no_domain")
     assert len(files) == 1
+
+    trained_model_path = "train_models_no_domain/nlu-model-only.tar.gz"
+    unpacked = model.unpack_model(trained_model_path)
+
+    metadata_path = os.path.join(unpacked, "nlu", "metadata.json")
+    assert os.path.exists(metadata_path)
+
+    
     
 
 
@@ -140,14 +151,14 @@ def test_train_core(run_in_default_project):
 
 def test_train_core_no_domain_exists(run_in_default_project):
 
-    os.remove("domain.yml"); 
+    os.remove("domain.yml");
     run_in_default_project(
         "train",
         "core",
         "--config",
         "config.yml",
         "--domain",
-        "domain.yml",
+        "domain1.yml",
         "--stories",
         "data",
         "--out",

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -40,7 +40,7 @@ def test_train(run_in_default_project):
 
 
 def test_train_no_domain_exists(run_in_default_project):
-    
+
     os.remove("domain.yml")
     run_in_default_project(
         "train",
@@ -63,9 +63,6 @@ def test_train_no_domain_exists(run_in_default_project):
 
     metadata_path = os.path.join(unpacked, "nlu", "metadata.json")
     assert os.path.exists(metadata_path)
-
-    
-    
 
 
 def test_train_skip_on_model_not_changed(run_in_default_project):
@@ -151,7 +148,7 @@ def test_train_core(run_in_default_project):
 
 def test_train_core_no_domain_exists(run_in_default_project):
 
-    os.remove("domain.yml");
+    os.remove("domain.yml")
     run_in_default_project(
         "train",
         "core",
@@ -169,7 +166,8 @@ def test_train_core_no_domain_exists(run_in_default_project):
 
     assert not os.path.exists("train_rasa_models_no_domain/rasa-model.tar.gz")
     assert not os.path.isfile("train_rasa_models_no_domain/rasa-model.tar.gz")
-    
+
+
 def count_rasa_temp_files():
     count = 0
     for entry in os.scandir(tempfile.gettempdir()):

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -37,6 +37,49 @@ def test_train(run_in_default_project):
     assert os.path.basename(files[0]) == "test-model.tar.gz"
 
 
+def test_train(run_in_default_project):
+    temp_dir = os.getcwd()
+
+    run_in_default_project(
+        "train",
+        "-c",
+        "config.yml",
+        "-d",
+        "domain.yml",
+        "--data",
+        "data",
+        "--out",
+        "train_models",
+        "--fixed-model-name",
+        "test-model",
+    )
+
+    assert os.path.exists(os.path.join(temp_dir, "train_models"))
+    files = list_files(os.path.join(temp_dir, "train_models"))
+    assert len(files) == 1
+    assert os.path.basename(files[0]) == "test-model.tar.gz"
+
+
+def test_train_no_domain_exists(run_in_default_project):
+    temp_dir = os.getcwd()
+
+    run_in_default_project(
+        "train",
+        "-c",
+        "config.yml",
+        "--data",
+        "data",
+        "--out",
+        "train_models",
+        "--fixed-model-name",
+        "test-model",
+    )
+    assert os.path.exists("train_models")
+    files = list_files("train_models")
+    assert len(files) == 1
+    assert os.path.basename(files[0]).startswith("nlu-")
+
+
 def test_train_skip_on_model_not_changed(run_in_default_project):
     temp_dir = os.getcwd()
 
@@ -116,6 +159,24 @@ def test_train_core(run_in_default_project):
 
     assert os.path.exists("train_rasa_models/rasa-model.tar.gz")
     assert os.path.isfile("train_rasa_models/rasa-model.tar.gz")
+
+
+def test_train_core_no_domain_exists(run_in_default_project):
+    run_in_default_project(
+        "train",
+        "core",
+        "-c",
+        "config.yml",
+        "--stories",
+        "data",
+        "--out",
+        "train_rasa_models",
+        "--fixed-model-name",
+        "rasa-model",
+    )
+
+    assert not os.path.exists("train_rasa_models/rasa-model.tar.gz")
+    assert not os.path.isfile("train_rasa_models/rasa-model.tar.gz")
 
 
 def test_train_nlu(run_in_default_project):


### PR DESCRIPTION
Fixes #3794

**Proposed changes**:
- An Error message will be displayed in case of invalid domain file provided
or no domain file provided at all for `rasa train core` only
- One more additional check added to `--domain` argument

**Tests**:
- [CORE] Provide Invalid domain file path  **[Error Message Displayed]**
`python rasa/rasa train core --domain rasa/examples/formbot/domain1.yml  --config rasa/examples/formbot/config.yml --stories rasa/examples/formbot/data/ --out rasa/examples/formbot/models --augmentation 0 --quiet`

- [CORE] No domain file provided **[Error Message Displayed]**
`python rasa/rasa train core  --config rasa/examples/formbot/config.yml --stories rasa/examples/formbot/data/ --out rasa/examples/formbot/models --augmentation 0 --quiet`

- [CORE] Provided valid domain file **[PASS]**
`python rasa/rasa train core --domain rasa/examples/formbot/domain.yml  --config rasa/examples/formbot/config.yml --stories rasa/examples/formbot/data/ --out rasa/examples/formbot/models --augmentation 0 --quiet`

- [NLU] No domain file provided **[PASS]**
`python rasa/rasa train nlu  --config rasa/examples/formbot/config.yml --nlu rasa/examples/formbot/data/ --out rasa/examples/formbot/models`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
