### PR TITLE
fixed random_seed does not work due to file order change when using MultiProjectImporter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,6 +77,7 @@ Fixed
 - fixed the hanging HTTP call with ``ner_duckling_http`` pipeline
 - fixed Interactive Learning intent payload messages saving in nlu files
 - fixed DucklingHTTPExtractor dimensions by actually applying to the request
+- fixed random_seed does not work when using MultiProjectImporter
 
 
 [1.3.10] - 2019-10-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Removed
 
 Fixed
 -----
+- ``MultiProjectImporter`` now imports files in the order of the import statements
 
 [1.4.1] - 2019-10-22
 ^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +78,6 @@ Fixed
 - fixed the hanging HTTP call with ``ner_duckling_http`` pipeline
 - fixed Interactive Learning intent payload messages saving in nlu files
 - fixed DucklingHTTPExtractor dimensions by actually applying to the request
-- ``MultiProjectImporter`` now imports files in the order of the import statements
 
 
 [1.3.10] - 2019-10-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,7 +77,7 @@ Fixed
 - fixed the hanging HTTP call with ``ner_duckling_http`` pipeline
 - fixed Interactive Learning intent payload messages saving in nlu files
 - fixed DucklingHTTPExtractor dimensions by actually applying to the request
-- fixed random_seed does not work when using MultiProjectImporter
+- ``MultiProjectImporter`` now imports files in the order of the import statements
 
 
 [1.3.10] - 2019-10-18

--- a/rasa/importers/multi_project.py
+++ b/rasa/importers/multi_project.py
@@ -32,7 +32,7 @@ class MultiProjectImporter(TrainingDataImporter):
             self._domain_paths = []
         self._story_paths = []
         self._nlu_paths = []
-        self._imports = set()
+        self._imports = []
         self._additional_paths = training_data_paths or []
         self._project_directory = project_directory or os.path.dirname(config_file)
 
@@ -74,11 +74,18 @@ class MultiProjectImporter(TrainingDataImporter):
 
     def _init_from_dict(self, _dict: Dict[Text, Any], parent_directory: Text) -> None:
         imports = _dict.get("imports") or []
-        imports = {os.path.join(parent_directory, i) for i in imports}
+        imports = [os.path.join(parent_directory, i) for i in imports]
         # clean out relative paths
-        imports = {os.path.abspath(i) for i in imports}
-        import_candidates = [p for p in imports if not self._is_explicitly_imported(p)]
-        self._imports = self._imports.union(import_candidates)
+        imports = [os.path.abspath(i) for i in imports]
+
+        # remove duplication
+        import_candidates = []
+        for i in imports:
+            if i in import_candidates or self._is_explicitly_imported(i):
+                continue
+            import_candidates.append(i)
+
+        self._imports.extend(import_candidates)
 
         # import config files from paths which have not been processed so far
         for p in import_candidates:
@@ -161,7 +168,7 @@ class MultiProjectImporter(TrainingDataImporter):
         return any([io_utils.is_subdirectory(path, i) for i in self._imports])
 
     def add_import(self, path: Text) -> None:
-        self._imports.add(path)
+        self._imports.append(path)
 
     async def get_domain(self) -> Domain:
         domains = [Domain.load(path) for path in self._domain_paths]

--- a/rasa/importers/multi_project.py
+++ b/rasa/importers/multi_project.py
@@ -81,9 +81,8 @@ class MultiProjectImporter(TrainingDataImporter):
         # remove duplication
         import_candidates = []
         for i in imports:
-            if i in import_candidates or self._is_explicitly_imported(i):
-                continue
-            import_candidates.append(i)
+            if i not in import_candidates and not self._is_explicitly_imported(i):
+                import_candidates.append(i)
 
         self._imports.extend(import_candidates)
 

--- a/tests/importers/test_multi_project.py
+++ b/tests/importers/test_multi_project.py
@@ -43,10 +43,10 @@ def test_load_imports_from_directory_tree(tmpdir_factory: TempdirFactory):
     subdirectory_3 = root / "Project C"
     subdirectory_3.mkdir()
 
-    expected = {
+    expected = [
         os.path.join(str(project_a_directory)),
         os.path.join(str(project_b_directory)),
-    }
+    ]
 
     actual = MultiProjectImporter(str(root / "config.yml"))
 
@@ -79,7 +79,7 @@ def test_load_from_none(input_dict: Dict, tmpdir_factory: TempdirFactory):
 
     actual = MultiProjectImporter(str(config_path))
 
-    assert actual._imports == set()
+    assert actual._imports == list()
 
 
 def test_load_if_subproject_is_more_specific_than_parent(
@@ -145,7 +145,7 @@ def test_cyclic_imports(tmpdir_factory):
 
     actual = MultiProjectImporter(str(root / "config.yml"))
 
-    assert actual._imports == {str(project_a_directory), str(project_b_directory)}
+    assert actual._imports == [str(project_a_directory), str(project_b_directory)]
 
 
 def test_import_outside_project_directory(tmpdir_factory):
@@ -169,7 +169,7 @@ def test_import_outside_project_directory(tmpdir_factory):
 
     actual = MultiProjectImporter(str(project_a_directory / "config.yml"))
 
-    assert actual._imports == {str(project_b_directory), str(root / "Project C")}
+    assert actual._imports == [str(project_b_directory), str(root / "Project C")]
 
 
 def test_importing_additional_files(tmpdir_factory):


### PR DESCRIPTION
The random_seed parameter of EmbeddingIntentClassifier does not work properly when using MultiProjectImporter.
The file order changes when training, which changes the order of the intent_examples in TrainingData.

**Proposed changes**:
- Change set to list to preserve order.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
