### PR TITLE
Allow requests to /status for NLU-only models

### DIFF
--- a/rasa/server.py
+++ b/rasa/server.py
@@ -341,7 +341,6 @@ def create_app(
 
     @app.get("/status")
     @requires_auth(app, auth_token)
-    @ensure_loaded_agent(app)
     async def status(request: Request):
         """Respond with the model name and the fingerprint of that model."""
 


### PR DESCRIPTION
**Proposed changes**:
- In the HTTP API, allow /status to be fetched for NLU-only models. Fixes #4250

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
