### PR TITLE
Add event_broker param to custom tracker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Changed
   Deserialisation of pickled trackers will be deprecated in version 2.0. For now,
   trackers are still loaded from pickle but will be dumped as json in any subsequent
   save operations.
-- In custom tracker store instantiation added ``event_broker``.
+- Event brokers are now also passed to custom tracker stores (using the ``event_broker`` parameter)
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ Changed
   Deserialisation of pickled trackers will be deprecated in version 2.0. For now,
   trackers are still loaded from pickle but will be dumped as json in any subsequent
   save operations.
+- In custom tracker store instantiation added ``event_broker``.
 
 Removed
 -------

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -103,10 +103,7 @@ class TrackerStore(object):
 
         if custom_tracker:
             return custom_tracker(
-                domain=domain,
-                url=store.url,
-                event_broker=event_broker,
-                **store.kwargs
+                domain=domain, url=store.url, event_broker=event_broker, **store.kwargs
             )
         else:
             return InMemoryTrackerStore(domain)

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -67,14 +67,18 @@ class TrackerStore(object):
                 domain=domain, event_broker=event_broker, **store.kwargs
             )
         else:
-            tracker_store = TrackerStore.load_tracker_from_module_string(domain, store)
+            tracker_store = TrackerStore.load_tracker_from_module_string(
+                domain, store, event_broker
+            )
 
         logger.debug("Connected to {}.".format(tracker_store.__class__.__name__))
         return tracker_store
 
     @staticmethod
     def load_tracker_from_module_string(
-        domain: Domain, store: EndpointConfig
+        domain: Domain,
+        store: EndpointConfig,
+        event_broker: Optional[EventChannel] = None,
     ) -> "TrackerStore":
         """
         Initializes a custom tracker.
@@ -82,6 +86,7 @@ class TrackerStore(object):
         Args:
             domain: defines the universe in which the assistant operates
             store: the specific tracker store
+            event_broker: an event broker to publish events
 
         Returns:
             custom_tracker: a tracker store from a specified database
@@ -97,7 +102,12 @@ class TrackerStore(object):
             )
 
         if custom_tracker:
-            return custom_tracker(domain=domain, url=store.url, **store.kwargs)
+            return custom_tracker(
+                domain=domain,
+                url=store.url,
+                event_broker=event_broker,
+                **store.kwargs
+            )
         else:
             return InMemoryTrackerStore(domain)
 

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -109,9 +109,15 @@ def test_find_tracker_store(default_domain):
 
 
 class ExampleTrackerStore(RedisTrackerStore):
-    def __init__(self, domain, url, port, db, password, record_exp):
+    def __init__(self, domain, url, port, db, password, record_exp, event_broker=None):
         super(ExampleTrackerStore, self).__init__(
-            domain, host=url, port=port, db=db, password=password, record_exp=record_exp
+            domain,
+            event_broker=event_broker,
+            host=url,
+            port=port,
+            db=db,
+            password=password,
+            record_exp=record_exp,
         )
 
 


### PR DESCRIPTION
Like other store types, custom tracker needs event_broker to stream events.
issue #4577

**Proposed changes**:
- Add event_broker parameter to custom tracker

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
