### PR TITLE
Report successful and incorrect predictions of NER

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,8 @@ Added
 - ``softmax`` starspace loss for both ``EmbeddingPolicy`` and ``EmbeddingIntentClassifier``
 - ``balanced`` batching strategy for both ``EmbeddingPolicy`` and ``EmbeddingIntentClassifier``
 - ``max_history`` parameter for ``EmbeddingPolicy``
-- Successful and incorrect predictions of the NER are written to a file if ``--errors`` and/or ``--successes`` are set
-  when running ``rasa test nlu``
+- Successful predictions of the NER are written to a file if ``--successes`` is set when running ``rasa test nlu``
+- Incorrect predictions of the NER are written to a file by default. You can disable it via ``--no-errors``.
 
 Changed
 -------
@@ -50,8 +50,10 @@ Changed
 - defaults parameters and architectures for both ``EmbeddingPolicy`` and
   ``EmbeddingIntentClassifier`` are changed (this is a breaking change)
 - evaluation of NER does not include 'no-entity' anymore
-- ``--errors`` and ``--successes`` for ``rasa test nlu`` are now boolean values. If set incorrect/successful predictions
+- ``--successes`` for ``rasa test nlu`` is now boolean values. If set incorrect/successful predictions
   are saved in a file.
+- ``--errors`` is renamed to ``--no-errors`` and is now a boolean value. By default incorrect predictions are saved
+  in a file. If ``--no-errors`` is set predictions are not written to a file.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Added
 - ``softmax`` starspace loss for both ``EmbeddingPolicy`` and ``EmbeddingIntentClassifier``
 - ``balanced`` batching strategy for both ``EmbeddingPolicy`` and ``EmbeddingIntentClassifier``
 - ``max_history`` parameter for ``EmbeddingPolicy``
+- Successful and incorrect predictions of the NER are written to a file if ``--errors`` and/or ``--successes`` are set
+  when running ``rasa test nlu``
 
 Changed
 -------
@@ -48,14 +50,17 @@ Changed
 - defaults parameters and architectures for both ``EmbeddingPolicy`` and
   ``EmbeddingIntentClassifier`` are changed (this is a breaking change)
 - evaluation of NER does not include 'no-entity' anymore
+- ``--errors`` and ``--successes`` for ``rasa test nlu`` are now boolean values. If set incorrect/successful predictions
+  are saved in a file.
 
 Fixed
 -----
 - ``rasa test nlu`` with a folder of configuration files
 - ``MappingPolicy`` standard featurizer is set to ``None``
 
-Fixed
------
+Removed
+-------
+- Removed ``--report`` argument from ``rasa test nlu``. All output files are stored in the ``--out`` directory.
 
 [1.2.5] - 2019-08-26
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/cli/arguments/test.py
+++ b/rasa/cli/arguments/test.py
@@ -100,10 +100,10 @@ def add_test_nlu_argument_group(
         "to a file.",
     )
     parser.add_argument(
-        "--errors",
+        "--no-errors",
         action="store_true",
         default=False,
-        help="If set incorrect predictions (intent and entities) will be written "
+        help="If set incorrect predictions (intent and entities) will NOT be written "
         "to a file.",
     )
     parser.add_argument(

--- a/rasa/cli/arguments/test.py
+++ b/rasa/cli/arguments/test.py
@@ -102,17 +102,17 @@ def add_test_nlu_argument_group(
     )
     parser.add_argument(
         "--successes",
-        required=False,
-        nargs="?",
-        const="successes.json",
-        default=None,
-        help="Output path to save successful predictions.",
+        action="store_true",
+        default=False,
+        help="If set successful predictions (intent and entities) will be written "
+        "to a file.",
     )
     parser.add_argument(
         "--errors",
-        required=False,
-        default="errors.json",
-        help="Output path to save model errors.",
+        action="store_true",
+        default=False,
+        help="If set incorrect predictions (intent and entities) will be written "
+        "to a file.",
     )
     parser.add_argument(
         "--histogram",

--- a/rasa/cli/arguments/test.py
+++ b/rasa/cli/arguments/test.py
@@ -93,14 +93,6 @@ def add_test_nlu_argument_group(
     )
 
     parser.add_argument(
-        "--report",
-        required=False,
-        nargs="?",
-        const="reports",
-        default=None,
-        help="Output path to save the intent/entity metrics report.",
-    )
-    parser.add_argument(
         "--successes",
         action="store_true",
         default=False,

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -99,6 +99,7 @@ def test_nlu(args: argparse.Namespace) -> None:
     nlu_data = cli_utils.get_validated_path(args.nlu, "nlu", DEFAULT_DATA_PATH)
     nlu_data = data.get_nlu_directory(nlu_data)
     output = args.out or DEFAULT_RESULTS_PATH
+    args.errors = not args.no_errors
 
     io_utils.create_directory(output)
 

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -14,6 +14,10 @@ from rasa.core.trackers import DialogueStateTracker
 if typing.TYPE_CHECKING:
     from rasa.core.agent import Agent
 
+import matplotlib
+
+matplotlib.use("TkAgg")
+
 logger = logging.getLogger(__name__)
 
 StoryEvalution = namedtuple(

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -278,7 +278,7 @@ def collect_nlu_errors(
             "correctly: \n{}".format(errors)
         )
     else:
-        logger.info("No incorrect intent predictions found.")
+        logger.info("Your model predicted all intents successfully.")
 
 
 def plot_intent_confidences(
@@ -450,13 +450,13 @@ def collect_entity_errors(
 
     if errors:
         utils.write_json_to_file(error_filename, errors)
-        logger.info("Incorrect enntity predictions saved to {}.".format(error_filename))
+        logger.info("Incorrect entity predictions saved to {}.".format(error_filename))
         logger.debug(
             "\n\nThese intent examples could not be classified "
             "correctly: \n{}".format(errors)
         )
     else:
-        logger.info("No incorrect entity prediction found.")
+        logger.info("Your model predicted all entities successfully.")
 
 
 def collect_entity_successes(

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -306,7 +306,6 @@ def evaluate_intents(
     errors_filename: Optional[Text],
     confmat_filename: Optional[Text],
     intent_hist_filename: Optional[Text],
-    output_folder: Optional[Text] = None,
 ) -> Dict:  # pragma: no cover
     """Creates a confusion matrix and summary statistics for intent predictions.
     Log samples which could not be classified correctly and save them to file.
@@ -347,14 +346,14 @@ def evaluate_intents(
             log_evaluation_table(report, precision, f1, accuracy)
 
     if successes_filename:
-        if output_folder:
-            successes_filename = os.path.join(output_folder, successes_filename)
+        if report_folder:
+            successes_filename = os.path.join(report_folder, successes_filename)
         # save classified samples to file for debugging
         collect_nlu_successes(intent_results, successes_filename)
 
     if errors_filename:
-        if output_folder:
-            errors_filename = os.path.join(output_folder, errors_filename)
+        if report_folder:
+            errors_filename = os.path.join(report_folder, errors_filename)
         # log and save misclassified samples to file for debugging
         collect_nlu_errors(intent_results, errors_filename)
 
@@ -363,9 +362,9 @@ def evaluate_intents(
         from sklearn.utils.multiclass import unique_labels
         import matplotlib.pyplot as plt
 
-        if output_folder:
-            confmat_filename = os.path.join(output_folder, confmat_filename)
-            intent_hist_filename = os.path.join(output_folder, intent_hist_filename)
+        if report_folder:
+            confmat_filename = os.path.join(report_folder, confmat_filename)
+            intent_hist_filename = os.path.join(report_folder, intent_hist_filename)
 
         cnf_matrix = confusion_matrix(target_intents, predicted_intents)
         labels = unique_labels(target_intents, predicted_intents)
@@ -499,7 +498,6 @@ def evaluate_entities(
     entity_results: List[EntityEvaluationResult],
     extractors: Set[Text],
     report_folder: Optional[Text],
-    output_folder: Optional[Text],
     successes_filename: Optional[Text] = None,
     errors_filename: Optional[Text] = None,
 ) -> Dict:  # pragma: no cover
@@ -551,16 +549,16 @@ def evaluate_entities(
         }
 
         if successes_filename:
-            if output_folder:
-                successes_filename = os.path.join(output_folder, successes_filename)
+            if report_folder:
+                successes_filename = os.path.join(report_folder, successes_filename)
             # save classified samples to file for debugging
             collect_entity_successes(
                 entity_results, merged_targets, merged_predictions, successes_filename
             )
 
         if errors_filename:
-            if output_folder:
-                errors_filename = os.path.join(output_folder, errors_filename)
+            if report_folder:
+                errors_filename = os.path.join(report_folder, errors_filename)
             # log and save misclassified samples to file for debugging
             collect_entity_errors(
                 entity_results, merged_targets, merged_predictions, errors_filename
@@ -1007,7 +1005,7 @@ def cross_validate(
     if intent_classifier_present:
         logger.info("Accumulated test folds intent evaluation results:")
         evaluate_intents(
-            intent_test_results, report, successes, errors, confmat, histogram, output
+            intent_test_results, report, successes, errors, confmat, histogram
         )
 
     if extractors:

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -348,14 +348,14 @@ def evaluate_intents(
     if successes:
         successes_filename = "intent_successes.json"
         if output_directory:
-            successes_filename = os.path.join(output_directory, "intent_successes.json")
+            successes_filename = os.path.join(output_directory, successes_filename)
         # save classified samples to file for debugging
         collect_nlu_successes(intent_results, successes_filename)
 
     if errors:
         errors_filename = "intent_errors.json"
         if output_directory:
-            errors_filename = os.path.join(output_directory, "intent_errors.json")
+            errors_filename = os.path.join(output_directory, errors_filename)
         # log and save misclassified samples to file for debugging
         collect_nlu_errors(intent_results, errors_filename)
 

--- a/rasa/test.py
+++ b/rasa/test.py
@@ -112,7 +112,7 @@ def test_core(
 def test_nlu(
     model: Optional[Text],
     nlu_data: Optional[Text],
-    output: Text = DEFAULT_RESULTS_PATH,
+    output_directory: Text = DEFAULT_RESULTS_PATH,
     kwargs: Optional[Dict] = None,
 ):
     from rasa.nlu.test import run_evaluation
@@ -127,13 +127,13 @@ def test_nlu(
         )
         return
 
-    io_utils.create_directory(output)
+    io_utils.create_directory(output_directory)
 
     nlu_model = os.path.join(unpacked_model, "nlu")
 
     if os.path.exists(nlu_model):
         kwargs = utils.minimal_kwargs(kwargs, run_evaluation, ["data_path", "model"])
-        run_evaluation(nlu_data, nlu_model, out_directory=output, **kwargs)
+        run_evaluation(nlu_data, nlu_model, output_directory=output_directory, **kwargs)
     else:
         print_error(
             "Could not find any model. Use 'rasa train nlu' to train a "

--- a/tests/cli/test_rasa_test.py
+++ b/tests/cli/test_rasa_test.py
@@ -11,21 +11,19 @@ def test_test_core(run_in_default_project):
 
 
 def test_test(run_in_default_project):
-    run_in_default_project("test", "--report", "report")
+    run_in_default_project("test")
 
-    assert os.path.exists("results/report")
     assert os.path.exists("results")
-    assert os.path.exists("results/report/hist.png")
-    assert os.path.exists("results/report/confmat.png")
+    assert os.path.exists("results/hist.png")
+    assert os.path.exists("results/confmat.png")
 
 
 def test_test_nlu(run_in_default_project):
-    run_in_default_project("test", "nlu", "--nlu", "data", "--success")
+    run_in_default_project("test", "nlu", "--nlu", "data", "--successes")
 
     assert os.path.exists("results/hist.png")
     assert os.path.exists("results/confmat.png")
     assert os.path.exists("results/intent_successes.json")
-    assert os.path.exists("results/entity_successes.json")
 
 
 def test_test_nlu_cross_validation(run_in_default_project):
@@ -129,10 +127,10 @@ def test_test_help(run):
                  [--max-stories MAX_STORIES] [--e2e] [--endpoints ENDPOINTS]
                  [--fail-on-prediction-errors] [--url URL]
                  [--evaluate-model-directory] [-u NLU] [--out OUT]
-                 [--report [REPORT]] [--successes] [--errors]
-                 [--histogram HISTOGRAM] [--confmat CONFMAT]
-                 [-c CONFIG [CONFIG ...]] [--cross-validation] [-f FOLDS]
-                 [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]]
+                 [--successes] [--errors] [--histogram HISTOGRAM]
+                 [--confmat CONFMAT] [-c CONFIG [CONFIG ...]]
+                 [--cross-validation] [-f FOLDS] [-r RUNS]
+                 [-p PERCENTAGES [PERCENTAGES ...]]
                  {core,nlu} ..."""
 
     lines = help_text.split("\n")
@@ -145,10 +143,10 @@ def test_test_nlu_help(run):
     output = run("test", "nlu", "--help")
 
     help_text = """usage: rasa test nlu [-h] [-v] [-vv] [--quiet] [-m MODEL] [-u NLU] [--out OUT]
-                     [--report [REPORT]] [--successes] [--errors]
-                     [--histogram HISTOGRAM] [--confmat CONFMAT]
-                     [-c CONFIG [CONFIG ...]] [--cross-validation] [-f FOLDS]
-                     [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]]"""
+                     [--successes] [--errors] [--histogram HISTOGRAM]
+                     [--confmat CONFMAT] [-c CONFIG [CONFIG ...]]
+                     [--cross-validation] [-f FOLDS] [-r RUNS]
+                     [-p PERCENTAGES [PERCENTAGES ...]]"""
 
     lines = help_text.split("\n")
 

--- a/tests/cli/test_rasa_test.py
+++ b/tests/cli/test_rasa_test.py
@@ -127,7 +127,7 @@ def test_test_help(run):
                  [--max-stories MAX_STORIES] [--e2e] [--endpoints ENDPOINTS]
                  [--fail-on-prediction-errors] [--url URL]
                  [--evaluate-model-directory] [-u NLU] [--out OUT]
-                 [--successes] [--errors] [--histogram HISTOGRAM]
+                 [--successes] [--no-errors] [--histogram HISTOGRAM]
                  [--confmat CONFMAT] [-c CONFIG [CONFIG ...]]
                  [--cross-validation] [-f FOLDS] [-r RUNS]
                  [-p PERCENTAGES [PERCENTAGES ...]]
@@ -143,7 +143,7 @@ def test_test_nlu_help(run):
     output = run("test", "nlu", "--help")
 
     help_text = """usage: rasa test nlu [-h] [-v] [-vv] [--quiet] [-m MODEL] [-u NLU] [--out OUT]
-                     [--successes] [--errors] [--histogram HISTOGRAM]
+                     [--successes] [--no-errors] [--histogram HISTOGRAM]
                      [--confmat CONFMAT] [-c CONFIG [CONFIG ...]]
                      [--cross-validation] [-f FOLDS] [-r RUNS]
                      [-p PERCENTAGES [PERCENTAGES ...]]"""

--- a/tests/cli/test_rasa_test.py
+++ b/tests/cli/test_rasa_test.py
@@ -15,16 +15,17 @@ def test_test(run_in_default_project):
 
     assert os.path.exists("results/report")
     assert os.path.exists("results")
-    assert os.path.exists("results/hist.png")
-    assert os.path.exists("results/confmat.png")
+    assert os.path.exists("results/report/hist.png")
+    assert os.path.exists("results/report/confmat.png")
 
 
 def test_test_nlu(run_in_default_project):
-    run_in_default_project("test", "nlu", "--nlu", "data", "--success", "success.json")
+    run_in_default_project("test", "nlu", "--nlu", "data", "--success")
 
     assert os.path.exists("results/hist.png")
     assert os.path.exists("results/confmat.png")
-    assert os.path.exists("results/success.json")
+    assert os.path.exists("results/intent_successes.json")
+    assert os.path.exists("results/entity_successes.json")
 
 
 def test_test_nlu_cross_validation(run_in_default_project):
@@ -128,8 +129,8 @@ def test_test_help(run):
                  [--max-stories MAX_STORIES] [--e2e] [--endpoints ENDPOINTS]
                  [--fail-on-prediction-errors] [--url URL]
                  [--evaluate-model-directory] [-u NLU] [--out OUT]
-                 [--report [REPORT]] [--successes [SUCCESSES]]
-                 [--errors ERRORS] [--histogram HISTOGRAM] [--confmat CONFMAT]
+                 [--report [REPORT]] [--successes] [--errors]
+                 [--histogram HISTOGRAM] [--confmat CONFMAT]
                  [-c CONFIG [CONFIG ...]] [--cross-validation] [-f FOLDS]
                  [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]]
                  {core,nlu} ..."""
@@ -144,11 +145,10 @@ def test_test_nlu_help(run):
     output = run("test", "nlu", "--help")
 
     help_text = """usage: rasa test nlu [-h] [-v] [-vv] [--quiet] [-m MODEL] [-u NLU] [--out OUT]
-                     [--report [REPORT]] [--successes [SUCCESSES]]
-                     [--errors ERRORS] [--histogram HISTOGRAM]
-                     [--confmat CONFMAT] [-c CONFIG [CONFIG ...]]
-                     [--cross-validation] [-f FOLDS] [-r RUNS]
-                     [-p PERCENTAGES [PERCENTAGES ...]]"""
+                     [--report [REPORT]] [--successes] [--errors]
+                     [--histogram HISTOGRAM] [--confmat CONFMAT]
+                     [-c CONFIG [CONFIG ...]] [--cross-validation] [-f FOLDS]
+                     [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]]"""
 
     lines = help_text.split("\n")
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -25,8 +25,6 @@ from rasa.core.tracker_store import InMemoryTrackerStore
 from rasa.core.trackers import DialogueStateTracker
 from rasa.train import train_async
 
-matplotlib.use("Agg")
-
 DEFAULT_DOMAIN_PATH_WITH_SLOTS = "data/test_domains/default_with_slots.yml"
 
 DEFAULT_DOMAIN_PATH_WITH_MAPPING = "data/test_domains/default_with_mapping.yml"

--- a/tests/nlu/base/test_evaluation.py
+++ b/tests/nlu/base/test_evaluation.py
@@ -28,6 +28,8 @@ from rasa.nlu.test import (
     get_unique_labels,
     get_evaluation_metrics,
     NO_ENTITY,
+    collect_successful_entity_predictions,
+    collect_incorrect_entity_predictions,
 )
 from rasa.nlu.test import does_token_cross_borders
 from rasa.nlu.test import align_entity_predictions
@@ -525,3 +527,160 @@ def test_nlu_comparison(tmpdir):
 
     run_1_path = os.path.join(output, "run_1")
     assert set(os.listdir(run_1_path)) == {"50%_exclusion", "80%_exclusion", "test.md"}
+
+
+@pytest.mark.parametrize(
+    "entity_results,targets,predictions,successes,errors",
+    [
+        (
+            [
+                EntityEvaluationResult(
+                    entity_targets=[
+                        {
+                            "start": 17,
+                            "end": 24,
+                            "value": "Italian",
+                            "entity": "cuisine",
+                        }
+                    ],
+                    entity_predictions=[
+                        {
+                            "start": 17,
+                            "end": 24,
+                            "value": "Italian",
+                            "entity": "cuisine",
+                        }
+                    ],
+                    tokens=[
+                        "I",
+                        "want",
+                        "to",
+                        "book",
+                        "an",
+                        "Italian",
+                        "restaurant",
+                        ".",
+                    ],
+                    message="I want to book an Italian restaurant.",
+                ),
+                EntityEvaluationResult(
+                    entity_targets=[
+                        {
+                            "start": 8,
+                            "end": 15,
+                            "value": "Mexican",
+                            "entity": "cuisine",
+                        },
+                        {
+                            "start": 31,
+                            "end": 32,
+                            "value": "4",
+                            "entity": "number_people",
+                        },
+                    ],
+                    entity_predictions=[],
+                    tokens=[
+                        "Book",
+                        "an",
+                        "Mexican",
+                        "restaurant",
+                        "for",
+                        "4",
+                        "people",
+                        ".",
+                    ],
+                    message="Book an Mexican restaurant for 4 people.",
+                ),
+            ],
+            [
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                "cuisine",
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                "cuisine",
+                NO_ENTITY,
+                NO_ENTITY,
+                "number_people",
+                NO_ENTITY,
+                NO_ENTITY,
+            ],
+            [
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                "cuisine",
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+                NO_ENTITY,
+            ],
+            [
+                {
+                    "text": "I want to book an Italian restaurant.",
+                    "entities": [
+                        {
+                            "start": 17,
+                            "end": 24,
+                            "value": "Italian",
+                            "entity": "cuisine",
+                        }
+                    ],
+                    "predicted_entities": [
+                        {
+                            "start": 17,
+                            "end": 24,
+                            "value": "Italian",
+                            "entity": "cuisine",
+                        }
+                    ],
+                }
+            ],
+            [
+                {
+                    "text": "Book an Mexican restaurant for 4 people.",
+                    "entities": [
+                        {
+                            "start": 8,
+                            "end": 15,
+                            "value": "Mexican",
+                            "entity": "cuisine",
+                        },
+                        {
+                            "start": 31,
+                            "end": 32,
+                            "value": "4",
+                            "entity": "number_people",
+                        },
+                    ],
+                    "predicted_entities": [],
+                }
+            ],
+        )
+    ],
+)
+def test_collect_entity_predictions(
+    entity_results, targets, predictions, successes, errors
+):
+    actual = collect_successful_entity_predictions(entity_results, targets, predictions)
+
+    assert len(successes) == len(actual)
+    assert successes == actual
+
+    actual = collect_incorrect_entity_predictions(entity_results, targets, predictions)
+
+    assert len(errors) == len(actual)
+    assert errors == actual

--- a/tests/nlu/base/test_evaluation.py
+++ b/tests/nlu/base/test_evaluation.py
@@ -142,9 +142,11 @@ EN_predicted = [
     },
 ]
 
-EN_entity_result = EntityEvaluationResult(EN_targets, EN_predicted, EN_tokens)
+EN_entity_result = EntityEvaluationResult(
+    EN_targets, EN_predicted, EN_tokens, " ".join([t.text for t in EN_tokens])
+)
 
-EN_entity_result_no_tokens = EntityEvaluationResult(EN_targets, EN_predicted, [])
+EN_entity_result_no_tokens = EntityEvaluationResult(EN_targets, EN_predicted, [], "")
 
 
 def test_token_entity_intersection():

--- a/tests/nlu/base/test_evaluation.py
+++ b/tests/nlu/base/test_evaluation.py
@@ -288,8 +288,8 @@ def test_intent_evaluation_report(tmpdir_factory):
     result = evaluate_intents(
         intent_results,
         report_folder,
-        successes_filename=None,
-        errors_filename=None,
+        successes=False,
+        errors=False,
         confmat_filename=None,
         intent_hist_filename=None,
     )


### PR DESCRIPTION
**Proposed changes**:
- remove the `--report` argument for `rasa test nlu` and use the output directory (`--out`) instead
- change `--successes` to a boolean value for `rasa test nlu` -  if set successful predictions are written to a file
- rename `--errors` to `--no-errors`. By default incorrect predictions are written to a file. If `--no-errors` is set, predictions are not written to a file.
- write successful/incorrect predictions for NER to a file

closes https://github.com/RasaHQ/rasa/issues/4329

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
