### PR TITLE
Add root route to server started without --enable-api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
 Added
 -----
+- add root route to server started without ``--enable-api`` parameter
 
 Changed
 -------

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -19,6 +19,7 @@ from rasa.core.tracker_store import TrackerStore
 from rasa.core.utils import AvailableEndpoints, configure_file_logging
 from rasa.model import get_model_subdirectories, get_model
 from rasa.utils.common import update_sanic_log_level, class_from_module_path
+from rasa.server import add_root_route
 
 logger = logging.getLogger()  # get the root logger
 
@@ -66,6 +67,13 @@ def _create_single_channel(channel, credentials):
             )
 
 
+def _create_app_without_api(cors: Optional[Union[Text, List[Text]]] = None):
+    app = Sanic(__name__, configure_logging=False)
+    add_root_route(app)
+    CORS(app, resources={r"/*": {"origins": cors or ""}}, automatic_options=True)
+    return app
+
+
 def configure_app(
     input_channels: Optional[List["InputChannel"]] = None,
     cors: Optional[Union[Text, List[Text]]] = None,
@@ -92,8 +100,7 @@ def configure_app(
             endpoints=endpoints,
         )
     else:
-        app = Sanic(__name__, configure_logging=False)
-        CORS(app, resources={r"/*": {"origins": cors or ""}}, automatic_options=True)
+        app = _create_app_without_api(cors)
 
     if input_channels:
         rasa.core.channels.channel.register(input_channels, app, route=route)

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -274,6 +274,13 @@ async def _load_agent(
     return loaded_agent
 
 
+def add_root_route(app: Sanic):
+    @app.get("/")
+    async def hello(request: Request):
+        """Check if the server is running and responds with the version."""
+        return response.text("Hello from Rasa: " + rasa.__version__)
+
+
 def create_app(
     agent: Optional["Agent"] = None,
     cors_origins: Union[Text, List[Text]] = "*",
@@ -311,10 +318,7 @@ def create_app(
     async def handle_error_response(request: Request, exception: ErrorResponse):
         return response.json(exception.error_info, status=exception.status)
 
-    @app.get("/")
-    async def hello(request: Request):
-        """Check if the server is running and responds with the version."""
-        return response.text("Hello from Rasa: " + rasa.__version__)
+    add_root_route(app)
 
     @app.get("/version")
     async def version(request: Request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from core.run import _create_app_without_api
+from rasa.core.run import _create_app_without_api
 from rasa import server
 from rasa.core import config
 from rasa.core.agent import Agent, load_agent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from core.run import _create_app_without_api
 from rasa import server
 from rasa.core import config
 from rasa.core.agent import Agent, load_agent
@@ -172,6 +173,13 @@ async def rasa_nlu_server(nlu_agent):
 @pytest.fixture
 async def rasa_server_secured(default_agent):
     app = server.create_app(agent=default_agent, auth_token="rasa", jwt_secret="core")
+    channel.register([RestInput()], app, "/webhooks/")
+    return app
+
+
+@pytest.fixture
+async def rasa_server_without_api():
+    app = _create_app_without_api()
     channel.register([RestInput()], app, "/webhooks/")
     return app
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,11 @@ test_events = [
 
 
 @pytest.fixture
+def rasa_app_without_api(rasa_server_without_api):
+    return rasa_server_without_api.test_client
+
+
+@pytest.fixture
 def rasa_app(rasa_server):
     return rasa_server.test_client
 
@@ -59,6 +64,12 @@ def rasa_secured_app(rasa_server_secured):
 
 def test_root(rasa_app):
     _, response = rasa_app.get("/")
+    assert response.status == 200
+    assert response.text.startswith("Hello from Rasa:")
+
+
+def test_root_without_enable_api(rasa_app_without_api):
+    _, response = rasa_app_without_api.get("/")
     assert response.status == 200
     assert response.text.startswith("Hello from Rasa:")
 


### PR DESCRIPTION
**Proposed changes**:
`curl -X GET http://localhost:5005/` responses with `Hello from Rasa: 1.x` for server started with and without `--enable-api`

fixes https://github.com/RasaHQ/rasa/issues/4066

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
