### PR TITLE
change default of slow_callback_duration in asyncio debugging

### DIFF
--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -132,7 +132,7 @@ async def _pull_model_and_fingerprint(
 
     async with model_server.session() as session:
         try:
-            set_log_level()
+            # set_log_level()
             params = model_server.combine_parameters()
             async with session.request(
                 "GET",

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -39,7 +39,8 @@ def configure_colored_logging(loglevel):
     )
 
 
-def enable_async_loop_debugging(event_loop: AbstractEventLoop) -> AbstractEventLoop:
+def enable_async_loop_debugging(event_loop: AbstractEventLoop,
+        slow_callback_duration: float = 0.1) -> AbstractEventLoop:
     logging.info(
         "Enabling coroutine debugging. Loop id {}.".format(id(asyncio.get_event_loop()))
     )
@@ -49,7 +50,7 @@ def enable_async_loop_debugging(event_loop: AbstractEventLoop) -> AbstractEventL
 
     # Make the threshold for "slow" tasks very very small for
     # illustration. The default is 0.1 (= 100 milliseconds).
-    event_loop.slow_callback_duration = 0.001
+    event_loop.slow_callback_duration = slow_callback_duration
 
     # Report all mistakes managing asynchronous resources.
     warnings.simplefilter("always", ResourceWarning)

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -23,7 +23,8 @@ from tests.core.conftest import DEFAULT_DOMAIN_PATH_WITH_SLOTS
 def loop():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    loop = rasa.utils.io.enable_async_loop_debugging(loop)
+    loop = rasa.utils.io.enable_async_loop_debugging(loop,
+            slow_callback_duration=0.1)
     yield loop
     loop.close()
 


### PR DESCRIPTION
**Proposed changes**:
- make `slow_callback_duration` a parameter of `enable_async_loop_debugging` and set its default value to something more reasonable than 1ms
For now the default value has been changed to 100ms, this was just a though, so it's very open to revision. Ideally the value would be set appropriately wherever the function is called.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
