### PR TITLE
Including story source filename for failed stories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
 Added
 -----
+- Including story source filename in core output for failed stories
 
 Changed
 -------
@@ -103,7 +104,6 @@ Fixed
 - ``rasa test nlu`` with a folder of configuration files
 - ``MappingPolicy`` standard featurizer is set to ``None``
 - Removed ``text`` parameter from send_attachment function in slack.py to avoid duplication of text output to slackbot
-- server ``/status`` endpoint reports status when an NLU-only model is loaded
 
 Removed
 -------

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -336,7 +336,7 @@ def _predict_tracker_actions(
     events = list(tracker.events)
 
     partial_tracker = DialogueStateTracker.from_events(
-        tracker.sender_id, events[:1], agent.domain.slots
+        tracker.sender_id, events[:1], agent.domain.slots, None, tracker.source_filename
     )
 
     tracker_actions = []
@@ -461,7 +461,7 @@ def log_failed_stories(failed, out_directory):
             f.write("<!-- All stories passed -->")
         else:
             for failure in failed:
-                f.write(failure.export_stories())
+                f.write(failure.export_stories(test=True))
                 f.write("\n\n")
 
 

--- a/rasa/core/training/generator.py
+++ b/rasa/core/training/generator.py
@@ -44,10 +44,16 @@ class TrackerWithCachedStates(DialogueStateTracker):
     """A tracker wrapper that caches the state creation of the tracker."""
 
     def __init__(
-        self, sender_id, slots, max_event_history=None, domain=None, is_augmented=False
+        self,
+        sender_id,
+        slots,
+        max_event_history=None,
+        domain=None,
+        is_augmented=False,
+        source_filename=None,
     ):
         super(TrackerWithCachedStates, self).__init__(
-            sender_id, slots, max_event_history
+            sender_id, slots, max_event_history, source_filename
         )
         self._states = None
         self.domain = domain
@@ -81,9 +87,12 @@ class TrackerWithCachedStates(DialogueStateTracker):
             self._max_event_history,
             self.domain,
             self.is_augmented,
+            self.source_filename,
         )
 
-    def copy(self, sender_id: Text = "") -> "TrackerWithCachedStates":
+    def copy(
+        self, sender_id: Text = "", source_filename: Text = ""
+    ) -> "TrackerWithCachedStates":
         """Creates a duplicate of this tracker.
 
         A new tracker will be created and all events
@@ -94,6 +103,7 @@ class TrackerWithCachedStates(DialogueStateTracker):
 
         tracker = self.init_copy()
         tracker.sender_id = sender_id
+        tracker.source_filename = source_filename
 
         for event in self.events:
             tracker.update(event, skip_states=True)
@@ -530,7 +540,7 @@ class TrainingDataGenerator(object):
                         new_sender = tracker.sender_id
                 else:
                     new_sender = step.block_name
-                trackers.append(tracker.copy(new_sender))
+                trackers.append(tracker.copy(new_sender, step.source_file_name))
 
         end_trackers = []
         for event in events:

--- a/rasa/data.py
+++ b/rasa/data.py
@@ -198,3 +198,10 @@ def _copy_files_to_new_dir(files: Set[Text]) -> Text:
         shutil.copy2(f, os.path.join(directory, unique_file_name))
 
     return directory
+
+
+def get_source_file_name(filename: Text):
+    src_filename = os.path.basename(filename)
+    # Removing unique prefix
+    filename_parts = src_filename.split("_", 1)
+    return filename_parts[1] if len(filename_parts) > 1 else filename_parts[0]

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -176,3 +176,10 @@ def test_is_not_nlu_file_with_json():
         f.write('{"test": "a"}')
 
     assert not data.is_nlu_file(file)
+
+
+def test_get_source_file_name():
+    assert data.get_source_file_name("") == ""
+    assert data.get_source_file_name("/tmp/stories.md") == "stories.md"
+    assert data.get_source_file_name("/tmp/123_stories.md") == "stories.md"
+    assert data.get_source_file_name("/tmp/123_my_stories.md") == "my_stories.md"


### PR DESCRIPTION
**Proposed changes**:
- Implements #3419 
- In `failed_stories.md file` stories have added comments with source file name.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
