### PR TITLE
Remove starter packs from Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,22 +69,6 @@ jobs:
     - swagger-cli validate docs/_static/spec/action-server.yml
     - swagger-cli validate docs/_static/spec/rasa.yml
   - stage: test
-    if: branch =~ /(\d+\.\d+\.x)/ or branch = "master" # only new version PRs & PRs to master will test starter packs
-    name: "NLU starter pack (NLU only)"
-    python: 3.6
-    script:
-    - git clone -b latest https://github.com/RasaHQ/starter-pack-rasa-nlu.git
-    - cd starter-pack-rasa-nlu
-    - python -m pytest tests
-  - stage: test
-    if: branch =~ /(\d+\.\d+\.x)/ or branch = "master" # only new version PRs & PRs to master will test starter packs
-    name: "Stack starter pack"
-    python: 3.6
-    script:
-    - git clone -b latest https://github.com/RasaHQ/starter-pack-rasa-stack.git
-    - cd starter-pack-rasa-stack
-    - python -m pytest tests
-  - stage: test
     name: "Test Docs"
     install:
     - pip install -r requirements-docs.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Removed
 -------
 - revert the stripping of trailing slashes in endpoint URLs since this can lead to
   problems in case the trailing slash is actually wanted
+- starter packs were removed from Github and are therefore no longer tested by Travis script
 
 Fixed
 -----


### PR DESCRIPTION
**Proposed changes**:
- Starter packs were deprecated and therefore can no longer be tested

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
