### PR TITLE
remove numpy deprecation errors when installed from pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ jobs:
   - stage: test
     name: "Test Docs"
     install:
+    - pip install -r requirements.txt
     - pip install -r requirements-docs.txt
     - pip install -e .[sql]
     - pip list
@@ -72,6 +73,7 @@ jobs:
     - RASABASTER=rasabaster-0.7.23.tar.gz
     - curl -sSL -o $RASABASTER "https://storage.googleapis.com/docs-theme/${RASABASTER}?q=$(date +%s%N)"
     - pip install $RASABASTER
+    - pip install -r requirements.txt
     - pip install --no-cache-dir -r requirements-docs.txt
     - pip install git+https://${GITHUB_TOKEN}:x-oauth-basic@github.com/RasaHQ/sphinxcontrib-versioning.git@version_list
     - pip install -e .

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Removed
 Fixed
 -----
 - Fixed exporting NLU training data in ``json`` format from ``rasa interactive``
+- Fixed numpy deprecation warnings showing in ``rasa`` installed with ``pip``
 
 [1.4.3] - 2019-10-29
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 -------
 - updated mattermost connector documentation to be more clear.
 - Updated format strings to f-strings where appropriate.
+- Updated tensorflow requirement to ``1.15.0``
 
 Removed
 -------
@@ -24,7 +25,7 @@ Removed
 Fixed
 -----
 - Fixed exporting NLU training data in ``json`` format from ``rasa interactive``
-- Fixed numpy deprecation warnings showing in ``rasa`` installed with ``pip``
+- Fixed numpy deprecation warnings
 
 [1.4.3] - 2019-10-29
 ^^^^^^^^^^^^^^^^^^^^

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ redis==3.3.5
 pymongo[tls,srv]==3.8.0
 numpy==1.16.3
 scipy==1.2.1
-tensorflow==1.14.0
+tensorflow==1.15.0
 absl-py>=0.8.0
 # setuptools comes from tensorboard requirement:
 # https://github.com/tensorflow/tensorboard/blob/1.14/tensorboard/pip_package/setup.py#L33

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     "pymongo[tls,srv]~=3.8",
     "numpy~=1.16",
     "scipy~=1.2",
-    "tensorflow~=1.14.0",
+    "tensorflow~=1.15.0",
     # absl is a tensorflow dependency, but produces double logging before 0.8
     # should be removed once tensorflow requires absl > 0.8 on its own
     "absl-py>=0.8.0",


### PR DESCRIPTION
**Proposed changes**:
- up tensorflow requirement to avoid numpy deprecation errors
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
