### PR TITLE
fix bug of #3917. Ignore order difference when compares the domain spec of the current and the loaded domain

### DIFF
--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -614,7 +614,7 @@ class Domain(object):
         loaded_domain_spec = self.load_specification(path)
         states = loaded_domain_spec["states"]
 
-        if states != self.input_states:
+        if set(states) != set(self.input_states):
             missing = ",".join(set(states) - set(self.input_states))
             additional = ",".join(set(self.input_states) - set(states))
             raise InvalidDomain(


### PR DESCRIPTION
fix bug of #3917, Ignore order difference when compares the domain spec of the current and
the loaded domain.

**Proposed changes**:
-It shouldn't raise except when the domain spec of the current and
the loaded domain is same but with different order. Change the two list as set to ignore the order difference when compares them.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
