### PR TITLE
Add event_broker param to custom tracker

### DIFF
--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -67,14 +67,18 @@ class TrackerStore(object):
                 domain=domain, event_broker=event_broker, **store.kwargs
             )
         else:
-            tracker_store = TrackerStore.load_tracker_from_module_string(domain, store)
+            tracker_store = TrackerStore.load_tracker_from_module_string(
+                domain, store, event_broker
+            )
 
         logger.debug("Connected to {}.".format(tracker_store.__class__.__name__))
         return tracker_store
 
     @staticmethod
     def load_tracker_from_module_string(
-        domain: Domain, store: EndpointConfig
+        domain: Domain,
+        store: EndpointConfig,
+        event_broker: Optional[EventChannel] = None,
     ) -> "TrackerStore":
         """
         Initializes a custom tracker.
@@ -82,6 +86,7 @@ class TrackerStore(object):
         Args:
             domain: defines the universe in which the assistant operates
             store: the specific tracker store
+            event_broker: an event broker to publish events
 
         Returns:
             custom_tracker: a tracker store from a specified database
@@ -97,7 +102,12 @@ class TrackerStore(object):
             )
 
         if custom_tracker:
-            return custom_tracker(domain=domain, url=store.url, **store.kwargs)
+            return custom_tracker(
+                domain=domain,
+                url=store.url,
+                event_broker=event_broker,
+                **store.kwargs
+            )
         else:
             return InMemoryTrackerStore(domain)
 


### PR DESCRIPTION
Like other store types, custom tracker needs event_broker to stream events. 
issue #4577

**Proposed changes**:
- Add event_broker parameter to custom tracker

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
