### PR TITLE
Fix dead link

### DIFF
--- a/docs/user-guide/messaging-and-voice-channels.rst
+++ b/docs/user-guide/messaging-and-voice-channels.rst
@@ -4,7 +4,7 @@ Messaging and Voice Channels
 ============================
 
 If you're testing this on your local computer (i.e. not a server), you
-will need to use `ngrok <../../rasa-x/docs/get-feedback-from-test-users/#use-ngrok-for-local-testing>`_.
+will need to use `ngrok <https://rasa.com/docs/rasa-x/get-feedback-from-test-users/#use-ngrok-for-local-testing>`_.
 This gives your machine a domain name so that Facebook, Slack, etc. know where to send messages to
 reach your local machine.
 


### PR DESCRIPTION
**Proposed changes**:
- The ngrok link is dead. It now resides in the Rasa X part of the website. But since the Rasa X docs is not in this repo, I'm not sure how to link to it so I just put the html link instead. Please advise if there are better approaches.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
