### PR TITLE
Clarify HTTP API route documentation for POST /model

### DIFF
--- a/docs/_static/spec/rasa.yml
+++ b/docs/_static/spec/rasa.yml
@@ -364,9 +364,9 @@ paths:
       - Model
       summary: Train a Rasa model
       description: >-
-        Trains a Rasa model. Depending on the data given only a dialogue model,
+        Trains a new Rasa model. Depending on the data given only a dialogue model,
         only a NLU model, or a model combining a trained dialogue model with an
-        NLU model will be trained. The trained model is not loaded by default.
+        NLU model will be trained. The new model is not loaded by default.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
This makes it clear that a new model is created and trained, rather than re-training an existing model. Fixes #4131

**Proposed changes**:
- Reword HTTP API route documentation for POST /model for clarity

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
