### PR TITLE
Rasa run model server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Removed
 Fixed
 -----
 - ``MappingPolicy`` now works correctly when used as part of a PolicyEnsemble
+- ``rasa run`` without ``--enable-api`` does not require a local model anymore
 
 
 [1.1.5] - 2019-07-10

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import shutil
 from typing import List, Text
 
 import rasa.cli.train as train

--- a/rasa/cli/run.py
+++ b/rasa/cli/run.py
@@ -75,8 +75,6 @@ def _validate_model_path(model_path: Text, parameter: Text, default: Text):
 def run(args: argparse.Namespace):
     import rasa.run
 
-    args.model = _validate_model_path(args.model, "model", DEFAULT_MODELS_PATH)
-
     args.endpoints = get_validated_path(
         args.endpoints, "endpoints", DEFAULT_ENDPOINTS_PATH, True
     )
@@ -85,6 +83,7 @@ def run(args: argparse.Namespace):
     )
 
     if args.enable_api:
+        args.model = _validate_model_path(args.model, "model", DEFAULT_MODELS_PATH)
         rasa.run(**vars(args))
 
     # if the API is not enable you cannot start without a model
@@ -99,17 +98,13 @@ def run(args: argparse.Namespace):
         rasa.run(**vars(args))
 
     # start server if model server is configured
-    try:
-        endpoints = AvailableEndpoints.read_endpoints(args.endpoints)
-        model_server = endpoints.model if endpoints and endpoints.model else None
-        model_server_set = model_server is not None
-    except ValueError:
-        model_server_set = False
-
-    if model_server_set:
+    endpoints = AvailableEndpoints.read_endpoints(args.endpoints)
+    model_server = endpoints.model if endpoints and endpoints.model else None
+    if model_server is not None:
         rasa.run(**vars(args))
 
     # start server if local model found
+    args.model = _validate_model_path(args.model, "model", DEFAULT_MODELS_PATH)
     local_model_set = True
     try:
         get_model(args.model)

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -1,20 +1,13 @@
 import argparse
 import os
-import tempfile
 from typing import List, Optional, Text, Dict
 import rasa.cli.arguments as arguments
 
-from rasa.cli.utils import (
-    get_validated_path,
-    missing_config_keys,
-    print_error,
-    print_warning,
-)
+from rasa.cli.utils import get_validated_path, missing_config_keys, print_error
 from rasa.constants import (
     DEFAULT_CONFIG_PATH,
     DEFAULT_DATA_PATH,
     DEFAULT_DOMAIN_PATH,
-    FALLBACK_CONFIG_PATH,
     CONFIG_MANDATORY_KEYS_NLU,
     CONFIG_MANDATORY_KEYS_CORE,
     CONFIG_MANDATORY_KEYS,

--- a/tests/cli/test_rasa_run.py
+++ b/tests/cli/test_rasa_run.py
@@ -1,3 +1,17 @@
+import os
+import shutil
+
+
+def test_run_does_not_start(run_in_default_project):
+    os.remove("domain.yml")
+    shutil.rmtree("models")
+
+    # the server should not start as no model is configured
+    output = run_in_default_project("run")
+
+    assert "No model found." in output.outlines[0]
+
+
 def test_run_help(run):
     output = run("run", "--help")
 

--- a/tests/cli/test_rasa_run.py
+++ b/tests/cli/test_rasa_run.py
@@ -1,17 +1,3 @@
-import os
-import shutil
-
-import pytest
-
-
-def test_run_without_model(run_in_default_project):
-    os.remove("endpoints.yml")
-    shutil.rmtree("models")
-
-    with pytest.raises(SystemExit):
-        run_in_default_project("run")
-
-
 def test_run_help(run):
     output = run("run", "--help")
 

--- a/tests/cli/test_rasa_run.py
+++ b/tests/cli/test_rasa_run.py
@@ -1,3 +1,17 @@
+import os
+import shutil
+
+import pytest
+
+
+def test_run_without_model(run_in_default_project):
+    os.remove("endpoints.yml")
+    shutil.rmtree("models")
+
+    with pytest.raises(SystemExit):
+        run_in_default_project("run")
+
+
 def test_run_help(run):
     output = run("run", "--help")
 

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -11,7 +11,6 @@ from rasa.constants import (
     CONFIG_MANDATORY_KEYS_CORE,
     CONFIG_MANDATORY_KEYS,
     CONFIG_MANDATORY_KEYS_NLU,
-    DEFAULT_CONFIG_PATH,
 )
 from rasa.nlu.utils import list_files
 


### PR DESCRIPTION
**Proposed changes**:
`rasa run` without `--enable-api` parameter works as long as you have a remote storage system, a model server or a local model configured. Before you always needed to have a local model.
- fix #3722 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
