### PR TITLE
use `endpoints.yml` as a default endpoints path for `rasa interactive`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ Fixed
 - ``x in AnySlotDict`` is now ``True`` for any ``x``, which fixes empty slot warnings in
   interactive learning
 - ``rasa train`` now also includes NLU files in other formats than the Rasa format
-- ``rasa interactive`` now looks for endpoints in ``endpoints.yml` if no ``--endpoints`` arg is passed
+- ``rasa interactive`` now looks for endpoints in ``endpoints.yml`` if no ``--endpoints`` arg is passed
 
 
 [1.1.4] - 2019-06-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 - ``x in AnySlotDict`` is now ``True`` for any ``x``, which fixes empty slot warnings in
   interactive learning
 - ``rasa train`` now also includes NLU files in other formats than the Rasa format
+- ``rasa interactive`` now looks for endpoints in ``endpoints.yml` if no ``--endpoints`` arg is passed
 
 
 [1.1.4] - 2019-06-18

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -10,7 +10,11 @@ from rasa import data, model
 
 # noinspection PyProtectedMember
 from rasa.cli.utils import get_validated_path, print_error
-from rasa.constants import DEFAULT_DATA_PATH, DEFAULT_MODELS_PATH, DEFAULT_ENDPOINTS_PATH
+from rasa.constants import (
+    DEFAULT_DATA_PATH,
+    DEFAULT_MODELS_PATH,
+    DEFAULT_ENDPOINTS_PATH,
+)
 from rasa.model import get_latest_model
 
 

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -10,7 +10,7 @@ from rasa import data, model
 
 # noinspection PyProtectedMember
 from rasa.cli.utils import get_validated_path, print_error
-from rasa.constants import DEFAULT_DATA_PATH, DEFAULT_MODELS_PATH
+from rasa.constants import DEFAULT_DATA_PATH, DEFAULT_MODELS_PATH, DEFAULT_ENDPOINTS_PATH
 from rasa.model import get_latest_model
 
 
@@ -77,6 +77,10 @@ def perform_interactive_learning(args, zipped_model):
         with model.unpack_model(zipped_model) as model_path:
             args.core, args.nlu = model.get_model_subdirectories(model_path)
             stories_directory = data.get_core_directory(args.data)
+
+            args.endpoints = get_validated_path(
+                args.endpoints, "endpoints", DEFAULT_ENDPOINTS_PATH, True
+            )
 
             do_interactive_learning(args, stories_directory)
     else:

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -380,14 +380,16 @@ class RemoteAction(Action):
         json_body = self._action_call_format(tracker, domain)
 
         if not self.action_endpoint:
-            raise Exception(
-                "The model predicted the custom action '{}' "
+            logger.error(
+                "The model predicted the custom action '{}', "
                 "but you didn't configure an endpoint to "
                 "run this custom action. Please take a look at "
-                "the docs and set an endpoint configuration. "
+                "the docs and set an endpoint configuration via the "
+                "--endpoints flag. "
                 "{}/core/actions"
                 "".format(self.name(), DOCS_BASE_URL)
             )
+            raise Exception("Failed to execute custom action.")
 
         try:
             logger.debug(
@@ -413,7 +415,7 @@ class RemoteAction(Action):
                 exception = ActionExecutionRejection(
                     response_data["action_name"], response_data.get("error")
                 )
-                logger.debug(exception.message)
+                logger.error(exception.message)
                 raise exception
             else:
                 raise Exception("Failed to execute custom action.") from e

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -201,7 +201,7 @@ async def test_remote_action_without_endpoint(
         await remote_action.run(
             default_channel, default_nlg, default_tracker, default_domain
         )
-    assert "you didn't configure an endpoint" in str(execinfo.value)
+    assert "Failed to execute custom action." in str(execinfo.value)
 
 
 async def test_remote_action_endpoint_not_running(


### PR DESCRIPTION
**Proposed changes**:
- closes #3959 
- use `endpoints.yml` as the default endpoints path in `rasa_interactive` 
- show error message in info mode if endpoints are not configured and custom actions are called

**Formbot** (endpoints required)
- Case 1: endpoints.yml exists but not passed -- endpoints are used
- Case 2: endpoints.yml DNE -- error message shows in chat:
```
2019-07-08 18:01:07 ERROR    rasa.core.actions.action  - The model predicted the custom action 'restaurant_form', but you didn't configure an endpoint to run this custom action. Please take a look at the docs and set an endpoint configuration via the --endpoints flag. https://rasa.com/docs/rasa/core/actions
```
**Moodbot** (endpoints not required)
- functionality does not change whether or not endpoints.yml exists

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
