### PR TITLE
Create method to handle prefixed intent messages in server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Removed
 Fixed
 -----
 - validation no longer throws an error during interactive learning
+- updated the server endpoint ``/model/parse`` to handle also messages with the intent prefix
 
 [1.1.6] - 2019-07-12
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -424,12 +424,9 @@ class Agent(object):
 
         """
 
-        try:
-            processor = self.create_processor()
-            message = UserMessage(message_data)
-            return await processor._parse_message(message)
-        except Exception:
-            logger.exception("Failed to parse message data from text.")
+        processor = self.create_processor()
+        message = UserMessage(message_data)
+        return await processor._parse_message(message)
 
     async def handle_message(
         self,

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -402,7 +402,7 @@ class Agent(object):
 
     async def prepare_message_text(self, message_data: Text):
         message = UserMessage(message_data)
-        processor = self.create_processor(message)
+        processor = self.create_processor(None)
         try:
             response_data = await processor._parse_message(message)
             return response_data

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -400,6 +400,15 @@ class Agent(object):
             and self.interpreter is not None
         )
 
+    async def prepare_message_text(self, message_data: Text):
+        message = UserMessage(message_data)
+        processor = self.create_processor(message)
+        try:
+            response_data = await processor._parse_message(message)
+            return response_data
+        except Exception:
+            logger.exception("Failed to parse message data")
+
     async def handle_message(
         self,
         message: UserMessage,

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -400,14 +400,30 @@ class Agent(object):
             and self.interpreter is not None
         )
 
-    async def prepare_message_text(self, message_data: Text):
-        message = UserMessage(message_data)
-        processor = self.create_processor(None)
+    async def parse_message_from_text(self, message_data: Text):
+        """Handles message text and intent payload input messages.
+
+        The return value of this function is parsed_data.
+
+        Example:
+
+            parsed_data = { \
+                "text": '/greet{"name":"Rasa"}', \
+                "intent": {"name": "greet", "confidence": 1.0}, \
+                "intent_ranking": [{"name": "greet", "confidence": 1.0}], \
+                "entities": [{"entity": "name", "start": 6, "end": 21, "value": "Rasa"}],\
+            }
+
+
+        """
+
         try:
-            response_data = await processor._parse_message(message)
-            return response_data
+            processor = self.create_processor()
+            message = UserMessage(message_data)
+            parsed_data = await processor._parse_message(message)
+            return parsed_data
         except Exception:
-            logger.exception("Failed to parse message data")
+            logger.exception("Failed to parse message data from text.")
 
     async def handle_message(
         self,

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -400,20 +400,27 @@ class Agent(object):
             and self.interpreter is not None
         )
 
-    async def parse_message_from_text(self, message_data: Text):
+    async def parse_message_using_nlu_interpreter(self, message_data: Text):
         """Handles message text and intent payload input messages.
 
         The return value of this function is parsed_data.
 
-        Example:
+        Args:
+            message_data (Text): Contain the received message in text or\
+            intent payload format.
 
-            parsed_data = { \
-                "text": '/greet{"name":"Rasa"}', \
-                "intent": {"name": "greet", "confidence": 1.0}, \
-                "intent_ranking": [{"name": "greet", "confidence": 1.0}], \
-                "entities": [{"entity": "name", "start": 6, "end": 21, "value": "Rasa"}],\
-            }
+        Returns:
+            The parsed message.
 
+            Ex::
+
+                {\
+                    "text": '/greet{"name":"Rasa"}',\
+                    "intent": {"name": "greet", "confidence": 1.0},\
+                    "intent_ranking": [{"name": "greet", "confidence": 1.0}],\
+                    "entities": [{"entity": "name", "start": 6,\
+                                  "end": 21, "value": "Rasa"}],\
+                }
 
         """
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -421,7 +421,6 @@ class Agent(object):
             processor = self.create_processor()
             message = UserMessage(message_data)
             parsed_data = await processor._parse_message(message)
-            return parsed_data
         except Exception:
             logger.exception("Failed to parse message data from text.")
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -400,7 +400,7 @@ class Agent(object):
             and self.interpreter is not None
         )
 
-    async def parse_message_using_nlu_interpreter(self, message_data: Text):
+    async def parse_message_using_nlu_interpreter(self, message_data: Text) -> Dict[Text, Any]:
         """Handles message text and intent payload input messages.
 
         The return value of this function is parsed_data.

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -420,7 +420,7 @@ class Agent(object):
         try:
             processor = self.create_processor()
             message = UserMessage(message_data)
-            parsed_data = await processor._parse_message(message)
+            return await processor._parse_message(message)
         except Exception:
             logger.exception("Failed to parse message data from text.")
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -412,7 +412,7 @@ class Agent(object):
         Returns:
             The parsed message.
 
-            Ex::
+            Example:
 
                 {\
                     "text": '/greet{"name":"Rasa"}',\

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -809,7 +809,7 @@ def create_app(
                     data.get("text")
                 )
             except Exception as e:
-                logger.debug("Error while handling message data")
+                logger.debug(traceback.format_exc())
                 raise ErrorResponse(
                     400,
                     "ParsingError",

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -804,7 +804,9 @@ def create_app(
 
         try:
             data = emulator.normalise_request_json(request.json)
-            parsed_data = await app.agent.parse_message_from_text(data.get("text"))
+            parsed_data = await app.agent.parse_message_using_nlu_interpreter(
+                data.get("text")
+            )
             response_data = emulator.normalise_response_json(parsed_data)
 
             return response.json(response_data)

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -804,9 +804,17 @@ def create_app(
 
         try:
             data = emulator.normalise_request_json(request.json)
-            parsed_data = await app.agent.parse_message_using_nlu_interpreter(
-                data.get("text")
-            )
+            try:
+                parsed_data = await app.agent.parse_message_using_nlu_interpreter(
+                    data.get("text")
+                )
+            except Exception as e:
+                logger.debug("Error while handling message data")
+                raise ErrorResponse(
+                    400,
+                    "ParsingError",
+                    "An unexpected error occurred. Error: {}".format(e),
+                )
             response_data = emulator.normalise_response_json(parsed_data)
 
             return response.json(response_data)

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -793,7 +793,6 @@ def create_app(
 
     @app.post("/model/parse")
     @requires_auth(app, auth_token)
-    @ensure_loaded_agent(app)
     async def parse(request: Request):
         validate_request_body(
             request,
@@ -805,7 +804,8 @@ def create_app(
 
         try:
             data = emulator.normalise_request_json(request.json)
-            response_data = await app.agent.prepare_message_text(data.get("text"))
+            parsed_data = await app.agent.parse_message_from_text(data.get("text"))
+            response_data = emulator.normalise_response_json(parsed_data)
 
             return response.json(response_data)
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -793,6 +793,7 @@ def create_app(
 
     @app.post("/model/parse")
     @requires_auth(app, auth_token)
+    @ensure_loaded_agent(app)
     async def parse(request: Request):
         validate_request_body(
             request,
@@ -804,10 +805,7 @@ def create_app(
 
         try:
             data = emulator.normalise_request_json(request.json)
-            parse_data = await app.agent.interpreter.parse(
-                data.get("text"), data.get("message_id")
-            )
-            response_data = emulator.normalise_response_json(parse_data)
+            response_data = await app.agent.prepare_message_text(data.get("text"))
 
             return response.json(response_data)
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -83,6 +83,17 @@ async def test_agent_train(tmpdir, default_domain):
     ]
 
 
+async def test_agent_prepare_message_text(default_agent):
+    text = INTENT_MESSAGE_PREFIX + 'greet{"name":"Rasa"}'
+    result = await default_agent.prepare_message_text(text)
+    assert result == {
+        "text": '/greet{"name":"Rasa"}',
+        "intent": {"name": "greet", "confidence": 1.0},
+        "intent_ranking": [{"name": "greet", "confidence": 1.0}],
+        "entities": [{"entity": "name", "start": 6, "end": 21, "value": "Rasa"}],
+    }
+
+
 async def test_agent_handle_text(default_agent):
     text = INTENT_MESSAGE_PREFIX + 'greet{"name":"Rasa"}'
     result = await default_agent.handle_text(text, sender_id="test_agent_handle_text")

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -83,9 +83,9 @@ async def test_agent_train(tmpdir, default_domain):
     ]
 
 
-async def test_agent_prepare_message_text(default_agent):
+async def test_agent_parse_message_from_text(default_agent):
     text = INTENT_MESSAGE_PREFIX + 'greet{"name":"Rasa"}'
-    result = await default_agent.prepare_message_text(text)
+    result = await default_agent.parse_message_from_text(text)
     assert result == {
         "text": '/greet{"name":"Rasa"}',
         "intent": {"name": "greet", "confidence": 1.0},

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -83,15 +83,37 @@ async def test_agent_train(tmpdir, default_domain):
     ]
 
 
-async def test_agent_parse_message_using_nlu_interpreter(default_agent):
-    text = INTENT_MESSAGE_PREFIX + 'greet{"name":"Rasa"}'
-    result = await default_agent.parse_message_using_nlu_interpreter(text)
-    assert result == {
-        "text": '/greet{"name":"Rasa"}',
-        "intent": {"name": "greet", "confidence": 1.0},
-        "intent_ranking": [{"name": "greet", "confidence": 1.0}],
-        "entities": [{"entity": "name", "start": 6, "end": 21, "value": "Rasa"}],
-    }
+@pytest.mark.parametrize(
+    "text_message_data, expected",
+    [
+        (
+            '/greet{"name":"Rasa"}',
+            {
+                "text": '/greet{"name":"Rasa"}',
+                "intent": {"name": "greet", "confidence": 1.0},
+                "intent_ranking": [{"name": "greet", "confidence": 1.0}],
+                "entities": [
+                    {"entity": "name", "start": 6, "end": 21, "value": "Rasa"}
+                ],
+            },
+        ),
+        (
+            "text",
+            {
+                "text": "/text",
+                "intent": {"name": "text", "confidence": 1.0},
+                "intent_ranking": [{"name": "text", "confidence": 1.0}],
+                "entities": [],
+            },
+        ),
+    ],
+)
+async def test_agent_parse_message_using_nlu_interpreter(
+    default_agent, text_message_data, expected
+):
+    result = await default_agent.parse_message_using_nlu_interpreter(text_message_data)
+    print ("RESULT:", result)
+    assert result == expected
 
 
 async def test_agent_handle_text(default_agent):

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -112,7 +112,6 @@ async def test_agent_parse_message_using_nlu_interpreter(
     default_agent, text_message_data, expected
 ):
     result = await default_agent.parse_message_using_nlu_interpreter(text_message_data)
-    print ("RESULT:", result)
     assert result == expected
 
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -83,9 +83,9 @@ async def test_agent_train(tmpdir, default_domain):
     ]
 
 
-async def test_agent_parse_message_from_text(default_agent):
+async def test_agent_parse_message_using_nlu_interpreter(default_agent):
     text = INTENT_MESSAGE_PREFIX + 'greet{"name":"Rasa"}'
-    result = await default_agent.parse_message_from_text(text)
+    result = await default_agent.parse_message_using_nlu_interpreter(text)
     assert result == {
         "text": '/greet{"name":"Rasa"}',
         "intent": {"name": "greet", "confidence": 1.0},


### PR DESCRIPTION
Signed-off-by: ArthurTemporim <arthurrtl@gmail.com>

Fix Rasa-X to understands **intent payload input**, further discussion [here](https://github.com/RasaHQ/rasa-x/issues/928).

**Proposed changes**:
- Change Rasa to understands `/` messages
- Create method `parse_message_from_text()` on `agent.py` (In RASA have others `_parse_messages()` methods, but this receive text type and not `UserMessage` object)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
