### PR TITLE
Rename ordered_steps to ordered_stories

### DIFF
--- a/rasa/core/training/generator.py
+++ b/rasa/core/training/generator.py
@@ -247,7 +247,7 @@ class TrainingDataGenerator(object):
             unused_checkpoints = set()  # type: Set[Text]
 
             pbar = tqdm(
-                self.story_graph.ordered_steps(),
+                self.story_graph.ordered_stories(),
                 desc="Processed Story Blocks",
                 disable=is_logging_disabled(),
             )

--- a/rasa/core/training/structures.py
+++ b/rasa/core/training/structures.py
@@ -407,7 +407,7 @@ class StoryGraph(object):
         else:
             self.story_end_checkpoints = {}
 
-    def ordered_steps(self) -> List[StoryStep]:
+    def ordered_stories(self) -> List[StoryStep]:
         """Returns the story steps ordered by topological order of the DAG."""
 
         return [self.get(step_id) for step_id in self.ordered_ids]


### PR DESCRIPTION
**Proposed changes**:
The `ordered_steps` function was actually returning a list of stories (with the steps within each story ordered as a DAG). So it makes more sense to call it `ordered_stories` (since it's a list of stories that are ordered) as opposed to `ordered_steps`.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
