### PR TITLE
Fix /status route in server.py to include original model location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Changed
   trackers are still loaded from pickle but will be dumped as json in any subsequent
   save operations.
 - Event brokers are now also passed to custom tracker stores (using the ``event_broker`` parameter)
-- Updated the ``/status`` api route to use the actual model file location instead of the tmp location.
+- Updated the ``/status`` api route to use the actual model file location instead of the ``tmp`` location.
 
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Added
   (``rasa.core.agent.handle_channels()``). The number of workers can be set using the
   environment variable ``SANIC_WORKERS`` (default: 1). A value of >1 is allowed only in
   combination with ``RedisLockStore`` as the lock store.
+- Updated the /status api route to include the original location of the model file.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Added
   (``rasa.core.agent.handle_channels()``). The number of workers can be set using the
   environment variable ``SANIC_WORKERS`` (default: 1). A value of >1 is allowed only in
   combination with ``RedisLockStore`` as the lock store.
-- Updated the /status api route to include the original location of the model file.
+- Updated the /status api route to use the actual model file location instead of the tmp location.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Changed
   trackers are still loaded from pickle but will be dumped as json in any subsequent
   save operations.
 - Event brokers are now also passed to custom tracker stores (using the ``event_broker`` parameter)
-- Updated the `/status` api route to use the actual model file location instead of the tmp location.
+- Updated the ``/status`` api route to use the actual model file location instead of the tmp location.
 
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,6 @@ Added
   (``rasa.core.agent.handle_channels()``). The number of workers can be set using the
   environment variable ``SANIC_WORKERS`` (default: 1). A value of >1 is allowed only in
   combination with ``RedisLockStore`` as the lock store.
-- Updated the /status api route to use the actual model file location instead of the tmp location.
 
 Changed
 -------
@@ -41,6 +40,8 @@ Changed
   trackers are still loaded from pickle but will be dumped as json in any subsequent
   save operations.
 - Event brokers are now also passed to custom tracker stores (using the ``event_broker`` parameter)
+- Updated the `/status` api route to use the actual model file location instead of the tmp location.
+
 
 Removed
 -------

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -400,6 +400,7 @@ def create_app(
 
         return response.json(
             {
+                "latest_model": model.get_latest_model(),
                 "model_file": app.agent.model_directory,
                 "fingerprint": model.fingerprint_from_path(app.agent.model_directory),
                 "num_active_training_jobs": app.active_training_processes.value,

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -400,8 +400,7 @@ def create_app(
 
         return response.json(
             {
-                "latest_model": model.get_latest_model(),
-                "model_file": app.agent.model_directory,
+                "model_file": model.get_latest_model(),
                 "fingerprint": model.fingerprint_from_path(app.agent.model_directory),
                 "num_active_training_jobs": app.active_training_processes.value,
             }


### PR DESCRIPTION
**Proposed changes**:
- Adding in a new `latest_model` object in the /status response object that is basically the `model.get_latest_model()` so we actually can get the original model location.

Right now it only shows the model_file with the tmp location which I'm not sure if we want to just replace that or not with this option above?  The only reason I can see maybe keeping it around is for troubleshooting to know where the actual model is that we are using and not that we trained from.

Thoughts?

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality - waiting until I know if I'm removing the old object response or not yet.
- [X] updated the changelog
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
