### PR TITLE
Ignore permission errors in count_rasa_temp_files

### DIFF
--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -124,9 +124,13 @@ def count_rasa_temp_files():
         if not entry.is_dir():
             continue
 
-        for f in os.listdir(entry.path):
-            if f.endswith("_nlu.md") or f.endswith("_stories.md"):
-                count += 1
+        try:
+            for f in os.listdir(entry.path):
+                if f.endswith("_nlu.md") or f.endswith("_stories.md"):
+                    count += 1
+        except PermissionError:
+            # Ignore permission errors
+            pass
 
     return count
 


### PR DESCRIPTION
**Proposed changes**:
The function `count_rasa_temp_files` can fail to run if it encounters a directory it can't access. Ignore those cases as they aren't needed for the tests to run.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
