### PR TITLE
make slow_callback_duration a parameter in asyncio debugging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,15 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
 
 
+[1.3.4] 
+^^^^^^^^^^^^^^^^^^^^
+
+Fixed
+-----
+- asyncio warnings are now only printed if the callback takes more than 100ms
+  (up from 1ms)
+- ``agent.load_model_from_server`` no longer affects logging
+
 [1.3.3] - 2019-09-13
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -35,7 +35,7 @@ from rasa.model import (
     get_model,
 )
 from rasa.nlu.utils import is_url
-from rasa.utils.common import update_sanic_log_level, set_log_level
+from rasa.utils.common import update_sanic_log_level
 from rasa.utils.endpoints import EndpointConfig
 
 logger = logging.getLogger(__name__)
@@ -132,7 +132,6 @@ async def _pull_model_and_fingerprint(
 
     async with model_server.session() as session:
         try:
-            # set_log_level()
             params = model_server.combine_parameters()
             async with session.request(
                 "GET",

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -132,7 +132,7 @@ async def _pull_model_and_fingerprint(
 
     async with model_server.session() as session:
         try:
-            set_log_level()
+            # set_log_level()
             params = model_server.combine_parameters()
             async with session.request(
                 "GET",

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -39,8 +39,9 @@ def configure_colored_logging(loglevel):
     )
 
 
-def enable_async_loop_debugging(event_loop: AbstractEventLoop,
-        slow_callback_duration: float = 0.1) -> AbstractEventLoop:
+def enable_async_loop_debugging(
+    event_loop: AbstractEventLoop, slow_callback_duration: float = 0.1
+) -> AbstractEventLoop:
     logging.info(
         "Enabling coroutine debugging. Loop id {}.".format(id(asyncio.get_event_loop()))
     )

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -39,7 +39,8 @@ def configure_colored_logging(loglevel):
     )
 
 
-def enable_async_loop_debugging(event_loop: AbstractEventLoop) -> AbstractEventLoop:
+def enable_async_loop_debugging(event_loop: AbstractEventLoop,
+        slow_callback_duration: float = 0.1) -> AbstractEventLoop:
     logging.info(
         "Enabling coroutine debugging. Loop id {}.".format(id(asyncio.get_event_loop()))
     )
@@ -49,7 +50,7 @@ def enable_async_loop_debugging(event_loop: AbstractEventLoop) -> AbstractEventL
 
     # Make the threshold for "slow" tasks very very small for
     # illustration. The default is 0.1 (= 100 milliseconds).
-    event_loop.slow_callback_duration = 0.001
+    event_loop.slow_callback_duration = slow_callback_duration
 
     # Report all mistakes managing asynchronous resources.
     warnings.simplefilter("always", ResourceWarning)

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -23,8 +23,7 @@ from tests.core.conftest import DEFAULT_DOMAIN_PATH_WITH_SLOTS
 def loop():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    loop = rasa.utils.io.enable_async_loop_debugging(loop,
-            slow_callback_duration=0.1)
+    loop = rasa.utils.io.enable_async_loop_debugging(loop)
     yield loop
     loop.close()
 

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -23,7 +23,8 @@ from tests.core.conftest import DEFAULT_DOMAIN_PATH_WITH_SLOTS
 def loop():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    loop = rasa.utils.io.enable_async_loop_debugging(loop)
+    loop = rasa.utils.io.enable_async_loop_debugging(loop,
+            slow_callback_duration=0.1)
     yield loop
     loop.close()
 


### PR DESCRIPTION
**Proposed changes**:
- Add the parameter `slow_callback_duration` to the utils function `enable_async_loop_debugging` and change its default value to 100ms, up from 1ms.
Any asyncio calls that take longer than `slow_callback_duration` produce a warning. (There were lots of warnings)
That was also the reason `agent.load_model_from_server` called `set_log_level`, since this is no longer necessary the call has been removed (it caused some other troubles).

`enable_async_loop_debugging` is called in tests and if rasa is run with `--debug`. A default value of 100ms might not always be appropriate and we might have to change it in some places for https://github.com/RasaHQ/rasa/issues/4356

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
