### PR TITLE
Fix to allow train only NLU components using RESTful API

### DIFF
--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -69,8 +69,13 @@ class Domain(object):
 
         domain = Domain.empty()
         for path in paths:
-            other = cls.from_path(path, skill_imports)
-            domain = domain.merge(other)
+            try:
+                other = cls.from_path(path, skill_imports)
+            except FileNotFoundError as error:
+                # Skip missing file and continue with other files
+                logger.warning(error)
+            else:
+                domain = domain.merge(other)
 
         return domain
 
@@ -87,7 +92,7 @@ class Domain(object):
         elif os.path.isdir(path):
             domain = cls.from_directory(path, skill_imports)
         else:
-            raise Exception(
+            raise FileNotFoundError(
                 "Failed to load domain specification from '{}'. "
                 "File not found!".format(os.path.abspath(path))
             )
@@ -890,6 +895,9 @@ class Domain(object):
                     "no matching utterance template. Please "
                     "check your domain.".format(template)
                 )
+
+    def is_empty(self) -> bool:
+        return len(self.intent_properties) <= 0
 
 
 class TemplateDomain(Domain):

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -78,15 +78,15 @@ async def train_async(
         training_files, skill_imports
     )
 
+    if domain is None:
+        return handle_domain_if_not_exists(
+            config, nlu_data_directory, output_path, fixed_model_name
+        )
+
     with ExitStack() as stack:
         train_path = stack.enter_context(TempDirectoryPath(tempfile.mkdtemp()))
         nlu_data = stack.enter_context(TempDirectoryPath(nlu_data_directory))
         story = stack.enter_context(TempDirectoryPath(story_directory))
-
-        if domain is None:
-            return handle_domain_if_not_exists(
-                config, nlu_data_directory, output_path, fixed_model_name
-            )
 
         return await _train_async_internal(
             domain,
@@ -98,11 +98,6 @@ async def train_async(
             force_training,
             fixed_model_name,
             kwargs,
-        )
-
-    if domain is None:
-        return handle_domain_if_not_exists(
-            config, nlu_data_directory, output_path, fixed_model_name
         )
 
 


### PR DESCRIPTION
**Proposed changes**:
- Change general Exception to FileNotFoundError
- Ignore domains with an invalid path
When a domain is not specified, DEFAULT_DOMAIN_PATH is used. If DEFAULT_DOMAIN_PATH is not exist, then it will raise an error. The error does not allow a user to train only NLU components using RESTful API
- Rewrite parts of create_app function to collect default filenames in one place
- Change key not in rjs to rjs.get(key) so that the server will not fail when the optional key is not provided
- Remove repetitive lines that call handle_domain_if_not_exists


**Status (please check what you already did)**:
- [v] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
