### PR TITLE
Avoid training CountVectorizer if no text is provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 -----
 - SQL tracker events are retrieved ordered by timestamps. This fixes interactive
   learning events being shown in the wrong order.
+- Avoid training CountVectorizer for a particular attribute of a message if no text is provided for that attribute across the training data.
 
 [1.3.1] - 2019-09-09
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Rasa Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
+[1.3.3] - 2019-09-11
+^^^^^^^^^^^^^^^^^^^^
+
+Fixed
+-----
+- Added a check to avoid training CountVectorizer for a particular attribute of a message if no text is provided for that attribute across the training data.
+
+
 [1.3.2] - 2019-09-10
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -14,7 +22,6 @@ Fixed
 -----
 - SQL tracker events are retrieved ordered by timestamps. This fixes interactive
   learning events being shown in the wrong order.
-- Added a check to avoid training CountVectorizer for a particular attribute of a message if no text is provided for that attribute across the training data.
 
 [1.3.1] - 2019-09-09
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Fixed
 -----
 - SQL tracker events are retrieved ordered by timestamps. This fixes interactive
   learning events being shown in the wrong order.
-- Avoid training CountVectorizer for a particular attribute of a message if no text is provided for that attribute across the training data.
+- Added a check to avoid training CountVectorizer for a particular attribute of a message if no text is provided for that attribute across the training data.
 
 [1.3.1] - 2019-09-09
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/count_vectors_featurizer.py
@@ -435,7 +435,7 @@ class CountVectorsFeaturizer(Featurizer):
 
     @staticmethod
     def _attribute_texts_is_non_empty(attribute_texts):
-        return any(text for text in attribute_texts)
+        return any(attribute_texts)
 
     def _train_with_independent_vocab(self, attribute_texts: Dict[Text, List[Text]]):
         """Construct the vectorizers and train them with an independent vocab"""

--- a/rasa/nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/count_vectors_featurizer.py
@@ -433,6 +433,10 @@ class CountVectorsFeaturizer(Featurizer):
                 "Unable to train a shared CountVectorizer. Leaving an untrained CountVectorizer"
             )
 
+    @staticmethod
+    def _attribute_texts_is_non_empty(attribute_texts):
+        return any(text for text in attribute_texts)
+
     def _train_with_independent_vocab(self, attribute_texts: Dict[Text, List[Text]]):
         """Construct the vectorizers and train them with an independent vocab"""
 
@@ -449,13 +453,18 @@ class CountVectorsFeaturizer(Featurizer):
         )
 
         for attribute in MESSAGE_ATTRIBUTES:
-
-            try:
-                self.vectorizers[attribute].fit(attribute_texts[attribute])
-            except ValueError:
-                logger.warning(
-                    "Unable to train CountVectorizer for message attribute {}. "
-                    "Leaving an untrained CountVectorizer for it".format(attribute)
+            if self._attribute_texts_is_non_empty(attribute_texts[attribute]):
+                try:
+                    self.vectorizers[attribute].fit(attribute_texts[attribute])
+                except ValueError:
+                    logger.warning(
+                        "Unable to train CountVectorizer for message attribute {}. "
+                        "Leaving an untrained CountVectorizer for it".format(attribute)
+                    )
+            else:
+                logger.debug(
+                    "No text provided for {} attribute in any messages of training data. Skipping "
+                    "training a CountVectorizer for it.".format(attribute)
                 )
 
     def _get_featurized_attribute(


### PR DESCRIPTION
**Proposed changes:**

- Add a check for empty text list for a particular attribute before calling the fit function on CountVectorizer object.
- Train method will now only log a warning if some text is provided for an attribute, but still .fit() throws an exception.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
