### PR TITLE
don't log to file by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 -------
 - new event broker class: ``SQLProducer``. This event broker is now used when running locally with
   Rasa X
+- API requests are not longer logged to ``rasa_core.log`` by default in order to avoid
+  problems when running on OpenShift
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,8 @@ Changed
 - new event broker class: ``SQLProducer``. This event broker is now used when running locally with
   Rasa X
 - API requests are not longer logged to ``rasa_core.log`` by default in order to avoid
-  problems when running on OpenShift
+  problems when running on OpenShift (use ``--log-file rasa_core.log`` to retain the
+  old behavior)
 
 Removed
 -------

--- a/rasa/cli/arguments/run.py
+++ b/rasa/cli/arguments/run.py
@@ -19,7 +19,9 @@ def add_server_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--log-file",
         type=str,
-        default="rasa_core.log",
+        # Rasa should not log to a file by default, otherwise there will be problems
+        # when running on OpenShift
+        default=None,
         help="Store logs in specified file.",
     )
     add_endpoint_param(


### PR DESCRIPTION
**Proposed changes**:
- API requests are not longer logged to ``rasa_core.log`` by default in order to avoid
  problems when running on OpenShift

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
