### PR TITLE
Yield event loop while receiving messages on rasa shell

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Removed
 Fixed
 -----
 - ``MultiProjectImporter`` now imports files in the order of the import statements
+- Fixed server hanging forever on exitting rasa shell before first message
 
 [Unreleased 1.4.2]
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Removed
 Fixed
 -----
 - ``MultiProjectImporter`` now imports files in the order of the import statements
-- Fixed server hanging forever on exitting rasa shell before first message
+- Fixed server hanging forever on leaving ``rasa shell`` before first message
 
 [Unreleased 1.4.2]
 ~~~~~~~~~~~~~~~~~~

--- a/rasa/core/channels/console.py
+++ b/rasa/core/channels/console.py
@@ -121,7 +121,7 @@ async def record_messages(
 
     num_messages = 0
     button_question = None
-    await asyncio.sleep(0.5)  # Wait for server beggining
+    await asyncio.sleep(0.5)  # Wait for server to start
     while not utils.is_limit_reached(num_messages, max_message_limit):
         text = get_user_input(button_question)
 

--- a/rasa/core/channels/console.py
+++ b/rasa/core/channels/console.py
@@ -1,6 +1,7 @@
 # this builtin is needed so we can overwrite in test
 import json
 import logging
+import asyncio
 from typing import Text, Optional
 
 import aiohttp
@@ -104,14 +105,12 @@ async def send_message_receive_stream(server_url, auth_token, sender_id, message
 
 async def record_messages(
     server_url=DEFAULT_SERVER_URL,
-    auth_token=None,
+    auth_token="",
     sender_id=UserMessage.DEFAULT_SENDER_ID,
     max_message_limit=None,
     use_response_stream=True,
 ):
     """Read messages from the command line and print bot responses."""
-
-    auth_token = auth_token if auth_token else ""
 
     exit_text = INTENT_MESSAGE_PREFIX + "stop"
 
@@ -122,6 +121,7 @@ async def record_messages(
 
     num_messages = 0
     button_question = None
+    await asyncio.sleep(0.5)  # Wait for server beggining
     while not utils.is_limit_reached(num_messages, max_message_limit):
         text = get_user_input(button_question)
 
@@ -142,6 +142,7 @@ async def record_messages(
                 button_question = print_bot_output(response)
 
         num_messages += 1
+        await asyncio.sleep(0)  # Yield event loop for others coroutines
     return num_messages
 
 


### PR DESCRIPTION
**Proposed changes**:
- Fixes #4630 
- Them problem was that the loop for getting messages wasn't yielding the event loop, not allowing finish tasks to be executed

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
