### PR TITLE
DucklingHTTPExtractor with defined request timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
 -----
 - fixed missing ``tkinter`` dependency for running tests on Ubuntu
 - fixed issue with ``conversation`` JSON serialization
+- fixed the hanging HTTP call with ``ner_duckling_http`` pipeline
 
 [Unreleased 1.3.7]
 ^^^^^^^^^^^^^^^^^^

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -857,3 +857,6 @@ DucklingHTTPExtractor
           # if not set the default timezone of Duckling is going to be used
           # needed to calculate dates from relative expressions like "tomorrow"
           timezone: "Europe/Berlin"
+          # Timeout for receiving response from http url of the running duckling server
+          # if not set the default timeout of duckling http url is set to 3 seconds. 
+          timeout : 3

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -62,6 +62,9 @@ class DucklingHTTPExtractor(EntityExtractor):
         # timezone like Europe/Berlin
         # if not set the default timezone of Duckling is going to be used
         "timezone": None,
+        # Timeout for receiving response from http url of the running duckling server
+        # if not set the default timeout of duckling http url is set to 3 seconds.
+        "timeout": 3,
     }
 
     def __init__(
@@ -113,7 +116,10 @@ class DucklingHTTPExtractor(EntityExtractor):
                 "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
             }
             response = requests.post(
-                self._url() + "/parse", data=payload, headers=headers
+                self._url() + "/parse",
+                data=payload,
+                headers=headers,
+                timeout=self.component_config.get("timeout"),
             )
             if response.status_code == 200:
                 return response.json()
@@ -124,10 +130,13 @@ class DucklingHTTPExtractor(EntityExtractor):
                     "".format(response.status_code, response.text)
                 )
                 return []
-        except requests.exceptions.ConnectionError as e:
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ReadTimeout,
+        ) as e:
             logger.error(
                 "Failed to connect to duckling http server. Make sure "
-                "the duckling server is running and the proper host "
+                "the duckling server is running/healthy/not stale and the proper host "
                 "and port are set in the configuration. More "
                 "information on how to run the server can be found on "
                 "github: "


### PR DESCRIPTION
**Proposed changes**:
- Fixed the bug being discussed under #1695
- Added a timeout of a default of 3 seconds to t.he Duckling HTTP Request Invocation and made it a configurable component parameter.
- Updated the docs to reflect the new timeout parameter.
- Updated the changelog to reflect the fix.
- Reformatted the code using black.
- Ran a few tests to ascertain the fix.Attached a screenshot (below) of the test that fulfills the fix.

![DucklingHTTPExtractorwithTimeout](https://user-images.githubusercontent.com/55908719/65815070-fbe13680-e207-11e9-834e-357deeaf8935.png)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
