### PR TITLE
add ability to extract attention weights from other attention types

### DIFF
--- a/rasa/core/policies/embedding_policy.py
+++ b/rasa/core/policies/embedding_policy.py
@@ -320,14 +320,14 @@ class EmbeddingPolicy(Policy):
             a, mask, self.attention_weights, hparams, self.C2, self._is_training
         )
 
+        if isinstance(self.featurizer, MaxHistoryTrackerFeaturizer):
+            # pick last label if max history featurizer is used
+            a = a[:, -1:, :]
+            mask = mask[:, -1:]
+
         dial_embed = train_utils.create_tf_embed(
             a, self.embed_dim, self.C2, self.similarity_type, layer_name_suffix="dial"
         )
-
-        if isinstance(self.featurizer, MaxHistoryTrackerFeaturizer):
-            # pick last label if max history featurizer is used
-            dial_embed = dial_embed[:, -1:, :]
-            mask = mask[:, -1:]
 
         return dial_embed, mask
 

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -967,6 +967,7 @@ def extract_attention(attention_weights) -> Optional["tf.Tensor"]:
     attention = [
         tf.expand_dims(t, 0)
         for name, t in attention_weights.items()
+        # the strings come from t2t library
         if "multihead_attention/dot_product" in name and not name.endswith("/logits")
     ]
 

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -967,7 +967,7 @@ def extract_attention(attention_weights) -> Optional["tf.Tensor"]:
     attention = [
         tf.expand_dims(t, 0)
         for name, t in attention_weights.items()
-        if name.endswith("multihead_attention/dot_product_attention")
+        if "multihead_attention/dot_product" in name and not name.endswith("/logits")
     ]
 
     if attention:


### PR DESCRIPTION
**Proposed changes**:
- add ability to extract attention weights from other attention types

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)