### PR TITLE
Explain fallback action clearly

### DIFF
--- a/docs/core/policies.rst
+++ b/docs/core/policies.rst
@@ -524,13 +524,15 @@ by trying to disambiguate the user input.
     |                               | <fallback-actions>`                      |
     |                               | to be called if the confidence of Rasa   |
     |                               | Core action prediction is below the      |
-    |                               | ``core_threshold``                       |
+    |                               | ``core_threshold``. This action is       |  
+    |                               | to propose the recognized intents        |
     +-------------------------------+------------------------------------------+
     | ``fallback_nlu_action_name``  | Name of the :ref:`fallback action        |
     |                               | <fallback-actions>`                      |
     |                               | to be called if the confidence of Rasa   |
     |                               | NLU intent classification is below the   |
-    |                               | ``nlu_threshold``                        |
+    |                               | ``nlu_threshold``. This action is called |
+    |                               | when the user denies the second time     |
     +-------------------------------+------------------------------------------+
     |``deny_suggestion_intent_name``| The name of the intent which is used to  |
     |                               | detect that the user denies the suggested|


### PR DESCRIPTION
The document didn't give a very clear picture on which fallback action was getting called during rephrasing and which action was getting called when showing all the intent alternatives . I have added one-liner to the explanation of each fallback action i.e. fallback_nlu_action_name and fallback_core_action_name in the table.

**Proposed changes**:
- Added one-liner explanation to each fallback action property in the table.

**Status (please check what you already did)**:
- [x] updated the documentation

