### PR TITLE
pin networkx in setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 -----
 - Fixed ``'Namespace' object has no attribute 'persist_nlu_data'`` error during
   interactive learning
+- Pinned `networkx~=2.3.0` to fix visualization in `rasa interactive` and Rasa X
 
 [1.4.1] - 2019-10-22
 ^^^^^^^^^^^^^^^^^^^^

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ tensorflow-probability==0.7.0
 tensor2tensor==1.14.0
 apscheduler==3.6.0
 tqdm==4.31.0
-networkx==2.3
+networkx~=2.3.0
 fbmessenger==6.0.0
 pykwalify==1.7.0
 coloredlogs==10.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     "tensor2tensor~=1.14.0",
     "apscheduler~=3.0",
     "tqdm~=4.0",
-    "networkx==2.3",
+    "networkx~=2.3.0",
     "fbmessenger~=6.0",
     "pykwalify~=1.7.0",
     "coloredlogs~=10.0",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     "tensor2tensor~=1.14.0",
     "apscheduler~=3.0",
     "tqdm~=4.0",
-    "networkx~=2.3",
+    "networkx==2.3",
     "fbmessenger~=6.0",
     "pykwalify~=1.7.0",
     "coloredlogs~=10.0",

--- a/tests/core/test_visualization.py
+++ b/tests/core/test_visualization.py
@@ -99,3 +99,22 @@ async def test_graph_persistence(default_domain, tmpdir):
 
     assert "isClient = true" in content
     assert "graph = `{}`".format(generated_graph.to_string()) in content
+
+
+async def test_merge_nodes(default_domain, tmpdir):
+    from os.path import isfile
+    from rasa.core.training.dsl import StoryFileReader
+    from rasa.core.interpreter import RegexInterpreter
+
+    story_steps = await StoryFileReader.read_from_file(
+        "data/test_stories/stories.md", default_domain, interpreter=RegexInterpreter()
+    )
+    out_file = tmpdir.join("graph.html").strpath
+    await visualization.visualize_stories(
+        story_steps,
+        default_domain,
+        output_file=out_file,
+        max_history=3,
+        should_merge_nodes=True,
+    )
+    assert isfile(out_file)


### PR DESCRIPTION
networkx 2.4 breaks visualization (i.e. `rasa interactive` as well as the visualization on rasa x -- viz just doesn't appear). pinning to 2.3 fixes this. Tested on rasa x by extending the rasa x image to install 2.3 and visualizations re-appeared. this should be in the next patch so that we can create a rasa x patch that pulls from this rasa version.

**Proposed changes**:
- pin networkx==2.3
- fix https://github.com/RasaHQ/rasa/issues/4643#issue-509074209 is the error that shows up in rasa x
- fix the rasa side of https://github.com/RasaHQ/rasa-x/issues/1464 (still need to update rasa x to use this rasa version)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
