### PR TITLE
Removing Unused Import with name core_cli

### DIFF
--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -18,8 +18,6 @@ from rasa.constants import (
 def add_subparser(
     subparsers: argparse._SubParsersAction, parents: List[argparse.ArgumentParser]
 ):
-    import rasa.cli.arguments.train as core_cli
-
     train_parser = subparsers.add_parser(
         "train",
         help="Trains a Rasa model using your NLU data and stories.",

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -12,7 +12,7 @@ import rasa.utils
 import rasa.utils.io
 from rasa.core import constants, utils
 from rasa.core.agent import load_agent, Agent
-from rasa.core.channels import BUILTIN_CHANNELS, console
+from rasa.core.channels import console
 from rasa.core.channels.channel import InputChannel
 from rasa.core.interpreter import NaturalLanguageInterpreter
 from rasa.core.tracker_store import TrackerStore


### PR DESCRIPTION
It should have been removed during cleanup "Refactoring of cmd args." Commit: 5589cfc

**Proposed changes**:
- ... Removing unused import with name core_cli

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
