### PR TITLE
Pin gast version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,7 @@ Changed
 - Deprecate ``as_markdown`` and ``as_json`` in favour of ``nlu_as_markdown`` and ``nlu_as_json`` respectively.
 - pin python-engineio >= 3.9.3
 - update python-socketio req to >= 4.3.1
+- Pin gast to == 0.2.2
 
 Fixed
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,6 @@ kafka-python==1.4.6
 sklearn-crfsuite==0.3.6
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
+# emove when tensorflow@1.15.x or a pre-release patch is released
+# https://github.com/tensorflow/tensorflow/issues/32319
+gast==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ kafka-python==1.4.6
 sklearn-crfsuite==0.3.6
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
-# emove when tensorflow@1.15.x or a pre-release patch is released
+# remove when tensorflow@1.15.x or a pre-release patch is released
 # https://github.com/tensorflow/tensorflow/issues/32319
 gast==0.2.2

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,9 @@ install_requires = [
     "kafka-python~=1.4",
     "sklearn-crfsuite~=0.3.6",
     "PyJWT~=1.7",
+    # remove when tensorflow@1.15.x or a pre-release patch is released
+    # https://github.com/tensorflow/tensorflow/issues/32319
+    "gast==0.2.2",
 ]
 
 extras_requires = {


### PR DESCRIPTION
**Proposed changes**:
- Pin `gast` version as a temporary fix until `tensorflow@1.15.x` or a pre-release patch is released

**Status (please check what you already did)**:
- [x] updated the changelog

@tmbo created a new branch based on `1.3.x` instead of cherry-picking the other one.
