### PR TITLE
agent no longer sets log level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,7 @@ Fixed
 -----
 - ``rasa test nlu`` with a folder of configuration files
 - ``MappingPolicy`` standard featurizer is set to ``None``
+- ``agent._pull_model_and_fingerprint`` no longer sets the log level
 
 Removed
 -------

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -35,7 +35,7 @@ from rasa.model import (
     get_model,
 )
 from rasa.nlu.utils import is_url
-from rasa.utils.common import update_sanic_log_level 
+from rasa.utils.common import update_sanic_log_level
 from rasa.utils.endpoints import EndpointConfig
 
 logger = logging.getLogger(__name__)

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -35,7 +35,7 @@ from rasa.model import (
     get_model,
 )
 from rasa.nlu.utils import is_url
-from rasa.utils.common import update_sanic_log_level, set_log_level
+from rasa.utils.common import update_sanic_log_level 
 from rasa.utils.endpoints import EndpointConfig
 
 logger = logging.getLogger(__name__)
@@ -132,7 +132,6 @@ async def _pull_model_and_fingerprint(
 
     async with model_server.session() as session:
         try:
-            set_log_level()
             params = model_server.combine_parameters()
             async with session.request(
                 "GET",


### PR DESCRIPTION
**Proposed changes**:
- Undo part of the changes in https://github.com/RasaHQ/rasa/pull/3511/files
Changing the log level had potentially too wide reaching consequences. For example it caused some tests that were expected warnings and debug from the `logger` to fail because the log level was inadvertently changed in another test.
(The original PR was also related to https://github.com/RasaHQ/rasa-x/issues/628, not sure how but including it here for completeness.)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
