### PR TITLE
Fix bug in examples and docs - slot validation method of form class should return a dict of {'slot_name': value}

### DIFF
--- a/examples/formbot/actions.py
+++ b/examples/formbot/actions.py
@@ -79,7 +79,7 @@ class RestaurantForm(FormAction):
         dispatcher: CollectingDispatcher,
         tracker: Tracker,
         domain: Dict[Text, Any],
-    ) -> Optional[Text]:
+    ) -> Dict[Text, Any]:
         """Validate cuisine value."""
 
         if value.lower() in self.cuisine_db():
@@ -97,7 +97,7 @@ class RestaurantForm(FormAction):
         dispatcher: CollectingDispatcher,
         tracker: Tracker,
         domain: Dict[Text, Any],
-    ) -> Optional[Text]:
+    ) -> Dict[Text, Any]:
         """Validate num_people value."""
 
         if self.is_int(value) and int(value) > 0:
@@ -113,7 +113,7 @@ class RestaurantForm(FormAction):
         dispatcher: CollectingDispatcher,
         tracker: Tracker,
         domain: Dict[Text, Any],
-    ) -> Any:
+    ) -> Dict[Text, Any]:
         """Validate outdoor_seating value."""
 
         if isinstance(value, str):


### PR DESCRIPTION
**Proposed changes**:
- fixed wrong return type of validate_{slot} methods in examples.

This also fixes a bug in the example code of https://rasa.com/docs/rasa/core/forms/#validating-user-input

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
