### PR TITLE
remove kwargs from default channel implementation send methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 -----
 - Fixed error ``Object of type 'MaxHistoryTrackerFeaturizer' is not JSON serializable``
   when running ``rasa train core``
+- Default channel ``send_`` methods no longer support kwargs as they caused issues in incompatible channelss
 
 [1.3.7] - 2019-09-27
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/core/channels/channel.py
+++ b/rasa/core/channels/channel.py
@@ -197,16 +197,14 @@ class OutputChannel(object):
     ) -> None:
         """Sends an image. Default will just post the url as a string."""
 
-        await self.send_text_message(recipient_id, "Image: {}".format(image), **kwargs)
+        await self.send_text_message(recipient_id, "Image: {}".format(image))
 
     async def send_attachment(
         self, recipient_id: Text, attachment: Text, **kwargs: Any
     ) -> None:
         """Sends an attachment. Default will just post as a string."""
 
-        await self.send_text_message(
-            recipient_id, "Attachment: {}".format(attachment), **kwargs
-        )
+        await self.send_text_message(recipient_id, "Attachment: {}".format(attachment))
 
     async def send_text_with_buttons(
         self,
@@ -219,10 +217,10 @@ class OutputChannel(object):
 
         Default implementation will just post the buttons as a string."""
 
-        await self.send_text_message(recipient_id, text, **kwargs)
+        await self.send_text_message(recipient_id, text)
         for idx, button in enumerate(buttons):
             button_msg = cli_utils.button_to_string(button, idx)
-            await self.send_text_message(recipient_id, button_msg, **kwargs)
+            await self.send_text_message(recipient_id, button_msg)
 
     async def send_quick_replies(
         self,
@@ -235,7 +233,7 @@ class OutputChannel(object):
 
         Default implementation will just send as buttons."""
 
-        await self.send_text_with_buttons(recipient_id, text, quick_replies, **kwargs)
+        await self.send_text_with_buttons(recipient_id, text, quick_replies)
 
     async def send_elements(
         self, recipient_id: Text, elements: Iterable[Dict[Text, Any]], **kwargs: Any
@@ -244,15 +242,12 @@ class OutputChannel(object):
 
         Default implementation will just post the elements as a string."""
 
-        # we can't pass the empty "buttons" key of the message through to send_text_with_buttons()
-        kwargs.pop("buttons", None)
-
         for element in elements:
             element_msg = "{title} : {subtitle}".format(
                 title=element.get("title", ""), subtitle=element.get("subtitle", "")
             )
             await self.send_text_with_buttons(
-                recipient_id, element_msg, element.get("buttons", []), **kwargs
+                recipient_id, element_msg, element.get("buttons", [])
             )
 
     async def send_custom_json(
@@ -262,7 +257,7 @@ class OutputChannel(object):
 
         Default implementation will just post the json contents as a string."""
 
-        await self.send_text_message(recipient_id, json.dumps(json_message), **kwargs)
+        await self.send_text_message(recipient_id, json.dumps(json_message))
 
 
 class CollectingOutputChannel(OutputChannel):


### PR DESCRIPTION
**Proposed changes**:
- remove kwargs from default channel implementation. If users want to support these kwargs and e.g. passing them along to another function (from elements to text with buttons, for example), they can still implement their own `send_elements` function that does just that. 
- fixes the following multiple values error we have seen with migrating from a `send_elements` workaround before `send_custom_json` existed:
```
  File "c:\anaconda3\envs\rasa_latest\lib\site-packages\rasa\core\channels\chan
nel.py", line 255, in send_elements
    recipient_id, element_msg, element.get("buttons", []), **kwargs
TypeError: send_text_with_buttons() got multiple values for argument 'text'
```

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
