### PR TITLE
Remove Travis jobs related to starter packs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,22 +69,6 @@ jobs:
     - swagger-cli validate docs/_static/spec/action-server.yml
     - swagger-cli validate docs/_static/spec/rasa.yml
   - stage: test
-    if: branch =~ /(\d+\.\d+\.x)/ or branch = "master" # only new version PRs & PRs to master will test starter packs
-    name: "NLU starter pack (NLU only)"
-    python: 3.6
-    script:
-    - git clone -b latest https://github.com/RasaHQ/starter-pack-rasa-nlu.git
-    - cd starter-pack-rasa-nlu
-    - python -m pytest tests
-  - stage: test
-    if: branch =~ /(\d+\.\d+\.x)/ or branch = "master" # only new version PRs & PRs to master will test starter packs
-    name: "Stack starter pack"
-    python: 3.6
-    script:
-    - git clone -b latest https://github.com/RasaHQ/starter-pack-rasa-stack.git
-    - cd starter-pack-rasa-stack
-    - python -m pytest tests
-  - stage: test
     name: "Test Docs"
     install:
     - pip install -r requirements-docs.txt


### PR DESCRIPTION
**Proposed changes**:
Since the starter packs are now [deprecated](https://forum.rasa.com/t/deprecating-the-nlu-rasa-stack-starter-packs/12552), Travis builds are failing on the starter pack jobs. This PR removes those stages.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
