### PR TITLE
Always return after starting server in cli/run.py

### DIFF
--- a/rasa/cli/run.py
+++ b/rasa/cli/run.py
@@ -98,12 +98,14 @@ def run(args: argparse.Namespace):
     # start server if remote storage is configured
     if args.remote_storage is not None:
         rasa.run(**vars(args))
+        return
 
     # start server if model server is configured
     endpoints = AvailableEndpoints.read_endpoints(args.endpoints)
     model_server = endpoints.model if endpoints and endpoints.model else None
     if model_server is not None:
         rasa.run(**vars(args))
+        return
 
     # start server if local model found
     args.model = _validate_model_path(args.model, "model", DEFAULT_MODELS_PATH)
@@ -115,6 +117,7 @@ def run(args: argparse.Namespace):
 
     if local_model_set:
         rasa.run(**vars(args))
+        return
 
     print_error(
         "No model found. You have three options to provide a model:\n"


### PR DESCRIPTION
**Proposed changes**:
- Add `return` statements in `cli/run.py::run()` so that the function always returns after the server has finished running. Fixes https://github.com/RasaHQ/rasa/issues/4012.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
