### PR TITLE
fix missing tensorflow version in dockerfiles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Removed
 
 Fixed
 -----
+- Fixed bug that stopped Dockerfiles from building version 1.4.4.
+
 
 [1.4.4] - 2019-11-13
 ^^^^^^^^^^^^^^^^^^^^

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY MANIFEST.in .
 COPY requirements.txt .
 
 # Install Rasa and its dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
 
 # Install Rasa as package
 COPY rasa ./rasa

--- a/docker/Dockerfile_full
+++ b/docker/Dockerfile_full
@@ -38,6 +38,9 @@ RUN apt-get update -qq \
     libffi-dev \
     libpng-dev
 
+# Make sure we have the latest pip version
+RUN pip install -U pip
+
 # Download mitie model
 RUN wget -P /app/data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
 

--- a/docker/Dockerfile_pretrained_embeddings_mitie_en
+++ b/docker/Dockerfile_pretrained_embeddings_mitie_en
@@ -38,6 +38,9 @@ RUN apt-get update -qq \
     libffi-dev \
     libpng-dev
 
+# Make sure we have the latest pip version
+RUN pip install -U pip
+
 # Download mitie model
 RUN wget -P /app/data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
 

--- a/docker/Dockerfile_pretrained_embeddings_spacy_de
+++ b/docker/Dockerfile_pretrained_embeddings_spacy_de
@@ -38,6 +38,9 @@ RUN apt-get update -qq \
     libffi-dev \
     libpng-dev
 
+# Make sure we have the latest pip version
+RUN pip install -U pip
+
 # Install spacy model
 RUN pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.1.0/de_core_news_sm-2.1.0.tar.gz#egg=de_core_news_sm==2.1.0 --no-cache-dir > /dev/null \
     && python -m spacy link de_core_news_sm de

--- a/docker/Dockerfile_pretrained_embeddings_spacy_en
+++ b/docker/Dockerfile_pretrained_embeddings_spacy_en
@@ -38,6 +38,9 @@ RUN apt-get update -qq \
     libffi-dev \
     libpng-dev
 
+# Make sure we have the latest pip version
+RUN pip install -U pip
+
 # Install spacy model
 RUN pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.1.0/en_core_web_md-2.1.0.tar.gz#egg=en_core_web_md==2.1.0 --no-cache-dir > /dev/null \
     && python -m spacy link en_core_web_md en


### PR DESCRIPTION
**Proposed changes**:
- make sure pip is updated to the latest version in our dockerfiles. fixes https://hub.docker.com/repository/registry-1.docker.io/rasa/rasa/builds/82494013-fba4-4ff4-8861-8178c4ec52be
```
Could not find a version that satisfies the requirement tensorflow==1.15.0 (from -r requirements.txt (line 11)) (from versions: 0.12.1, 1.0.0, 1.0.1, 1.1.0rc0, 1.1.0rc1, 1.1.0rc2, 1.1.0, 1.2.0rc0, 1.2.0rc1, 1.2.0rc2, 1.2.0, 1.2.1, 1.3.0rc0, 1.3.0rc1, 1.3.0rc2, 1.3.0, 1.4.0rc0, 1.4.0rc1, 1.4.0, 1.4.1, 1.5.0rc0, 1.5.0rc1, 1.5.0, 1.5.1, 1.6.0rc0, 1.6.0rc1, 1.6.0, 1.7.0rc0, 1.7.0rc1, 1.7.0, 1.7.1, 1.8.0rc0, 1.8.0rc1, 1.8.0, 1.9.0rc0, 1.9.0rc1, 1.9.0rc2, 1.9.0, 1.10.0rc0, 1.10.0rc1, 1.10.0, 1.10.1, 1.11.0rc0, 1.11.0rc1, 1.11.0rc2, 1.11.0, 1.12.0rc0, 1.12.0rc1, 1.12.0rc2, 1.12.0, 1.12.2, 1.12.3, 1.13.0rc0, 1.13.0rc1, 1.13.0rc2, 1.13.1, 1.13.2, 1.14.0rc0, 1.14.0rc1, 1.14.0, 2.0.0a0, 2.0.0b0, 2.0.0b1)
No matching distribution found for tensorflow==1.15.0 (from -r requirements.txt (line 11))
You are using pip version 18.1, however version 19.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
