### PR TITLE
Luis schema version incompatibility

### DIFF
--- a/rasa/nlu/training_data/formats/luis.py
+++ b/rasa/nlu/training_data/formats/luis.py
@@ -18,9 +18,19 @@ class LuisReader(JsonTrainingDataReader):
 
         training_examples = []
         regex_features = []
-        # Simple check to ensure we support this luis data schema version
-        version = int(js["luis_schema_version"][0])
 
+        # Simple check to ensure we support this luis data schema
+        if not ("regex_features" in js
+        and "utterances" in js
+        and "text" in js["utterances"][0]
+        and "intent" in js["utterances"][0]
+        and "entities" in js["utterances"][0]):
+            raise Exception(
+                "Invalid LUIS data schema structure."
+                "Your file is not supported."
+            )
+
+        version = int(js["luis_schema_version"][0])
         if version > 5:
             warnings.warn(
                 "Your luis data schema version {} "

--- a/rasa/nlu/training_data/formats/luis.py
+++ b/rasa/nlu/training_data/formats/luis.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+import warnings
 from typing import Any, Dict, Text
 
 from rasa.nlu.training_data.formats.readerwriter import JsonTrainingDataReader
@@ -21,11 +22,10 @@ class LuisReader(JsonTrainingDataReader):
         version = int(js["luis_schema_version"][0])
 
         if version > 5:
-            raise Exception(
-                "Invalid luis data schema version {}, "
-                "should be 2.x.x or 3.x.x."
-                "Make sure to use one of those versions"
-                "(e.g. by downloading your data again)."
+            warnings.warn(
+                "Your luis data schema version {} "
+                "is higher than 5.x.x. "
+                "Traning may not be performed correctly. "
                 "".format(js["luis_schema_version"])
             )
 

--- a/rasa/nlu/training_data/formats/luis.py
+++ b/rasa/nlu/training_data/formats/luis.py
@@ -17,13 +17,14 @@ class LuisReader(JsonTrainingDataReader):
 
         training_examples = []
         regex_features = []
-
         # Simple check to ensure we support this luis data schema version
-        if not js["luis_schema_version"].startswith("2"):
+        version = int(js["luis_schema_version"][0])
+
+        if version > 5:
             raise Exception(
                 "Invalid luis data schema version {}, "
-                "should be 2.x.x. "
-                "Make sure to use the latest luis version "
+                "should be 2.x.x or 3.x.x."
+                "Make sure to use one of those versions"
                 "(e.g. by downloading your data again)."
                 "".format(js["luis_schema_version"])
             )

--- a/rasa/nlu/training_data/formats/luis.py
+++ b/rasa/nlu/training_data/formats/luis.py
@@ -20,14 +20,15 @@ class LuisReader(JsonTrainingDataReader):
         regex_features = []
 
         # Simple check to ensure we support this luis data schema
-        if not ("regex_features" in js
-        and "utterances" in js
-        and "text" in js["utterances"][0]
-        and "intent" in js["utterances"][0]
-        and "entities" in js["utterances"][0]):
+        if not (
+            "regex_features" in js
+            and "utterances" in js
+            and "text" in js["utterances"][0]
+            and "intent" in js["utterances"][0]
+            and "entities" in js["utterances"][0]
+        ):
             raise Exception(
-                "Invalid LUIS data schema structure."
-                "Your file is not supported."
+                "Invalid LUIS data schema structure." "Your file is not supported."
             )
 
         version = int(js["luis_schema_version"][0])


### PR DESCRIPTION
**Proposed changes**:
- Allow Rasa to be trained by Luis scheme with version higher than 5.
- Validating the presence of utters, intents and entities in Luis schema.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
