### PR TITLE
Fix missing link to blog post on Retrieval Actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,11 @@ Fixed
   when running ``rasa train core``
 - Default channel ``send_`` methods no longer support kwargs as they caused issues in incompatible channels
 
+Added
+-----
+- Link to detailed blog post about ``Retrieval Actions`` on its corresponding page in docs.
+- Warning inside ``Retrieval Actions`` docs page concerning usage of Rasa X with it.
+
 [1.3.7] - 2019-09-27
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,11 +21,6 @@ Fixed
   when running ``rasa train core``
 - Default channel ``send_`` methods no longer support kwargs as they caused issues in incompatible channels
 
-Added
------
-- Link to detailed blog post about ``Retrieval Actions`` on its corresponding page in docs.
-- Warning inside ``Retrieval Actions`` docs page concerning usage of Rasa X with it.
-
 [1.3.7] - 2019-09-27
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/core/retrieval-actions.rst
+++ b/docs/core/retrieval-actions.rst
@@ -242,4 +242,4 @@ the corresponding response selector will be identified as ``default`` in the ret
 
 .. warning::
 
-   Since the feature is experimental, retrieval actions are not supported by Rasa-X and interactive learning within Rasa. Using them may lead to unexpected behaviour.
+   Since the feature is experimental, retrieval actions are not currently supported by Rasa-X and interactive learning within Rasa. Using them may lead to unexpected behaviour.

--- a/docs/core/retrieval-actions.rst
+++ b/docs/core/retrieval-actions.rst
@@ -242,4 +242,4 @@ the corresponding response selector will be identified as ``default`` in the ret
 
 .. warning::
 
-   Since the feature is experimental, retrieval actions are not currently supported by Rasa-X and interactive learning within Rasa. Using them may lead to unexpected behaviour.
+   Since the feature is experimental, retrieval actions are currently not supported by Rasa-X and interactive learning within Rasa. Using them may lead to unexpected behaviour.

--- a/docs/core/retrieval-actions.rst
+++ b/docs/core/retrieval-actions.rst
@@ -13,6 +13,8 @@ Retrieval Actions
    We introduce experimental features to get feedback from our community, so we encourage you to try it out!
    However, the functionality might be changed or removed in the future.
    If you have feedback (positive or negative) please share it with us on the `forum <https://forum.rasa.com>`_.
+   Also, currently we do not support adding new annotations in Rasa X if your training data contains retrieval actions.
+   Once we have gathered enough feedback on the feature in terms of the training data format, we'll tightly integrate these for better support.
 
 .. note::
    There is an in-depth blog post `here <https://blog.rasa.com/response-retrieval-models/>`_ about how to use retrieval
@@ -239,7 +241,3 @@ Example result:
 
 If the ``retrieval_intent`` parameter of a particular response selector was left to its default value,
 the corresponding response selector will be identified as ``default`` in the returned output.
-
-.. warning::
-
-   Since the feature is experimental, retrieval actions are currently not supported by Rasa-X and interactive learning within Rasa. Using them may lead to unexpected behaviour.

--- a/docs/core/retrieval-actions.rst
+++ b/docs/core/retrieval-actions.rst
@@ -14,6 +14,10 @@ Retrieval Actions
    However, the functionality might be changed or removed in the future.
    If you have feedback (positive or negative) please share it with us on the `forum <https://forum.rasa.com>`_.
 
+.. note::
+   There is an in-depth blog post `here <https://blog.rasa.com/response-retrieval-models/>`_ about how to use retrieval
+   actions for handling single turn interactions.
+
 .. contents::
    :local:
 
@@ -235,3 +239,7 @@ Example result:
 
 If the ``retrieval_intent`` parameter of a particular response selector was left to its default value,
 the corresponding response selector will be identified as ``default`` in the returned output.
+
+.. warning::
+
+   Since the feature is experimental, retrieval actions are not supported by Rasa-X and interactive learning within Rasa. Using them may lead to unexpected behaviour.

--- a/docs/core/retrieval-actions.rst
+++ b/docs/core/retrieval-actions.rst
@@ -14,7 +14,7 @@ Retrieval Actions
    However, the functionality might be changed or removed in the future.
    If you have feedback (positive or negative) please share it with us on the `forum <https://forum.rasa.com>`_.
    Also, currently we do not support adding new annotations in Rasa X if your training data contains retrieval actions.
-   Once we have gathered enough feedback on the feature in terms of the training data format, we'll tightly integrate these for better support.
+   Once we have gathered enough feedback and we're happy with the training data format, we'll add support for training response retrieval models in Rasa X.
 
 .. note::
    There is an in-depth blog post `here <https://blog.rasa.com/response-retrieval-models/>`_ about how to use retrieval


### PR DESCRIPTION
**Proposed changes**:
- Add link to blog post on Retrieval Actions
- Add warning related to usage of Rasa X with Retrieval Actions.

**Status (please check what you already did)**:
- [x] updated the documentation
- [x] updated the changelog
