### PR TITLE
add timestamp to BotUttered message representation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
 Added
 -----
+- bot messages contain the `timestamp` of the `BotUttered` event, which can be used in channels
 
 
 Changed

--- a/rasa/core/events/__init__.py
+++ b/rasa/core/events/__init__.py
@@ -377,6 +377,7 @@ class BotUttered(Event):
 
         m = self.data.copy()
         m["text"] = self.text
+        m["timestamp"] = self.timestamp
         m.update(self.metadata)
 
         if m.get("image") == m.get("attachment"):


### PR DESCRIPTION
**Proposed change**:
This adds the event timestamp to the message representation of `BotUttered` events. This is useful for custom channels, especially for communication with Rasa X, which uses the timestamp as the id.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
