### PR TITLE
Fix slack multiple responses issue

### DIFF
--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -253,8 +253,8 @@ class SlackInput(InputChannel):
         failure conditions defined here:
         https://api.slack.com/events-api#failure_conditions
         """
-        retry_reason = request.headers.get("HTTP_X_SLACK_RETRY_REASON")
-        retry_count = request.headers.get("HTTP_X_SLACK_RETRY_NUM")
+        retry_reason = request.headers.get("x-slack-retry-reason")
+        retry_count = request.headers.get("x-slack-retry-num")
         if retry_count and retry_reason in self.errors_ignore_retry:
             logger.warning(
                 "Received retry #{} request from slack"


### PR DESCRIPTION
Rename header getters to correct variable names

**Proposed changes**:
- As slack event API sends multiple retries if the response is not received within 3 seconds. Therefore multiple responses are received while chatting with the bot. In this retry requests, the headers contain it is a retry header. This case is handled in RASA but the variable names in headers are different. I have fixed the variable names to neglect retry requests due to http timeout if the server is running.

**Status (please check what you already did)**:
- [+] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
