### PR TITLE
recognise e2e format when intent restated as /intent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 -----
 - Fixed exporting NLU training data in ``json`` format from ``rasa interactive``
 - Fixed numpy deprecation warnings
+- Fixed format guessing for e2e stories with intent restated as /intent
 
 [1.4.3] - 2019-10-29
 ^^^^^^^^^^^^^^^^^^^^

--- a/data/test_evaluations/end_to_end_story.md
+++ b/data/test_evaluations/end_to_end_story.md
@@ -25,3 +25,7 @@
  - utter_ack_dosearch
  - action_search_restaurants
  - action_suggest
+
+## story_with_intent_restated
+* greet: /greet
+ - utter_ask_howcanhelp

--- a/rasa/nlu/training_data/loading.py
+++ b/rasa/nlu/training_data/loading.py
@@ -51,7 +51,7 @@ _json_format_heuristics = {
 # ##
 # * intent/response_key
 #   - response_text
-_nlg_markdown_marker_regex = re.compile(r"##\s*.*\n\*.*\/.*\n\s*\t*\-.*")
+_nlg_markdown_marker_regex = re.compile(r"##\s*.*\n\*.*(?<!: )\/.*\n\s*\t*\-.*")
 
 
 def load_data(resource_name: Text, language: Optional[Text] = "en") -> "TrainingData":

--- a/rasa/nlu/training_data/loading.py
+++ b/rasa/nlu/training_data/loading.py
@@ -51,7 +51,7 @@ _json_format_heuristics = {
 # ##
 # * intent/response_key
 #   - response_text
-_nlg_markdown_marker_regex = re.compile(r"##\s*.*\n\*.*(?<!: )\/.*\n\s*\t*\-.*")
+_nlg_markdown_marker_regex = re.compile(r"##\s*.*\n\*[^:]*\/.*\n\s*\t*\-.*")
 
 
 def load_data(resource_name: Text, language: Optional[Text] = "en") -> "TrainingData":

--- a/tests/core/test_evaluation.py
+++ b/tests/core/test_evaluation.py
@@ -62,6 +62,8 @@ async def test_end_to_end_evaluation_script(tmpdir, restaurantbot):
         "action_search_restaurants",
         "action_suggest",
         "action_listen",
+        "utter_ask_howcanhelp",
+        "action_listen",
         "greet",
         "greet",
         "inform",
@@ -71,6 +73,7 @@ async def test_end_to_end_evaluation_script(tmpdir, restaurantbot):
         "inform",
         "inform",
         "deny",
+        "greet",
         "[moderately](price:moderate)",
         "[east](location)",
         "[french](cuisine)",
@@ -84,7 +87,7 @@ async def test_end_to_end_evaluation_script(tmpdir, restaurantbot):
     assert story_evaluation.evaluation_store.serialise()[0] == serialised_store
     assert not story_evaluation.evaluation_store.has_prediction_target_mismatch()
     assert len(story_evaluation.failed_stories) == 0
-    assert num_stories == 3
+    assert num_stories == 4
 
 
 async def test_end_to_end_evaluation_script_unknown_entity(tmpdir, default_agent):


### PR DESCRIPTION
**Proposed changes**:
- modify retrieval action story regex to exclude matching e2e stories
- closes #4520 
@wochinge 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
