### PR TITLE
Flexible handling of non-existent message_attribute for given training sample

### DIFF
--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -150,8 +150,8 @@ class SpacyNLP(Component):
             # in spaCy and are therefore set as empty strings by Rasa. Since third-party
             # libraries relying on spaCy might have problems with Doc-objects created on empty
             # strings, we further treat them separately.
-            docs_to_pipe = list(filter(lambda f: f[1] != "", freezed_indices))
-            empty_docs = list(filter(lambda f: f[1] == "", freezed_indices))
+            docs_to_pipe = list(filter(lambda fi_tpl: fi_tpl[1] != "", freezed_indices))
+            empty_docs = list(filter(lambda fi_tpl: fi_tpl[1] == "", freezed_indices))
 
             # To preserve the order of the training samples, we send the non-empty samples to
             # pipe and then simply update their original/index tuple.

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -182,7 +182,7 @@ class SpacyNLP(Component):
                 freezed_indices, docs + n_docs
             )
 
-            # Since we only need the trainings samples strings, we create a list to get them out
+            # Since we only need the training samples strings, we create a list to get them out
             # of the tuple.
             attribute_docs[attribute] = [doc for _, doc in attribute_document_list]
         return attribute_docs


### PR DESCRIPTION
**Proposed changes**:

As discussed [here](https://github.com/RasaHQ/rasa/issues/4445) third-party libraries or applications that rely on spaCy might have problems with spaCy's `Doc`-objects created by parsing empty strings. To avoid that, only those training samples should further be sent to `nlp.pipe`, that actually carry content, however, the order of training samples need to be preserved and in addition, the batch-processing of spaCy should still be used. The new workflow consists of:

1. Index all training samples
2. Splitting empty from content-carrying training samples
3. Update content-carrying training samples by converting `(index, text)` to `(index, Doc)` samples
4. Update empty training samples by converting `(index, "")` to `(index, Doc)` samples
5. Merging the resulting lists back into their original order

The functionality has been tested and evaluated with different config-scenarios with and without ResponseSelector training samples, mainly:

```
language: de
pipeline:
 - name: SpacyNLP
   case_sensitive: 1
   model: de
 - name: SpacyTokenizer
 - name: SpacyFeaturizer
 - name: SklearnIntentClassifier
```
which reflects a more or less default scenario with spaCys pipeline and

```
language: de
pipeline:
 - name: SpacyNLP
   case_sensitive: 1
   model: de_pytt_bertbasecased_lg_spo
 - name: SpacyTokenizer
 - name: SpacyFeaturizer
 - name: SklearnIntentClassifier
 - name: ResponseSelector
```
which uses a finetuned BERT model using `spacy-pytorch-transformers`, one of the libraries that caused the mentioned error. The functionality worked as expected.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
