### PR TITLE
Fixes #4455 Implement buttons for Mattermost channel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
 Added
 -----
+- Added buttons and images to mattermost.
 
 Changed
 -------

--- a/docs/user-guide/connectors/mattermost.rst
+++ b/docs/user-guide/connectors/mattermost.rst
@@ -51,7 +51,8 @@ you need to supply a ``credentials.yml`` with the following content:
      team: "community"
      user: "user@user.com"
      pw: "password"
+     webhook_url: "https://server.example.com/webhooks/mattermost/webhook"
 
 The endpoint for receiving Mattermost channel messages
-is ``/webhooks/mattermost/webhook``. This is the url you should
-add in the Mattermost outgoing webhook.
+is ``/webhooks/mattermost/webhook``, the same as ``webhook_url`` here. You should
+add this url also in the Mattermost outgoing webhook.

--- a/rasa/cli/initial_project/credentials.yml
+++ b/rasa/cli/initial_project/credentials.yml
@@ -21,5 +21,12 @@ rest:
 #  bot_message_evt: <event name for but messages>
 #  session_persistence: <true/false>
 
+#mattermost:
+#  url: "https://<mattermost instance>/api/v4"
+#  team: "<mattermost team>"
+#  user: "<bot username>"
+#  pw: "<bot token>"
+#  webhook_url: "<callback URL>"
+
 rasa:
   url: "http://localhost:5002/api"

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -175,7 +175,6 @@ class MattermostInput(InputChannel):
         except Exception as e:
             logger.error("Exception when trying to handle message.{0}".format(e))
             logger.debug(e, exc_info=True)
-            pass
 
     async def action_from_button(
         self,
@@ -204,7 +203,6 @@ class MattermostInput(InputChannel):
         except Exception as e:
             logger.error("Exception when trying to handle message.{0}".format(e))
             logger.debug(e, exc_info=True)
-            pass
 
     def blueprint(self, on_new_message: Callable[[UserMessage], Awaitable[None]]):
         mattermost_webhook = Blueprint("mattermost_webhook", __name__)

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -55,6 +55,21 @@ class MattermostBot(MattermostAPI, OutputChannel):
         json_message.setdefault("message", "")
         self.post("/posts", json_message)
 
+    async def send_image_url(
+        self, recipient_id: Text, image: Text, **kwargs: Any
+    ) -> None:
+        """Sends an image. """
+        image_url = image
+
+        props = {"attachments": []}
+        props["attachments"].append(image_url)
+
+        json_message = {}
+        json_message.setdefault("channel_id", self.bot_channel)
+        json_message.setdefault("props", props)
+
+        self.post("/posts", json_message)
+
     async def send_text_with_buttons(
         self,
         recipient_id: Text,
@@ -145,14 +160,15 @@ class MattermostInput(InputChannel):
             if not output:
                 return response.text("")
 
+            sender_id = output["user_id"]
+            self.bot_channel = output["channel_id"]
+                
             # handle normal message with trigger_word
             if "trigger_word" in output:
                 # splitting to get rid of the @botmention
                 # trigger we are using for this
                 text = output["text"].split(" ", 1)
                 text = text[1]
-                sender_id = output["user_id"]
-                self.bot_channel = output["channel_id"]
                 try:
                     out_channel = MattermostBot(
                         self.url,
@@ -176,8 +192,6 @@ class MattermostInput(InputChannel):
             # handle context actions from buttons
             elif "context" in output:
                 action = output["context"]["action"]
-                sender_id = output["user_id"]
-                self.bot_channel = output["channel_id"]
                 try:
                     out_channel = MattermostBot(
                         self.url,

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -2,7 +2,7 @@ import logging
 from mattermostwrapper import MattermostAPI
 from sanic import Blueprint, response
 from sanic.request import Request
-from typing import Text, Dict, Any
+from typing import Text, Dict, Any, List
 
 from rasa.core.channels.channel import UserMessage, OutputChannel, InputChannel
 
@@ -16,12 +16,22 @@ class MattermostBot(MattermostAPI, OutputChannel):
     def name(cls):
         return "mattermost"
 
-    def __init__(self, url, team, user, pw, bot_channel):
+    @classmethod
+    def from_credentials(cls, credentials):
+        if not credentials:
+            cls.raise_missing_credentials_exception()
+
+        return cls(
+            credentials.get("webhook_url"),
+        )
+
+    def __init__(self, url, team, user, pw, bot_channel, webhook_url):
         self.url = url
         self.team = team
         self.user = user
         self.pw = pw
         self.bot_channel = bot_channel
+        self.webhook_url = webhook_url
 
         super(MattermostBot, self).__init__(url, team)
         super(MattermostBot, self).login(user, pw)
@@ -37,6 +47,35 @@ class MattermostBot(MattermostAPI, OutputChannel):
     ) -> None:
         json_message.setdefault("channel_id", self.bot_channel)
         json_message.setdefault("message", "")
+        self.post("/posts", json_message)
+
+    async def send_text_with_buttons(
+        self,
+        recipient_id: Text,
+        text: Text,
+        buttons: List[Dict[Text, Any]],
+        **kwargs: Any
+    ) -> None:
+        """Sends buttons to the output."""
+
+        # buttons is a list of tuples: [(option_name, payload)]
+        # See https://docs.mattermost.com/developer/interactive-messages.html#message-buttons
+        button_block = {"actions": []}
+        for button in buttons:
+            button_block["actions"].append(
+                {
+                    "name": button["title"],
+                    "integration": {"url": self.webhook_url, "context": {"action": button["payload"]}}
+                }
+            )
+        props = {"attachments": []}
+        props["attachments"].append(button_block)
+
+        json_message = {}
+        json_message.setdefault("channel_id", self.bot_channel)
+        json_message.setdefault("message", text)
+        json_message.setdefault("props", props)
+
         self.post("/posts", json_message)
 
 
@@ -57,9 +96,10 @@ class MattermostInput(InputChannel):
             credentials.get("team"),
             credentials.get("user"),
             credentials.get("pw"),
+            credentials.get("webhook_url"),
         )
 
-    def __init__(self, url: Text, team: Text, user: Text, pw: Text) -> None:
+    def __init__(self, url: Text, team: Text, user: Text, pw: Text, webhook_url: Text) -> None:
         """Create a Mattermost input channel.
         Needs a couple of settings to properly authenticate and validate
         messages.
@@ -70,11 +110,15 @@ class MattermostInput(InputChannel):
             team: Your mattermost team name
             user: Your mattermost userid that will post messages
             pw: Your mattermost password for your user
+            webhook_url: The mattermost callback url as specified
+                in the outgoing webhooks in mattermost example
+                https://mysite.example.com/webhooks/mattermost/webhook
         """
         self.url = url
         self.team = team
         self.user = user
         self.pw = pw
+        self.webhook_url = webhook_url
 
     def blueprint(self, on_new_message):
         mattermost_webhook = Blueprint("mattermost_webhook", __name__)
@@ -87,26 +131,49 @@ class MattermostInput(InputChannel):
         async def webhook(request: Request):
             output = request.json
             if output:
-                # splitting to get rid of the @botmention
-                # trigger we are using for this
-                text = output["text"].split(" ", 1)
-                text = text[1]
-                sender_id = output["user_id"]
-                self.bot_channel = output["channel_id"]
-                try:
-                    out_channel = MattermostBot(
-                        self.url, self.team, self.user, self.pw, self.bot_channel
-                    )
-                    user_msg = UserMessage(
-                        text, out_channel, sender_id, input_channel=self.name()
-                    )
-                    await on_new_message(user_msg)
-                except Exception as e:
-                    logger.error(
-                        "Exception when trying to handle message.{0}".format(e)
-                    )
-                    logger.debug(e, exc_info=True)
-                    pass
+                # handle normal message with trigger_word
+                if "trigger_word" in output:
+                    # splitting to get rid of the @botmention
+                    # trigger we are using for this
+                    text = output["text"].split(" ", 1)
+                    text = text[1]
+                    sender_id = output["user_id"]
+                    self.bot_channel = output["channel_id"]
+                    try:
+                        out_channel = MattermostBot(
+                            self.url, self.team, self.user, self.pw, self.bot_channel, self.webhook_url
+                        )
+                        user_msg = UserMessage(
+                            text, out_channel, sender_id, input_channel=self.name()
+                        )
+                        await on_new_message(user_msg)
+                    except Exception as e:
+                        logger.error(
+                            "Exception when trying to handle message.{0}".format(e)
+                        )
+                        logger.debug(e, exc_info=True)
+                        pass
+
+                # handle context actions from buttons
+                elif "context" in output:
+                    action = output["context"]["action"]
+                    sender_id = output["user_id"]
+                    self.bot_channel = output["channel_id"]
+                    try:
+                        out_channel = MattermostBot(
+                            self.url, self.team, self.user, self.pw, self.bot_channel, self.webhook_url
+                        )
+                        context_action = UserMessage(
+                            action, out_channel, sender_id, input_channel=self.name()
+                        )
+                        await on_new_message(context_action)
+                    except Exception as e:
+                        logger.error(
+                            "Exception when trying to handle message.{0}".format(e)
+                        )
+                        logger.debug(e, exc_info=True)
+                        pass
+
             return response.text("")
 
         return mattermost_webhook

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -220,9 +220,6 @@ class MattermostInput(InputChannel):
             if not output:
                 return response.text("")
 
-            sender_id = output["user_id"]
-            self.bot_channel = output["channel_id"]
-
             # handle normal message with trigger_word
             if "trigger_word" in output:
                 await self.message_with_trigger_word(on_new_message, output)

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -58,7 +58,7 @@ class MattermostBot(MattermostAPI, OutputChannel):
     async def send_image_url(
         self, recipient_id: Text, image: Text, **kwargs: Any
     ) -> None:
-        """Sends an image. """
+        """Sends an image."""
         image_url = image
 
         props = {"attachments": []}

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -203,11 +203,12 @@ def test_mattermost_channel():
         url="http://chat.example.com/api/v4",
         # the name of your team for mattermost
         team="community",
-        # the username of your bot user that will post
+        # the username of your bot user that will post messages
         user="user@email.com",
-        # messages
-        pw="password"
         # the password of your bot user that will post messages
+        pw="password",
+        # the webhook-url your bot should listen for messages
+        webhook_url="YOUR_WEBHOOK_URL",
     )
 
     s = rasa.core.run.configure_app([input_channel], port=5004)


### PR DESCRIPTION
**Proposed changes**:
   - rasa\core\channels\mattermost.py
      - Implement send_text_with_buttons() in MattermostBot class according to mattermost message buttons docs
      - Initialize MattermostBot and MattermostInput with an additional parameter webhook_url
   - rasa\cli\initial_project\credentials.yml (not really necessary, but very helpful for an easy start)
      - add Mattermost example with additional webhook_url

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)