### PR TITLE
Black py3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ author = "Rasa Technologies"
 #
 # The short X.Y version.
 __version__ = None
-exec (open("../rasa/version.py").read())
+exec(open("../rasa/version.py").read())
 version = ".".join(__version__.split(".")[:2])
 # The full version, including alpha/beta/rc tags.
 release = __version__
@@ -399,4 +399,4 @@ def setup(sphinx):
 
         sphinx.add_lexer("story", StoryLexer())
     except ImportError:
-        print ("No Story Lexer :( Sad times!")
+        print("No Story Lexer :( Sad times!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py27', 'py35', 'py36', 'py37']
+target-version = ['py36', 'py37']
 exclude = '''
 (
   /(

--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -51,7 +51,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
 
 
 def print_version() -> None:
-    print ("Rasa", version.__version__)
+    print("Rasa", version.__version__)
 
 
 def main() -> None:

--- a/rasa/cli/scaffold.py
+++ b/rasa/cli/scaffold.py
@@ -91,7 +91,7 @@ def print_run_or_instructions(args: argparse.Namespace, path: Text) -> None:
         shell(args)
     else:
         if args.no_prompt:
-            print (
+            print(
                 "If you want to speak to the assistant, "
                 "run 'rasa shell' at any time inside "
                 "the project directory."
@@ -109,7 +109,7 @@ def print_run_or_instructions(args: argparse.Namespace, path: Text) -> None:
 
 def init_project(args: argparse.Namespace, path: Text) -> None:
     create_initial_project(path)
-    print ("Created project directory at '{}'.".format(os.path.abspath(path)))
+    print("Created project directory at '{}'.".format(os.path.abspath(path)))
     print_train_or_instructions(args, path)
 
 
@@ -158,14 +158,14 @@ def run(args: argparse.Namespace) -> None:
 
     print_success("Welcome to Rasa! 🤖\n")
     if args.no_prompt:
-        print (
+        print(
             "To get started quickly, an "
             "initial project will be created.\n"
             "If you need some help, check out "
             "the documentation at {}.\n".format(DOCS_BASE_URL)
         )
     else:
-        print (
+        print(
             "To get started quickly, an "
             "initial project will be created.\n"
             "If you need some help, check out "

--- a/rasa/cli/utils.py
+++ b/rasa/cli/utils.py
@@ -212,7 +212,7 @@ def wrap_with_color(*args: Any, color: Text):
 
 
 def print_color(*args: Any, color: Text):
-    print (wrap_with_color(*args, color=color))
+    print(wrap_with_color(*args, color=color))
 
 
 def print_success(*args: Any):
@@ -239,5 +239,5 @@ def print_error_and_exit(message: Text, exit_code: int = 1) -> None:
 
 
 def signal_handler(sig, frame):
-    print ("Goodbye 👋")
+    print("Goodbye 👋")
     sys.exit(0)

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -382,7 +382,7 @@ def run_locally(args: argparse.Namespace):
     try:
         local.main(args, project_path, args.data, token=rasa_x_token)
     except Exception:
-        print (traceback.format_exc())
+        print(traceback.format_exc())
         cli_utils.print_error(
             "Sorry, something went wrong (see error above). Make sure to start "
             "Rasa X with valid data and valid domain and config files. Please, "

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -444,7 +444,7 @@ class Agent(object):
         self,
         message: UserMessage,
         message_preprocessor: Optional[Callable[[Text], Text]] = None,
-        **kwargs
+        **kwargs,
     ) -> Optional[List[Dict[Text, Any]]]:
         """Handle a single message."""
 
@@ -482,7 +482,7 @@ class Agent(object):
         self,
         message: UserMessage,
         message_preprocessor: Optional[Callable[[Text], Text]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DialogueStateTracker:
         """Append a message to a dialogue - does not predict actions."""
 

--- a/rasa/core/channels/botframework.py
+++ b/rasa/core/channels/botframework.py
@@ -129,7 +129,7 @@ class BotFramework(OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         hero_content = {
             "contentType": "application/vnd.microsoft.card.hero",

--- a/rasa/core/channels/channel.py
+++ b/rasa/core/channels/channel.py
@@ -175,7 +175,7 @@ class OutputChannel:
                 recipient_id,
                 message.pop("text"),
                 message.pop("quick_replies"),
-                **message
+                **message,
             )
         elif message.get("buttons"):
             await self.send_text_with_buttons(
@@ -227,7 +227,7 @@ class OutputChannel:
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends buttons to the output.
 
@@ -243,7 +243,7 @@ class OutputChannel:
         recipient_id: Text,
         text: Text,
         quick_replies: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends quick replies to the output.
 
@@ -345,7 +345,7 @@ class CollectingOutputChannel(OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         await self._persist_message(
             self._message(recipient_id, text=text, buttons=buttons)

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -162,7 +162,7 @@ class MessengerBot(OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends buttons to the output."""
 
@@ -196,7 +196,7 @@ class MessengerBot(OutputChannel):
         recipient_id: Text,
         text: Text,
         quick_replies: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends quick replies to the output."""
 

--- a/rasa/core/channels/mattermost.py
+++ b/rasa/core/channels/mattermost.py
@@ -76,7 +76,7 @@ class MattermostBot(MattermostAPI, OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends buttons to the output."""
 

--- a/rasa/core/channels/rocketchat.py
+++ b/rasa/core/channels/rocketchat.py
@@ -60,7 +60,7 @@ class RocketChatBot(OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         # implementation is based on
         # https://github.com/RocketChat/Rocket.Chat/pull/11473

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -64,7 +64,7 @@ class SlackBot(SlackClient, OutputChannel):
             channel=recipient,
             as_user=True,
             attachments=[attachment],
-            **kwargs
+            **kwargs,
         )
 
     async def send_text_with_buttons(
@@ -72,7 +72,7 @@ class SlackBot(SlackClient, OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         recipient = self.slack_channel or recipient_id
 

--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -58,7 +58,7 @@ class SocketIOOutput(OutputChannel):
         recipient_id: Text,
         text: Text,
         buttons: List[Dict[Text, Any]],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends buttons to the output."""
 

--- a/rasa/core/channels/telegram.py
+++ b/rasa/core/channels/telegram.py
@@ -46,7 +46,7 @@ class TelegramOutput(Bot, OutputChannel):
         text: Text,
         buttons: List[Dict[Text, Any]],
         button_type: Optional[Text] = "inline",
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Sends a message with keyboard.
 

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -116,7 +116,7 @@ class Domain(object):
             utter_templates,
             data.get("actions", []),
             data.get("forms", []),
-            **additional_arguments
+            **additional_arguments,
         )
 
     @classmethod

--- a/rasa/core/nlg/callback.py
+++ b/rasa/core/nlg/callback.py
@@ -53,7 +53,7 @@ def nlg_request_format(
     template_name: Text,
     tracker: DialogueStateTracker,
     output_channel: Text,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Dict[Text, Any]:
     """Create the json body for the NLG json body for the request."""
 
@@ -84,7 +84,7 @@ class CallbackNaturalLanguageGenerator(NaturalLanguageGenerator):
         template_name: Text,
         tracker: DialogueStateTracker,
         output_channel: Text,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Dict[Text, Any]:
         """Retrieve a named template from the domain using an endpoint."""
 

--- a/rasa/core/nlg/template.py
+++ b/rasa/core/nlg/template.py
@@ -66,7 +66,7 @@ class TemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
         template_name: Text,
         tracker: DialogueStateTracker,
         output_channel: Text,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Optional[Dict[Text, Any]]:
         """Generate a response for the requested template."""
 
@@ -80,7 +80,7 @@ class TemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
         template_name: Text,
         filled_slots: Dict[Text, Any],
         output_channel: Text,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Optional[Dict[Text, Any]]:
         """Generate a response for the requested template."""
 
@@ -96,7 +96,7 @@ class TemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
         self,
         template: Dict[Text, Any],
         filled_slots: Optional[Dict[Text, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Dict[Text, Any]:
         """"Combine slot values and key word arguments to fill templates."""
 

--- a/rasa/core/policies/embedding_policy.py
+++ b/rasa/core/policies/embedding_policy.py
@@ -129,7 +129,7 @@ class EmbeddingPolicy(Policy):
         all_bot_embed: Optional["tf.Tensor"] = None,
         attention_weights: Optional["tf.Tensor"] = None,
         max_history: Optional[int] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Declare instant variables with default values"""
 
@@ -409,7 +409,7 @@ class EmbeddingPolicy(Policy):
         self,
         training_trackers: List["DialogueStateTracker"],
         domain: "Domain",
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Train the policy on given training trackers."""
 
@@ -498,7 +498,7 @@ class EmbeddingPolicy(Policy):
         self,
         training_trackers: List["DialogueStateTracker"],
         domain: "Domain",
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Continue training an already trained policy."""
 

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -120,7 +120,7 @@ class PolicyEnsemble(object):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         if training_trackers:
             for policy in self.policies:

--- a/rasa/core/policies/fallback.py
+++ b/rasa/core/policies/fallback.py
@@ -60,7 +60,7 @@ class FallbackPolicy(Policy):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Does nothing. This policy is deterministic."""
 

--- a/rasa/core/policies/keras_policy.py
+++ b/rasa/core/policies/keras_policy.py
@@ -61,7 +61,7 @@ class KerasPolicy(Policy):
         session: Optional[tf.compat.v1.Session] = None,
         current_epoch: int = 0,
         max_history: Optional[int] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         if not featurizer:
             featurizer = self._standard_featurizer(max_history)
@@ -169,7 +169,7 @@ class KerasPolicy(Policy):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
 
         # set numpy random seed
@@ -209,7 +209,7 @@ class KerasPolicy(Policy):
                     batch_size=self.batch_size,
                     shuffle=False,
                     verbose=obtain_verbosity(),
-                    **self._train_params
+                    **self._train_params,
                 )
                 # the default parameter for epochs in keras fit is 1
                 self.current_epoch = self.defaults.get("epochs", 1)
@@ -219,7 +219,7 @@ class KerasPolicy(Policy):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Continues training an already trained policy."""
 

--- a/rasa/core/policies/mapping_policy.py
+++ b/rasa/core/policies/mapping_policy.py
@@ -70,7 +70,7 @@ class MappingPolicy(Policy):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Does nothing. This policy is deterministic."""
 

--- a/rasa/core/policies/memoization.py
+++ b/rasa/core/policies/memoization.py
@@ -143,7 +143,7 @@ class MemoizationPolicy(Policy):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Trains the policy on given training trackers."""
         self.lookup = {}
@@ -164,7 +164,7 @@ class MemoizationPolicy(Policy):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
 
         # add only the last tracker, because it is the only new one

--- a/rasa/core/policies/policy.py
+++ b/rasa/core/policies/policy.py
@@ -61,7 +61,7 @@ class Policy(object):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DialogueTrainingData:
         """Transform training trackers into a vector representation.
         The trackers, consisting of multiple turns, will be transformed
@@ -83,7 +83,7 @@ class Policy(object):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Trains the policy on given training trackers."""
 
@@ -116,7 +116,7 @@ class Policy(object):
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Continues training an already trained policy.
 

--- a/rasa/core/policies/sklearn_policy.py
+++ b/rasa/core/policies/sklearn_policy.py
@@ -41,7 +41,7 @@ class SklearnPolicy(Policy):
         scoring: Optional[Text or List or Dict or Callable] = "accuracy",
         label_encoder: LabelEncoder = LabelEncoder(),
         shuffle: bool = True,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Create a new sklearn policy.
 
@@ -114,14 +114,14 @@ class SklearnPolicy(Policy):
             model, param_grid=param_grid, cv=self.cv, scoring="accuracy", verbose=1
         )
         search.fit(X, y)
-        print ("Best params:", search.best_params_)
+        print("Best params:", search.best_params_)
         return search.best_estimator_, search.best_score_
 
     def train(
         self,
         training_trackers: List[DialogueStateTracker],
         domain: Domain,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
 
         training_data = self.featurize_for_training(training_trackers, domain, **kwargs)

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -449,15 +449,15 @@ async def _print_history(sender_id: Text, endpoint: EndpointConfig) -> None:
     table = _chat_history_table(events)
     slot_strs = _slot_history(tracker_dump)
 
-    print ("------")
-    print ("Chat History\n")
-    print (table)
+    print("------")
+    print("Chat History\n")
+    print(table)
 
     if slot_strs:
-        print ("\n")
-        print ("Current slots: \n\t{}\n".format(", ".join(slot_strs)))
+        print("\n")
+        print("Current slots: \n\t{}\n".format(", ".join(slot_strs)))
 
-    print ("------")
+    print("------")
 
 
 def _chat_history_table(events: List[Dict[Text, Any]]) -> Text:
@@ -662,7 +662,7 @@ async def _request_action_from_user(
         is_new_action = True
         action_name = action_name[32:]
 
-    print ("Thanks! The bot will now run {}.\n".format(action_name))
+    print("Thanks! The bot will now run {}.\n".format(action_name))
     return action_name, is_new_action
 
 
@@ -1144,7 +1144,7 @@ async def _validate_user_text(
         )
 
     if intent is None:
-        print ("The NLU classification for '{}' returned '{}'".format(text, intent))
+        print("The NLU classification for '{}' returned '{}'".format(text, intent))
         return False
     else:
         question = questionary.confirm(message)

--- a/rasa/core/training/visualization.py
+++ b/rasa/core/training/visualization.py
@@ -223,7 +223,7 @@ def _merge_equivalent_nodes(graph, max_history):
                                 succ_node,
                                 k,
                                 d.get("label"),
-                                **{"class": d.get("class", "")}
+                                **{"class": d.get("class", "")},
                             )
                             graph.remove_edge(j, succ_node)
                         # moves all incoming edges to the other node
@@ -235,7 +235,7 @@ def _merge_equivalent_nodes(graph, max_history):
                                 i,
                                 k,
                                 d.get("label"),
-                                **{"class": d.get("class", "")}
+                                **{"class": d.get("class", "")},
                             )
                             graph.remove_edge(prev_node, j)
                         graph.remove_node(j)
@@ -273,7 +273,7 @@ async def _replace_edge_labels_with_nodes(
                 shape="rect",
                 style="filled",
                 fillcolor="lightblue",
-                **_transfer_style(d, {"class": "intent"})
+                **_transfer_style(d, {"class": "intent"}),
             )
             graph.add_edge(s, next_id, **{"class": d.get("class", "")})
             graph.add_edge(next_id, e, **{"class": d.get("class", "")})
@@ -336,7 +336,7 @@ def _add_default_nodes(graph: "networkx.MultiDiGraph", fontsize: int = 12) -> No
         fillcolor="green",
         style="filled",
         fontsize=fontsize,
-        **{"class": "start active"}
+        **{"class": "start active"},
     )
     graph.add_node(
         END_NODE_ID,
@@ -344,7 +344,7 @@ def _add_default_nodes(graph: "networkx.MultiDiGraph", fontsize: int = 12) -> No
         fillcolor="red",
         style="filled",
         fontsize=fontsize,
-        **{"class": "end"}
+        **{"class": "end"},
     )
     graph.add_node(TMP_NODE_ID, label="TMP", style="invis", **{"class": "invisible"})
 
@@ -388,7 +388,7 @@ def _add_message_edge(
         next_node_idx,
         message_key,
         message_label,
-        **{"class": "active" if is_current else ""}
+        **{"class": "active" if is_current else ""},
     )
 
 
@@ -440,7 +440,7 @@ async def visualize_neighborhood(
                     next_node_idx,
                     label=el.action_name,
                     fontsize=fontsize,
-                    **{"class": "active" if is_current else ""}
+                    **{"class": "active" if is_current else ""},
                 )
 
                 _add_message_edge(
@@ -466,7 +466,7 @@ async def visualize_neighborhood(
                     if not message
                     else sanitize(message.get("intent", {}).get("name", "  ?  ")),
                     shape="rect",
-                    **{"class": "intent dashed active"}
+                    **{"class": "intent dashed active"},
                 )
                 target = next_node_idx
             elif current_node:

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -131,7 +131,7 @@ def generate_id(prefix="", max_chars=None):
 
 def request_input(valid_values=None, prompt=None, max_suggested=3):
     def wrong_input_message():
-        print (
+        print(
             "Invalid answer, only {}{} allowed\n".format(
                 ", ".join(valid_values[:max_suggested]),
                 ",..." if len(valid_values) > max_suggested else "",

--- a/rasa/jupyter.py
+++ b/rasa/jupyter.py
@@ -47,7 +47,7 @@ def chat(
         )
         return
 
-    print ("Your bot is ready to talk! Type your messages here or send '/stop'.")
+    print("Your bot is ready to talk! Type your messages here or send '/stop'.")
     loop = asyncio.get_event_loop()
     while True:
         message = input()

--- a/rasa/nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa/nlu/classifiers/embedding_intent_classifier.py
@@ -506,7 +506,7 @@ class EmbeddingIntentClassifier(Component):
         self,
         training_data: "TrainingData",
         cfg: Optional["RasaNLUModelConfig"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Train the embedding label classifier on a data set."""
 
@@ -691,7 +691,7 @@ class EmbeddingIntentClassifier(Component):
         model_dir: Text = None,
         model_metadata: "Metadata" = None,
         cached_component: Optional["EmbeddingIntentClassifier"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "EmbeddingIntentClassifier":
 
         if model_dir and meta.get("file"):

--- a/rasa/nlu/classifiers/mitie_intent_classifier.py
+++ b/rasa/nlu/classifiers/mitie_intent_classifier.py
@@ -87,7 +87,7 @@ class MitieIntentClassifier(Component):
         model_dir: Optional[Text] = None,
         model_metadata: Optional[Metadata] = None,
         cached_component: Optional["MitieIntentClassifier"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "MitieIntentClassifier":
         import mitie
 

--- a/rasa/nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa/nlu/classifiers/sklearn_intent_classifier.py
@@ -214,7 +214,7 @@ class SklearnIntentClassifier(Component):
         model_dir: Optional[Text] = None,
         model_metadata: Optional[Metadata] = None,
         cached_component: Optional["SklearnIntentClassifier"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "SklearnIntentClassifier":
         from sklearn.preprocessing import LabelEncoder
 

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -234,7 +234,7 @@ class Component(object, metaclass=ComponentMetaclass):
         model_dir: Optional[Text] = None,
         model_metadata: Optional["Metadata"] = None,
         cached_component: Optional["Component"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "Component":
         """Load this component from file.
 
@@ -429,7 +429,7 @@ class ComponentBuilder(object):
         component_meta: Dict[Text, Any],
         model_dir: Text,
         model_metadata: "Metadata",
-        **context: Any
+        **context: Any,
     ) -> Component:
         """Tries to retrieve a component from the cache, else calls
         ``load`` to create a new component.

--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -403,7 +403,7 @@ class CRFEntityExtractor(EntityExtractor):
         model_dir: Text = None,
         model_metadata: Metadata = None,
         cached_component: Optional["CRFEntityExtractor"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "CRFEntityExtractor":
         from sklearn.externals import joblib
 

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -191,7 +191,7 @@ class DucklingHTTPExtractor(EntityExtractor):
         model_dir: Text = None,
         model_metadata: Optional[Metadata] = None,
         cached_component: Optional["DucklingHTTPExtractor"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "DucklingHTTPExtractor":
 
         language = model_metadata.get("language") if model_metadata else None

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -62,7 +62,7 @@ class EntitySynonymMapper(EntityExtractor):
         model_dir: Optional[Text] = None,
         model_metadata: Optional[Metadata] = None,
         cached_component: Optional["EntitySynonymMapper"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "EntitySynonymMapper":
 
         file_name = meta.get("file")

--- a/rasa/nlu/extractors/mitie_entity_extractor.py
+++ b/rasa/nlu/extractors/mitie_entity_extractor.py
@@ -134,7 +134,7 @@ class MitieEntityExtractor(EntityExtractor):
         model_dir: Text = None,
         model_metadata: Metadata = None,
         cached_component: Optional["MitieEntityExtractor"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "MitieEntityExtractor":
         import mitie
 

--- a/rasa/nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/count_vectors_featurizer.py
@@ -585,7 +585,7 @@ class CountVectorsFeaturizer(Featurizer):
         model_dir: Text = None,
         model_metadata: Metadata = None,
         cached_component: Optional["CountVectorsFeaturizer"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "CountVectorsFeaturizer":
 
         file_name = meta.get("file")

--- a/rasa/nlu/featurizers/ngram_featurizer.py
+++ b/rasa/nlu/featurizers/ngram_featurizer.py
@@ -99,7 +99,7 @@ class NGramFeaturizer(Featurizer):
         model_dir: Optional[Text] = None,
         model_metadata: Optional["Metadata"] = None,
         cached_component: Optional["NGramFeaturizer"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "NGramFeaturizer":
 
         file_name = meta.get("file")

--- a/rasa/nlu/featurizers/regex_featurizer.py
+++ b/rasa/nlu/featurizers/regex_featurizer.py
@@ -136,7 +136,7 @@ class RegexFeaturizer(Featurizer):
         model_dir: Optional[Text] = None,
         model_metadata: Optional["Metadata"] = None,
         cached_component: Optional["RegexFeaturizer"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "RegexFeaturizer":
 
         file_name = meta.get("file")

--- a/rasa/nlu/registry.py
+++ b/rasa/nlu/registry.py
@@ -191,7 +191,7 @@ def load_component_by_meta(
     model_dir: Text,
     metadata: Metadata,
     cached_component: Optional["Component"],
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Optional["Component"]:
     """Resolves a component and calls its load method.
 

--- a/rasa/nlu/run.py
+++ b/rasa/nlu/run.py
@@ -24,7 +24,7 @@ def run_cmdline(model_path, component_builder=None):
         else:
             result = interpreter.parse(message)
 
-        print (json_to_string(result))
+        print(json_to_string(result))
 
 
 if __name__ == "__main__":

--- a/rasa/nlu/tokenizers/jieba_tokenizer.py
+++ b/rasa/nlu/tokenizers/jieba_tokenizer.py
@@ -123,7 +123,7 @@ class JiebaTokenizer(Tokenizer, Component):
         model_dir: Optional[Text] = None,
         model_metadata: Optional["Metadata"] = None,
         cached_component: Optional[Component] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "JiebaTokenizer":
 
         relative_dictionary_path = meta.get("dictionary_path")

--- a/rasa/nlu/train.py
+++ b/rasa/nlu/train.py
@@ -54,7 +54,7 @@ async def train(
     component_builder: Optional[ComponentBuilder] = None,
     training_data_endpoint: Optional[EndpointConfig] = None,
     persist_nlu_training_data: bool = False,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Tuple[Trainer, Interpreter, Optional[Text]]:
     """Loads the trainer and the data and runs the training of the model."""
     from rasa.importers.importer import TrainingDataImporter

--- a/rasa/nlu/training_data/formats/rasa.py
+++ b/rasa/nlu/training_data/formats/rasa.py
@@ -89,7 +89,7 @@ class RasaWriter(TrainingDataWriter):
                     "entity_synonyms": formatted_synonyms,
                 }
             },
-            **kwargs
+            **kwargs,
         )
 
 

--- a/rasa/nlu/utils/mitie_utils.py
+++ b/rasa/nlu/utils/mitie_utils.py
@@ -92,7 +92,7 @@ class MitieNLP(Component):
         model_dir: Optional[Text] = None,
         model_metadata: Optional[Metadata] = None,
         cached_component: Optional["MitieNLP"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "MitieNLP":
         import mitie
 

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -255,7 +255,7 @@ class SpacyNLP(Component):
         model_dir: Text = None,
         model_metadata: "Metadata" = None,
         cached_component: Optional["SpacyNLP"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "SpacyNLP":
 
         if cached_component:

--- a/rasa/run.py
+++ b/rasa/run.py
@@ -17,7 +17,7 @@ def run(
     endpoints: Text,
     connector: Text = None,
     credentials: Text = None,
-    **kwargs: Dict
+    **kwargs: Dict,
 ):
     """Runs a Rasa model.
 
@@ -53,7 +53,7 @@ def run(
         channel=connector,
         credentials=credentials,
         endpoints=_endpoints,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/rasa/utils/endpoints.py
+++ b/rasa/utils/endpoints.py
@@ -73,7 +73,7 @@ class EndpointConfig(object):
         basic_auth: Dict[Text, Text] = None,
         token: Optional[Text] = None,
         token_name: Text = "token",
-        **kwargs
+        **kwargs,
     ):
         self.url = url
         self.params = params if params else {}
@@ -118,7 +118,7 @@ class EndpointConfig(object):
         subpath: Optional[Text] = None,
         content_type: Optional[Text] = "application/json",
         return_method: Text = "json",
-        **kwargs: Any
+        **kwargs: Any,
     ):
         """Send a HTTP request to the endpoint.
 
@@ -141,7 +141,7 @@ class EndpointConfig(object):
                 url,
                 headers=headers,
                 params=self.combine_parameters(kwargs),
-                **kwargs
+                **kwargs,
             ) as resp:
                 if resp.status >= 400:
                     raise ClientResponseError(
@@ -161,7 +161,7 @@ class EndpointConfig(object):
             self.basic_auth,
             self.token,
             self.token_name,
-            **self.kwargs
+            **self.kwargs,
         )
 
     def __eq__(self, other):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Avoids IDE errors, but actual version is read from version.py
 __version__ = None
 with open("rasa/version.py") as f:
-    exec (f.read())
+    exec(f.read())
 
 # Get the long description from the README file
 with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
@@ -138,8 +138,8 @@ setup(
     },
 )
 
-print ("\nWelcome to Rasa!")
-print (
+print("\nWelcome to Rasa!")
+print(
     "If you have any questions, please visit our documentation page: https://rasa.com/docs/"
 )
-print ("or join the community discussions on https://forum.rasa.com/")
+print("or join the community discussions on https://forum.rasa.com/")

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -387,7 +387,7 @@ class TestEmbeddingPolicyWithEval(TestEmbeddingPolicy):
         p = EmbeddingPolicy(
             featurizer=featurizer,
             priority=priority,
-            **{"scale_loss": False, "evaluate_on_num_examples": 4}
+            **{"scale_loss": False, "evaluate_on_num_examples": 4},
         )
         return p
 

--- a/tests/core/utilities.py
+++ b/tests/core/utilities.py
@@ -56,7 +56,7 @@ def mocked_cmd_input(package, text):
 
     def mocked_input(*args, **kwargs):
         value = next(text_generator)
-        print ("wrote '{}' to input".format(value))
+        print("wrote '{}' to input".format(value))
         return value
 
     package.get_user_input = mocked_input

--- a/tests/nlu/example_component.py
+++ b/tests/nlu/example_component.py
@@ -75,7 +75,7 @@ class MyComponent(Component):
         model_dir: Optional[Text] = None,
         model_metadata: Optional["Metadata"] = None,
         cached_component: Optional["Component"] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "Component":
         """Load this component from file."""
 


### PR DESCRIPTION
**Proposed changes**:
- when we removed 3.5 python support, we missed to change the black config to remove the unsupported version
- this PR removes black formatting support for 3.5 (and for that matter 2.7 as it was still in there as well)
- only the first commit needs to be reviewed, the second is just running black with the changed config

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
