### PR TITLE
Fix botframework send_elements

### DIFF
--- a/rasa/core/channels/botframework.py
+++ b/rasa/core/channels/botframework.py
@@ -142,7 +142,7 @@ class BotFramework(OutputChannel):
     async def send_elements(
         self, recipient_id: Text, elements: Iterable[Dict[Text, Any]], **kwargs: Any
     ) -> None:
-        for e in elements:
+        for e in elements[0]:
             message = self.prepare_message(recipient_id, e)
             await self.send(message)
 


### PR DESCRIPTION
**Proposed changes**:
I just updated my Rasa setup by bumping all my project from Core + NLU to Rasa. I noticed that attachments sent by actions through `utter_custom_message` don't work anymore. The issue I found is the double encapsulation of `elements`, leading to an issue similar to [this](https://github.com/RasaHQ/rasa/issues/3557) and also [this one](https://github.com/RasaHQ/rasa/issues/3370) I guess. 

Let me know what do you think of that quick fix. 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
