### PR TITLE
Flexible handling of non-existent message_attribute for given training sample

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,17 @@ Added
   number of unaccepted connections the server allows before refusing new
   connections. A default value of 100 is used if the variable is not set.
 
+Fixed
+-----
+
+- Added the ability to properly deal with spaC'y ``Doc``-objects created on
+  empty strings as discussed `here <https://github.com/RasaHQ/rasa/issues/4445>`_.
+  Only training samples that actually bear content are sent to ``self.nlp.pipe``
+  for every given attribute. Non-content-bearing samples are converted to empty
+  ``Doc``-objects. The resulting lists are merged with their preserved order and
+  properly returned.
+
+
 [1.3.3] - 2019-09-13
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 Fixed
 -----
 
-- Added the ability to properly deal with spaC'y ``Doc``-objects created on
+- Added the ability to properly deal with spaCy ``Doc``-objects created on
   empty strings as discussed `here <https://github.com/RasaHQ/rasa/issues/4445>`_.
   Only training samples that actually bear content are sent to ``self.nlp.pipe``
   for every given attribute. Non-content-bearing samples are converted to empty

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -142,7 +142,7 @@ class SpacyNLP(Component):
 
     @staticmethod
     def filter_training_samples_by_content(
-        indexed_training_samples: List[Any]
+        indexed_training_samples: List[Tuple[int, Text]]
     ) -> Tuple[Any, Any]:
         """Separates empty training samples from content bearing ones."""
 

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -132,7 +132,7 @@ class SpacyNLP(Component):
 
     @staticmethod
     def merge_content_lists(
-        indexed_training_samples: List[Any], doc_lists: List[Any]
+        indexed_training_samples: List[Tuple[int, Text]], doc_lists: List[Tuple[int, "Doc"]]
     ) -> List[Any]:
         """Merge lists with processed Docs back into their original order."""
 

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -1,7 +1,8 @@
 import logging
 import typing
-from typing import Any, Dict, List, Optional, Text
+from typing import Any, Dict, List, Optional, Text, Tuple
 
+from spacy.tokens import Doc
 from rasa.nlu.components import Component
 from rasa.nlu.config import RasaNLUModelConfig, override_defaults
 from rasa.nlu.training_data import Message, TrainingData
@@ -129,18 +130,98 @@ class SpacyNLP(Component):
 
         return self.preprocess_text(example.get(attribute))
 
+    @staticmethod
+    def merge_content_lists(
+            indexed_training_samples: List, doc_lists: List
+    ) -> List:
+        """ Merge lists with processed Docs back into their original order. """
+
+        dct = dict(indexed_training_samples)
+        dct.update(dict(doc_lists))
+        return list(dct.items())
+
+    @staticmethod
+    def filter_training_samples_by_content(
+            indexed_training_samples: List
+    ) -> Tuple:
+        """ Separates empty training samples from content bearing ones. """
+
+        docs_to_pipe = list(filter(lambda training_sample: training_sample[1] != "", indexed_training_samples))
+        empty_docs = list(filter(lambda training_sample: training_sample[1] == "", indexed_training_samples))
+        return docs_to_pipe, empty_docs
+
+    def process_content_bearing_samples(
+            self, samples_to_pipe: Tuple
+    ) -> List:
+        """ Sends content bearing training samples to spaCy's pipe. """
+
+        docs = [
+            (to_pipe_sample[0], doc)
+            for to_pipe_sample, doc in zip(
+                samples_to_pipe,
+                [
+                    doc
+                    for doc in self.nlp.pipe(
+                    [txt for _, txt in samples_to_pipe], batch_size=50
+                )
+                ],
+            )
+        ]
+        return docs
+
+    def process_non_content_bearing_samples(
+            self, empty_samples: Tuple
+    ) -> List:
+        """ Creates empty Doc-objects from zero-lenghted training samples strings. """
+
+        n_docs = [
+            (empty_sample[0], doc)
+            for empty_sample, doc in zip(
+                empty_samples, [Doc(self.nlp.vocab) for doc in empty_samples]
+            )
+        ]
+        return n_docs
+
+    @staticmethod
+    def check_non_content_bearing_sample_order(
+            empty_samples: Tuple, attribute_document_list: List
+    ) -> Any:
+        """ Checks if zero-lengthed strings were converted into Doc objects in their preserved order. """
+
+        preserved_order_and_type = True
+        attribute_document_list_as_dict = dict(attribute_document_list)
+        for sample_index, _ in empty_samples:
+            if not isinstance(attribute_document_list_as_dict[sample_index], Doc) \
+                    or len(attribute_document_list_as_dict[sample_index]) != 0:
+                preserved_order_and_type = False
+        return preserved_order_and_type
+
     def docs_for_training_data(
         self, training_data: TrainingData
     ) -> Dict[Text, List[Any]]:
 
         attribute_docs = {}
         for attribute in SPACY_FEATURIZABLE_ATTRIBUTES:
-
             texts = [self.get_text(e, attribute) for e in training_data.intent_examples]
+            # Index and freeze indices of the training samples for preserving the order
+            # after processing the data.
+            indexed_training_samples = [(idx, text) for idx, text in enumerate(texts)]
 
-            docs = [doc for doc in self.nlp.pipe(texts, batch_size=50)]
+            samples_to_pipe, empty_samples = self.filter_training_samples_by_content(indexed_training_samples)
 
-            attribute_docs[attribute] = docs
+            content_bearing_docs = self.process_content_bearing_samples(samples_to_pipe)
+
+            non_content_bearing_docs = self.process_non_content_bearing_samples(empty_samples)
+
+            attribute_document_list = self.merge_content_lists(
+                indexed_training_samples, content_bearing_docs + non_content_bearing_docs
+            )
+
+            assert self.check_non_content_bearing_sample_order(empty_samples, attribute_document_list)
+
+            # Since we only need the training samples strings, we create a list to get them out
+            # of the tuple.
+            attribute_docs[attribute] = [doc for _, doc in attribute_document_list]
         return attribute_docs
 
     def train(

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -162,7 +162,7 @@ class SpacyNLP(Component):
 
     def process_content_bearing_samples(
         self, samples_to_pipe: List[int, Text]
-    ) -> List[Any]:
+    ) -> List[Tuple[int,"Doc"]]:
         """Sends content bearing training samples to spaCy's pipe."""
 
         docs = [

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -133,7 +133,7 @@ class SpacyNLP(Component):
     @staticmethod
     def merge_content_lists(
         indexed_training_samples: List[Tuple[int, Text]], doc_lists: List[Tuple[int, "Doc"]]
-    ) -> List[Tuple[int,"Doc"]]:
+    ) -> List[Tuple[int, "Doc"]]:
         """Merge lists with processed Docs back into their original order."""
 
         dct = dict(indexed_training_samples)

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -132,7 +132,8 @@ class SpacyNLP(Component):
 
     @staticmethod
     def merge_content_lists(
-        indexed_training_samples: List[Tuple[int, Text]], doc_lists: List[Tuple[int, "Doc"]]
+        indexed_training_samples: List[Tuple[int, Text]],
+        doc_lists: List[Tuple[int, "Doc"]],
     ) -> List[Tuple[int, "Doc"]]:
         """Merge lists with processed Docs back into their original order."""
 

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -180,7 +180,7 @@ class SpacyNLP(Component):
         return docs
 
     def process_non_content_bearing_samples(
-        self, empty_samples: Tuple[Any]
+        self, empty_samples: List[int, Text]
     ) -> List[Any]:
         """Creates empty Doc-objects from zero-lengthed training samples strings."""
 

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -138,12 +138,12 @@ class SpacyNLP(Component):
 
         dct = dict(indexed_training_samples)
         dct.update(dict(doc_lists))
-        return list(sorted(dct.items()))
+        return sorted(dct.items())
 
     @staticmethod
     def filter_training_samples_by_content(
         indexed_training_samples: List[Tuple[int, Text]]
-    ) -> Tuple[List[Tuple[int, str]], List[Tuple[int, str]]]:
+    ) -> Tuple[List[Tuple[int, Text]], List[Tuple[int, Text]]]:
         """Separates empty training samples from content bearing ones."""
 
         docs_to_pipe = list(

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -143,7 +143,7 @@ class SpacyNLP(Component):
     @staticmethod
     def filter_training_samples_by_content(
         indexed_training_samples: List[Tuple[int, Text]]
-    ) -> Tuple[Any, Any]:
+    ) -> Tuple[List[int, Text], List[int, Text]]:
         """Separates empty training samples from content bearing ones."""
 
         docs_to_pipe = list(

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -181,7 +181,7 @@ class SpacyNLP(Component):
 
     def process_non_content_bearing_samples(
         self, empty_samples: List[int, Text]
-    ) -> List[Any]:
+    ) -> List[Tuple[int,"Doc"]]:
         """Creates empty Doc-objects from zero-lengthed training samples strings."""
 
         n_docs = [

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -133,7 +133,7 @@ class SpacyNLP(Component):
     @staticmethod
     def merge_content_lists(
         indexed_training_samples: List[Tuple[int, Text]], doc_lists: List[Tuple[int, "Doc"]]
-    ) -> List[Any]:
+    ) -> List[Tuple[int,"Doc"]]:
         """Merge lists with processed Docs back into their original order."""
 
         dct = dict(indexed_training_samples)

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -131,16 +131,20 @@ class SpacyNLP(Component):
         return self.preprocess_text(example.get(attribute))
 
     @staticmethod
-    def merge_content_lists(indexed_training_samples: List, doc_lists: List) -> List:
-        """ Merge lists with processed Docs back into their original order. """
+    def merge_content_lists(
+        indexed_training_samples: List[Any], doc_lists: List[Any]
+    ) -> List[Any]:
+        """Merge lists with processed Docs back into their original order."""
 
         dct = dict(indexed_training_samples)
         dct.update(dict(doc_lists))
         return list(dct.items())
 
     @staticmethod
-    def filter_training_samples_by_content(indexed_training_samples: List) -> Tuple:
-        """ Separates empty training samples from content bearing ones. """
+    def filter_training_samples_by_content(
+        indexed_training_samples: List[Any]
+    ) -> Tuple[Any, Any]:
+        """Separates empty training samples from content bearing ones."""
 
         docs_to_pipe = list(
             filter(
@@ -156,8 +160,10 @@ class SpacyNLP(Component):
         )
         return docs_to_pipe, empty_docs
 
-    def process_content_bearing_samples(self, samples_to_pipe: Tuple) -> List:
-        """ Sends content bearing training samples to spaCy's pipe. """
+    def process_content_bearing_samples(
+        self, samples_to_pipe: Tuple[Any, Any]
+    ) -> List[Any]:
+        """Sends content bearing training samples to spaCy's pipe."""
 
         docs = [
             (to_pipe_sample[0], doc)
@@ -173,8 +179,10 @@ class SpacyNLP(Component):
         ]
         return docs
 
-    def process_non_content_bearing_samples(self, empty_samples: Tuple) -> List:
-        """ Creates empty Doc-objects from zero-lenghted training samples strings. """
+    def process_non_content_bearing_samples(
+        self, empty_samples: Tuple[Any]
+    ) -> List[Any]:
+        """Creates empty Doc-objects from zero-lenghted training samples strings."""
 
         n_docs = [
             (empty_sample[0], doc)
@@ -184,26 +192,9 @@ class SpacyNLP(Component):
         ]
         return n_docs
 
-    @staticmethod
-    def check_non_content_bearing_sample_order(
-        empty_samples: Tuple, attribute_document_list: List
-    ) -> Any:
-        """ Checks if zero-lengthed strings were converted into Doc objects in their preserved order. """
-
-        preserved_order_and_type = True
-        attribute_document_list_as_dict = dict(attribute_document_list)
-        for sample_index, _ in empty_samples:
-            if (
-                not isinstance(attribute_document_list_as_dict[sample_index], Doc)
-                or len(attribute_document_list_as_dict[sample_index]) != 0
-            ):
-                preserved_order_and_type = False
-        return preserved_order_and_type
-
     def docs_for_training_data(
         self, training_data: TrainingData
     ) -> Dict[Text, List[Any]]:
-
         attribute_docs = {}
         for attribute in SPACY_FEATURIZABLE_ATTRIBUTES:
             texts = [self.get_text(e, attribute) for e in training_data.intent_examples]
@@ -224,10 +215,6 @@ class SpacyNLP(Component):
             attribute_document_list = self.merge_content_lists(
                 indexed_training_samples,
                 content_bearing_docs + non_content_bearing_docs,
-            )
-
-            assert self.check_non_content_bearing_sample_order(
-                empty_samples, attribute_document_list
             )
 
             # Since we only need the training samples strings, we create a list to get them out

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -161,7 +161,7 @@ class SpacyNLP(Component):
         return docs_to_pipe, empty_docs
 
     def process_content_bearing_samples(
-        self, samples_to_pipe: Tuple[Any, Any]
+        self, samples_to_pipe: List[int, Text]
     ) -> List[Any]:
         """Sends content bearing training samples to spaCy's pipe."""
 

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -131,9 +131,7 @@ class SpacyNLP(Component):
         return self.preprocess_text(example.get(attribute))
 
     @staticmethod
-    def merge_content_lists(
-            indexed_training_samples: List, doc_lists: List
-    ) -> List:
+    def merge_content_lists(indexed_training_samples: List, doc_lists: List) -> List:
         """ Merge lists with processed Docs back into their original order. """
 
         dct = dict(indexed_training_samples)
@@ -141,18 +139,24 @@ class SpacyNLP(Component):
         return list(dct.items())
 
     @staticmethod
-    def filter_training_samples_by_content(
-            indexed_training_samples: List
-    ) -> Tuple:
+    def filter_training_samples_by_content(indexed_training_samples: List) -> Tuple:
         """ Separates empty training samples from content bearing ones. """
 
-        docs_to_pipe = list(filter(lambda training_sample: training_sample[1] != "", indexed_training_samples))
-        empty_docs = list(filter(lambda training_sample: training_sample[1] == "", indexed_training_samples))
+        docs_to_pipe = list(
+            filter(
+                lambda training_sample: training_sample[1] != "",
+                indexed_training_samples,
+            )
+        )
+        empty_docs = list(
+            filter(
+                lambda training_sample: training_sample[1] == "",
+                indexed_training_samples,
+            )
+        )
         return docs_to_pipe, empty_docs
 
-    def process_content_bearing_samples(
-            self, samples_to_pipe: Tuple
-    ) -> List:
+    def process_content_bearing_samples(self, samples_to_pipe: Tuple) -> List:
         """ Sends content bearing training samples to spaCy's pipe. """
 
         docs = [
@@ -162,16 +166,14 @@ class SpacyNLP(Component):
                 [
                     doc
                     for doc in self.nlp.pipe(
-                    [txt for _, txt in samples_to_pipe], batch_size=50
-                )
+                        [txt for _, txt in samples_to_pipe], batch_size=50
+                    )
                 ],
             )
         ]
         return docs
 
-    def process_non_content_bearing_samples(
-            self, empty_samples: Tuple
-    ) -> List:
+    def process_non_content_bearing_samples(self, empty_samples: Tuple) -> List:
         """ Creates empty Doc-objects from zero-lenghted training samples strings. """
 
         n_docs = [
@@ -184,15 +186,17 @@ class SpacyNLP(Component):
 
     @staticmethod
     def check_non_content_bearing_sample_order(
-            empty_samples: Tuple, attribute_document_list: List
+        empty_samples: Tuple, attribute_document_list: List
     ) -> Any:
         """ Checks if zero-lengthed strings were converted into Doc objects in their preserved order. """
 
         preserved_order_and_type = True
         attribute_document_list_as_dict = dict(attribute_document_list)
         for sample_index, _ in empty_samples:
-            if not isinstance(attribute_document_list_as_dict[sample_index], Doc) \
-                    or len(attribute_document_list_as_dict[sample_index]) != 0:
+            if (
+                not isinstance(attribute_document_list_as_dict[sample_index], Doc)
+                or len(attribute_document_list_as_dict[sample_index]) != 0
+            ):
                 preserved_order_and_type = False
         return preserved_order_and_type
 
@@ -207,17 +211,24 @@ class SpacyNLP(Component):
             # after processing the data.
             indexed_training_samples = [(idx, text) for idx, text in enumerate(texts)]
 
-            samples_to_pipe, empty_samples = self.filter_training_samples_by_content(indexed_training_samples)
+            samples_to_pipe, empty_samples = self.filter_training_samples_by_content(
+                indexed_training_samples
+            )
 
             content_bearing_docs = self.process_content_bearing_samples(samples_to_pipe)
 
-            non_content_bearing_docs = self.process_non_content_bearing_samples(empty_samples)
-
-            attribute_document_list = self.merge_content_lists(
-                indexed_training_samples, content_bearing_docs + non_content_bearing_docs
+            non_content_bearing_docs = self.process_non_content_bearing_samples(
+                empty_samples
             )
 
-            assert self.check_non_content_bearing_sample_order(empty_samples, attribute_document_list)
+            attribute_document_list = self.merge_content_lists(
+                indexed_training_samples,
+                content_bearing_docs + non_content_bearing_docs,
+            )
+
+            assert self.check_non_content_bearing_sample_order(
+                empty_samples, attribute_document_list
+            )
 
             # Since we only need the training samples strings, we create a list to get them out
             # of the tuple.

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -182,7 +182,7 @@ class SpacyNLP(Component):
     def process_non_content_bearing_samples(
         self, empty_samples: Tuple[Any]
     ) -> List[Any]:
-        """Creates empty Doc-objects from zero-lenghted training samples strings."""
+        """Creates empty Doc-objects from zero-lengthed training samples strings."""
 
         n_docs = [
             (empty_sample[0], doc)

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -138,12 +138,12 @@ class SpacyNLP(Component):
 
         dct = dict(indexed_training_samples)
         dct.update(dict(doc_lists))
-        return list(dct.items())
+        return list(sorted(dct.items()))
 
     @staticmethod
     def filter_training_samples_by_content(
         indexed_training_samples: List[Tuple[int, Text]]
-    ) -> Tuple[List[int, Text], List[int, Text]]:
+    ) -> Tuple[List[Tuple[int, str]], List[Tuple[int, str]]]:
         """Separates empty training samples from content bearing ones."""
 
         docs_to_pipe = list(
@@ -161,8 +161,8 @@ class SpacyNLP(Component):
         return docs_to_pipe, empty_docs
 
     def process_content_bearing_samples(
-        self, samples_to_pipe: List[int, Text]
-    ) -> List[Tuple[int,"Doc"]]:
+        self, samples_to_pipe: List[Tuple[int, Text]]
+    ) -> List[Tuple[int, "Doc"]]:
         """Sends content bearing training samples to spaCy's pipe."""
 
         docs = [
@@ -180,8 +180,8 @@ class SpacyNLP(Component):
         return docs
 
     def process_non_content_bearing_samples(
-        self, empty_samples: List[int, Text]
-    ) -> List[Tuple[int,"Doc"]]:
+        self, empty_samples: List[Tuple[int, Text]]
+    ) -> List[Tuple[int, "Doc"]]:
         """Creates empty Doc-objects from zero-lengthed training samples strings."""
 
         n_docs = [

--- a/tests/nlu/base/test_featurizers.py
+++ b/tests/nlu/base/test_featurizers.py
@@ -28,6 +28,67 @@ def test_spacy_featurizer(sentence, expected, spacy_nlp):
     assert np.allclose(doc.vector[:5], expected, atol=1e-5)
     assert np.allclose(vecs, doc.vector, atol=1e-5)
 
+@pytest.mark.parametrize(
+    "indexed_training_samples",
+    [
+        (
+            [
+                (0, "I have a feeling"), (1, "that tonight is gonna be the night"), (2, ""), (3, ""),
+                (4, "we are visiting"), (5, ""), (6, " in the west of"), (7, "California's coast"),
+                (8, ""), (9, "we have already taken"), (10, ""), (11, "account")
+            ]
+        )
+    ],
+)
+def test_spacy_training_sample_order(indexed_training_samples, spacy_nlp):
+    from rasa.nlu.utils.spacy_utils import SpacyNLP
+    from spacy.tokens import Doc
+
+    def process_content_bearing_samples(samples_to_pipe):
+
+        docs = [
+            (to_pipe_sample[0], doc)
+            for to_pipe_sample, doc in zip(
+                samples_to_pipe,
+                [
+                    doc
+                    for doc in spacy_nlp.pipe(
+                        [txt for _, txt in samples_to_pipe], batch_size=50
+                    )
+                ],
+            )
+        ]
+        return docs
+
+    def process_non_content_bearing_samples(empty_samples):
+
+        n_docs = [
+            (empty_sample[0], doc)
+            for empty_sample, doc in zip(
+                empty_samples, [Doc(spacy_nlp.vocab) for doc in empty_samples]
+            )
+        ]
+        return n_docs
+
+    samples_to_pipe, empty_samples = SpacyNLP.filter_training_samples_by_content(
+        indexed_training_samples
+    )
+
+    content_bearing_docs = process_content_bearing_samples(samples_to_pipe)
+
+    non_content_bearing_docs = process_non_content_bearing_samples(
+        empty_samples
+    )
+
+    attribute_document_list = SpacyNLP.merge_content_lists(
+        indexed_training_samples,
+        content_bearing_docs + non_content_bearing_docs,
+    )
+
+    assert SpacyNLP.check_non_content_bearing_sample_order(
+        empty_samples, attribute_document_list
+    )
+
 
 def test_spacy_intent_featurizer(spacy_nlp_component):
     from rasa.nlu.featurizers.spacy_featurizer import SpacyFeaturizer


### PR DESCRIPTION
Proposed changes:

As discussed here third-party libraries or applications that rely on `spaCy `might have problems with spaCy's `Doc`-objects created by parsing empty strings. To avoid that, only those training samples should further be sent to `nlp.pipe`, that actually carry content, however, the order of training samples need to be preserved and in addition, the batch-processing of `spaCy `should still be used. The new workflow consists of:

1. Index all training samples
2. Splitting empty from content-carrying training samples
3. Update content-carrying training samples by converting `(index, text)` to `(index, Doc)` samples
4. Update empty training samples by converting `(index, "")` to `(index, Doc)` samples
5. Merging the resulting lists back into their original order

The functionality has been tested and evaluated with different config-scenarios with and without ResponseSelector training samples, mainly:

```
language: de
pipeline:
 - name: SpacyNLP
   case_sensitive: 1
   model: de
 - name: SpacyTokenizer
 - name: SpacyFeaturizer
 - name: SklearnIntentClassifier
```

which reflects a more or less default scenario with spaCys pipeline and

```
language: de
pipeline:
 - name: SpacyNLP
   case_sensitive: 1
   model: de_pytt_bertbasecased_lg_spo
 - name: SpacyTokenizer
 - name: SpacyFeaturizer
 - name: SklearnIntentClassifier
 - name: ResponseSelector
```

which uses a finetuned BERT model using `spacy-pytorch-transformers`, one of the libraries that caused the mentioned error. The functionality worked as expected.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
