### PR TITLE
rasa run: remove default model path

### DIFF
--- a/docs/user-guide/running-the-server.rst
+++ b/docs/user-guide/running-the-server.rst
@@ -66,7 +66,7 @@ You can configure the HTTP server to fetch models from another URL:
 
 .. code-block:: bash
 
-    rasa run -m models --enable-api --log-file out.log --endpoints my_endpoints.yml
+    rasa run --enable-api --log-file out.log --endpoints my_endpoints.yml
 
 The model server is specified in the endpoint configuration
 (``my_endpoints.yml``), where you specify the server URL Rasa

--- a/docs/user-guide/running-the-server.rst
+++ b/docs/user-guide/running-the-server.rst
@@ -29,12 +29,12 @@ The different parameters are:
 
 Rasa can load your model in three different ways:
 
-1. Load the model specified via ``-m`` from your local storage system,
-2. Fetch the model from a server (see :ref:`server_fetch_from_server`), or
-3. Fetch the model from a remote storage (see :ref:`cloud-storage`).
+1. Fetch the model from a server (see :ref:`server_fetch_from_server`), or
+2. Fetch the model from a remote storage (see :ref:`cloud-storage`).
+3. Load the model specified via ``-m`` from your local storage system,
 
-Rasa tries to load a model in the above mentioned order, i.e. it only tries to load your model from a server
-if it could not find the model on your local storage system.
+Rasa tries to load a model in the above mentioned order, i.e. it only tries to load your model from your local
+storage system if no model server and no remote storage were configured.
 
 .. warning::
 

--- a/rasa/cli/arguments/run.py
+++ b/rasa/cli/arguments/run.py
@@ -5,7 +5,7 @@ from rasa.core import constants
 
 
 def set_run_arguments(parser: argparse.ArgumentParser):
-    add_model_param(parser)
+    add_model_param(parser, default=None)
     add_server_arguments(parser)
 
 

--- a/rasa/cli/arguments/run.py
+++ b/rasa/cli/arguments/run.py
@@ -5,7 +5,7 @@ from rasa.core import constants
 
 
 def set_run_arguments(parser: argparse.ArgumentParser):
-    add_model_param(parser, default=None)
+    add_model_param(parser)
     add_server_arguments(parser)
 
 

--- a/rasa/cli/run.py
+++ b/rasa/cli/run.py
@@ -89,7 +89,8 @@ def run(args: argparse.Namespace):
         except ModelNotFound:
             print_error(
                 "No model found. Train a model before running the "
-                "server using `rasa train`."
+                "server using `rasa train` and use '--model' to provide "
+                "the model path."
             )
             return
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -227,18 +227,7 @@ async def load_agent(
     action_endpoint: Optional[EndpointConfig] = None,
 ):
     try:
-        if model_path is not None and os.path.exists(model_path):
-            return Agent.load_local_model(
-                model_path,
-                interpreter=interpreter,
-                generator=generator,
-                tracker_store=tracker_store,
-                action_endpoint=action_endpoint,
-                model_server=model_server,
-                remote_storage=remote_storage,
-            )
-
-        elif model_server is not None:
+        if model_server is not None:
             return await load_from_server(
                 Agent(
                     interpreter=interpreter,
@@ -260,6 +249,17 @@ async def load_agent(
                 tracker_store=tracker_store,
                 action_endpoint=action_endpoint,
                 model_server=model_server,
+            )
+
+        elif model_path is not None and os.path.exists(model_path):
+            return Agent.load_local_model(
+                model_path,
+                interpreter=interpreter,
+                generator=generator,
+                tracker_store=tracker_store,
+                action_endpoint=action_endpoint,
+                model_server=model_server,
+                remote_storage=remote_storage,
             )
 
         else:


### PR DESCRIPTION
**Proposed changes**:
- Remove default value of argument `model` for `rasa run` so that it is actually possible to fetch a model from a server.

fixes https://github.com/RasaHQ/rasa/issues/3931

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
