### PR TITLE
Make vaildate method static

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Removed
 
 Fixed
 -----
-
+- validation no longer throws an error during interactive learning
 
 [1.1.6] - 2019-07-12
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -293,6 +293,7 @@ def create_validator(
     from prompt_toolkit.document import Document
 
     class FunctionValidator(Validator):
+        @staticmethod
         def validate(document: Document) -> None:
             is_valid = function(document.text)
             if not is_valid:


### PR DESCRIPTION
`self` was being passed to `prompt_toolkit`'s validation methods, which would cause errors during interactive learning

**Proposed changes**:
- Make the validate method static

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
