### PR TITLE
Add `ThirdPartyTokenizer` to integrate with existing NLP models

### DIFF
--- a/rasa/nlu/registry.py
+++ b/rasa/nlu/registry.py
@@ -26,6 +26,7 @@ from rasa.nlu.model import Metadata
 from rasa.nlu.tokenizers.jieba_tokenizer import JiebaTokenizer
 from rasa.nlu.tokenizers.mitie_tokenizer import MitieTokenizer
 from rasa.nlu.tokenizers.spacy_tokenizer import SpacyTokenizer
+from rasa.nlu.tokenizers.third_party_tokenizer import ThirdPartyTokenizer
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.utils.mitie_utils import MitieNLP
 from rasa.nlu.utils.spacy_utils import SpacyNLP
@@ -49,6 +50,7 @@ component_classes = [
     SpacyTokenizer,
     WhitespaceTokenizer,
     JiebaTokenizer,
+    ThirdPartyTokenizer,
     # extractors
     SpacyEntityExtractor,
     MitieEntityExtractor,

--- a/rasa/nlu/tokenizers/third_party_tokenizer.py
+++ b/rasa/nlu/tokenizers/third_party_tokenizer.py
@@ -1,0 +1,33 @@
+import typing
+from typing import Any, Dict, Text
+
+import requests
+from rasa.nlu.components import Component
+from rasa.nlu.config import RasaNLUModelConfig
+from rasa.nlu.tokenizers import Token, Tokenizer
+from rasa.nlu.training_data import Message, TrainingData
+
+
+class ThirdPartyTokenizer(Tokenizer, Component):
+    provides = ["tokens"]
+
+    requires = []
+
+    def __init__(self, component_config: Dict[Text, Any] = None) -> None:
+        super(ThirdPartyTokenizer, self).__init__(component_config)
+        self.third_party_service_endpoint = self.component_config.get(
+            "third_party_service_endpoint"
+        )
+
+    def train(
+        self, training_data: TrainingData, config: RasaNLUModelConfig, **kwargs: Any
+    ) -> None:
+        for example in training_data.training_examples:
+            example.set("tokens", self.tokenize(example.text))
+
+    def process(self, message: Message, **kwargs: Any) -> None:
+        message.set("tokens", self.tokenize(message.text))
+
+    def tokenize(self, text: Text) -> typing.List[Token]:
+        req = requests.get(self.third_party_service_endpoint + str(text))
+        return [Token(v["text"], v["end"]) for v in req.json()]

--- a/rasa/nlu/tokenizers/third_party_tokenizer.py
+++ b/rasa/nlu/tokenizers/third_party_tokenizer.py
@@ -33,7 +33,7 @@ class ThirdPartyTokenizer(Tokenizer, Component):
 
     def tokenize(self, text: Text) -> typing.List[Token]:
         if self.third_party_service_endpoint is not None:
-            req = requests.get(self.third_party_service_endpoint + str(text))
+            req = requests.post(self.third_party_service_endpoint, data={"text": text})
             return [Token(v["text"], v["end"]) for v in req.json()]
         else:
             logger.warning(

--- a/rasa/nlu/tokenizers/third_party_tokenizer.py
+++ b/rasa/nlu/tokenizers/third_party_tokenizer.py
@@ -1,3 +1,4 @@
+import logging
 import typing
 from typing import Any, Dict, Text
 
@@ -6,6 +7,8 @@ from rasa.nlu.components import Component
 from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.tokenizers import Token, Tokenizer
 from rasa.nlu.training_data import Message, TrainingData
+
+logger = logging.getLogger(__name__)
 
 
 class ThirdPartyTokenizer(Tokenizer, Component):
@@ -29,5 +32,12 @@ class ThirdPartyTokenizer(Tokenizer, Component):
         message.set("tokens", self.tokenize(message.text))
 
     def tokenize(self, text: Text) -> typing.List[Token]:
-        req = requests.get(self.third_party_service_endpoint + str(text))
-        return [Token(v["text"], v["end"]) for v in req.json()]
+        if self.third_party_service_endpoint is not None:
+            req = requests.get(self.third_party_service_endpoint + str(text))
+            return [Token(v["text"], v["end"]) for v in req.json()]
+        else:
+            logger.warning(
+                "Third party tokenizer component in pipeline, but no "
+                "`third_party_service_endpoint` configuration in the config."
+            )
+            return [Token(text, 0)]

--- a/tests/nlu/training/test_train.py
+++ b/tests/nlu/training/test_train.py
@@ -32,6 +32,7 @@ def pipelines_for_tests():
                 "WhitespaceTokenizer",
                 "MitieTokenizer",
                 "SpacyTokenizer",
+                "ThirdPartyTokenizer",
                 "MitieFeaturizer",
                 "SpacyFeaturizer",
                 "NGramFeaturizer",


### PR DESCRIPTION
**Proposed changes**:
In this PR, we add `ThirdPartyTokenizer` to provide support of existing NLP models.
Related to #453, users could add Stanford CoreNLP support by config the `ThirdPartyTokenizer` with `third_party_service_endpoint`.

Feedbacks are welcome, tests/documentation/changelog will be add/update later.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
