### PR TITLE
Mappol lastaction nopolicy

### DIFF
--- a/rasa/core/policies/mapping_policy.py
+++ b/rasa/core/policies/mapping_policy.py
@@ -114,7 +114,9 @@ class MappingPolicy(Policy):
         elif tracker.latest_action_name == action and action is not None:
             latest_action = tracker.get_last_event_for(ActionExecuted)
             assert latest_action.action_name == action
-            if latest_action.policy and latest_action.policy.endswith(type(self).__name__):
+            if latest_action.policy and latest_action.policy.endswith(
+                type(self).__name__
+            ):
                 # this ensures that we only predict listen, if we predicted
                 # the mapped action
                 logger.debug(

--- a/rasa/core/policies/mapping_policy.py
+++ b/rasa/core/policies/mapping_policy.py
@@ -114,9 +114,7 @@ class MappingPolicy(Policy):
         elif tracker.latest_action_name == action and action is not None:
             latest_action = tracker.get_last_event_for(ActionExecuted)
             assert latest_action.action_name == action
-            if latest_action.policy == type(
-                self
-            ).__name__ or latest_action.policy.endswith("_" + type(self).__name__):
+            if latest_action.policy and latest_action.policy.endswith(type(self).__name__):
                 # this ensures that we only predict listen, if we predicted
                 # the mapped action
                 logger.debug(


### PR DESCRIPTION
**Proposed changes**:
- Let the mapping policy check whether the last action was actually predicted by a policy. This fixes an issue where if the latest action in the tracker did not have an associated policy and had the same name as the mapped action for the current intent the mapping policy would fail.
Also changed the name check to only check if `action.policy` ends with `policy.name` as should covers both previous cases.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
