### PR TITLE
Add note about pip version

### DIFF
--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -96,9 +96,9 @@ Otherwise, proceed with the instructions below to install them.
             C:\> pip3 install -U pip
 
 .. note::
+   Note that `pip` in this refers to `pip3` as Rasa requires python3. To see which version the `pip` 
+   command on your machine calls use `pip --version`.
 
-   Note that `pip` in this refers to `pip3` as Rasa requires python3. To see which version the `pip` command on your 
-   machine calls use `pip --version`.
 
 2. Create a virtual environment (strongly recommended)
 ------------------------------------------------------

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -96,8 +96,9 @@ Otherwise, proceed with the instructions below to install them.
             C:\> pip3 install -U pip
 
 .. note::
-  Note that `pip` in this refers to `pip3` as Rasa requires python3. To see which version the `pip` command on your 
-  machine calls use `pip --version`.
+
+   Note that `pip` in this refers to `pip3` as Rasa requires python3. To see which version the `pip` command on your 
+   machine calls use `pip --version`.
 
 2. Create a virtual environment (strongly recommended)
 ------------------------------------------------------

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -17,7 +17,7 @@ You can install both Rasa and Rasa X using pip (requires Python 3.5.4 or higher)
 
 .. code-block:: bash
 
-    $ pip install rasa-x --extra-index-url https://pypi.rasa.com/simple
+    $ pip3 install rasa-x --extra-index-url https://pypi.rasa.com/simple
 
 - Having trouble installing? Read our :ref:`step-by-step installation guide <installation_guide>`.
 - You can also :ref:`build Rasa from source <build_from_source>`.
@@ -95,6 +95,9 @@ Otherwise, proceed with the instructions below to install them.
 
             C:\> pip3 install -U pip
 
+.. note::
+  Note that `pip` in this refers to `pip3` as Rasa requires python3. To see which version the `pip` command on your 
+  machine calls use `pip --version`.
 
 2. Create a virtual environment (strongly recommended)
 ------------------------------------------------------


### PR DESCRIPTION
The docs refer only to `pip` in the installation, this only works if `pip` has been linked to `pip3`. It might slightly annoying to users who do not have this linked, if they just copy and paste the commands.

**Proposed changes**:
- Change 'quick install' to use `pip3` and add a note to clarify that pip3 is meant.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
