### PR TITLE
Add validation for duplicated data example in multiple intents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Added
   (``rasa.core.agent.handle_channels()``). The number of workers can be set using the
   environment variable ``SANIC_WORKERS`` (default: 1). A value of >1 is allowed only in
   combination with ``RedisLockStore`` as the lock store.
+- Added data validator that checks there is no duplicated example data across multiples intents
 
 Changed
 -------

--- a/docs/user-guide/validate-files.rst
+++ b/docs/user-guide/validate-files.rst
@@ -30,6 +30,8 @@ which has the following methods:
 
 **verify_intents():** Checks if intents listed in domain file are consistent with the NLU data.
 
+**verify_example_repetition_in_intents():** Checks if there is no duplicated data among distinct intents at NLU data.
+
 **verify_intents_in_stories():** Verification for intents in the stories, to check if they are valid.
 
 **verify_utterances():** Checks domain file for consistency between utterance templates and utterances listed under

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -88,10 +88,6 @@ class Validator(object):
         all valid intents are used in the stories."""
 
         everything_is_alright = self.verify_intents(ignore_warnings)
-        everything_is_alright = (
-            self.verify_example_repetition_in_intents(ignore_warnings)
-            and everything_is_alright
-        )
 
         stories_intents = {
             event.intent["name"]
@@ -196,6 +192,11 @@ class Validator(object):
         logger.info("Validating intents...")
         intents_are_valid = self.verify_intents_in_stories(ignore_warnings)
 
+        logger.info("Validating there is no duplications...")
+        there_is_no_duplication = self.verify_example_repetition_in_intents(
+            ignore_warnings
+        )
+
         logger.info("Validating utterances...")
         stories_are_valid = self.verify_utterances_in_stories(ignore_warnings)
-        return intents_are_valid and stories_are_valid
+        return intents_are_valid and stories_are_valid and there_is_no_duplication

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -66,17 +66,16 @@ class Validator(object):
         everything_is_alright = True
 
         duplication_hash = defaultdict(set)
-        duplicated_examples = []
-        for msg in self.intents.intent_examples:
-            msg_dict = msg.as_dict_nlu()
-            text = msg_dict.get("text")
-            duplication_hash[text].add(msg_dict.get("intent"))
+        duplicated_examples = {}
+        for example in self.intents.intent_examples:
+            text = example.text
+            duplication_hash[text].add(example.get("intent"))
 
             if len(duplication_hash[text]) > 1:
-                duplicated_examples.append((text, duplication_hash[text]))
+                duplicated_examples[text] = duplication_hash[text]
                 everything_is_alright = ignore_warnings and everything_is_alright
 
-        for text, intents in duplicated_examples:
+        for text, intents in duplicated_examples.items():
             logger.warning(
                 "The example '{}' was found in these multiples intents: {}".format(
                     text, ", ".join(intents)

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -66,21 +66,19 @@ class Validator(object):
         everything_is_alright = True
 
         duplication_hash = defaultdict(set)
-        duplicated_examples = {}
         for example in self.intents.intent_examples:
             text = example.text
             duplication_hash[text].add(example.get("intent"))
 
-            if len(duplication_hash[text]) > 1:
-                duplicated_examples[text] = duplication_hash[text]
-                everything_is_alright = ignore_warnings and everything_is_alright
+        for text, intents in duplication_hash.items():
 
-        for text, intents in duplicated_examples.items():
-            logger.warning(
-                "The example '{}' was found in these multiples intents: {}".format(
-                    text, ", ".join(sorted(intents))
+            if len(duplication_hash[text]) > 1:
+                everything_is_alright = ignore_warnings and everything_is_alright
+                logger.warning(
+                    "The example '{}' was found in these multiples intents: {}".format(
+                        text, ", ".join(sorted(intents))
+                    )
                 )
-            )
         return everything_is_alright
 
     def verify_intents_in_stories(self, ignore_warnings: bool = True) -> bool:

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -78,7 +78,7 @@ class Validator(object):
         for text, intents in duplicated_examples.items():
             logger.warning(
                 "The example '{}' was found in these multiples intents: {}".format(
-                    text, ", ".join(intents)
+                    text, ", ".join(sorted(intents))
                 )
             )
         return everything_is_alright

--- a/tests/core/test_validator.py
+++ b/tests/core/test_validator.py
@@ -55,3 +55,23 @@ async def test_fail_on_invalid_utterances(tmpdir):
     importer = RasaFileImporter(domain_path=invalid_domain)
     validator = await Validator.from_importer(importer)
     assert not validator.verify_utterances()
+
+
+async def test_verify_there_is_example_repetition_in_intents():
+    # moodbot nlu data already has duplicated example 'good afternoon'
+    # for intents greet and goodbye
+    importer = RasaFileImporter(
+        domain_path="examples/moodbot/domain.yml",
+        training_data_paths=["examples/moodbot/data/nlu.md"],
+    )
+    validator = await Validator.from_importer(importer)
+    assert not validator.verify_example_repetition_in_intents(False)
+
+
+async def test_verify_there_is_not_example_repetition_in_intents():
+    importer = RasaFileImporter(
+        domain_path="examples/moodbot/domain.yml",
+        training_data_paths=["examples/knowledgebasebot/data/nlu.md"],
+    )
+    validator = await Validator.from_importer(importer)
+    assert validator.verify_example_repetition_in_intents(False)

--- a/tests/core/test_validator.py
+++ b/tests/core/test_validator.py
@@ -68,6 +68,26 @@ async def test_verify_there_is_example_repetition_in_intents():
     assert not validator.verify_example_repetition_in_intents(False)
 
 
+async def test_verify_logging_message_for_repetition_in_intents(caplog):
+    # moodbot nlu data already has duplicated example 'good afternoon'
+    # for intents greet and goodbye
+    importer = RasaFileImporter(
+        domain_path="examples/moodbot/domain.yml",
+        training_data_paths=["examples/moodbot/data/nlu.md"],
+    )
+    validator = await Validator.from_importer(importer)
+    validator.verify_example_repetition_in_intents(False)
+    log_object = caplog.records[-1]
+    level = log_object.levelname
+    message = log_object.message
+    assert "WARNING" == level
+    assert (
+        "The example 'good afternoon' was found in these "
+        + "multiples intents: greet, goodbye"
+        == message
+    )
+
+
 async def test_verify_there_is_not_example_repetition_in_intents():
     importer = RasaFileImporter(
         domain_path="examples/moodbot/domain.yml",

--- a/tests/core/test_validator.py
+++ b/tests/core/test_validator.py
@@ -83,7 +83,7 @@ async def test_verify_logging_message_for_repetition_in_intents(caplog):
     assert "WARNING" == level
     assert (
         "The example 'good afternoon' was found in these "
-        + "multiples intents: greet, goodbye"
+        + "multiples intents: goodbye, greet"
         == message
     )
 


### PR DESCRIPTION
Closes #4566 
**Proposed changes**:
- The command `rasa data validate` checks there is no duplicated example data at nlu file.

**Expected Behavior**:
- nlu data file has some intents as shown:
```
## intent:greet
- hello

## intent:goodbye
- hello
```
- The following warning should be displayed when running `rasa data validate`:
```
WARNING  rasa.core.validator  - The example 'hello' was found in these multiples intents: goodbye, greet
```

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
