### PR TITLE
Fix documentation error

### DIFF
--- a/docs/core/forms.rst
+++ b/docs/core/forms.rst
@@ -47,7 +47,7 @@ configuration file. For example:
   policies:
     - name: "FormPolicy"
 
-see ``examples/formbot/domain.yml`` for an example.
+see ``examples/formbot/config.yml`` for an example.
 
 Form Basics
 -----------


### PR DESCRIPTION
policies are defined in config.yml, not domain.yml.

**Proposed changes**:
- Policies are defined in config.yml

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
