### PR TITLE
Fix Rasa X (local) not working when any tracker store was configured for Rasa

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Removed
 
 Fixed
 -----
+- Fixed Rasa X not working when any tracker store was configured for Rasa.
 
 [1.4.5] - 2019-11-14
 ^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +31,6 @@ Fixed
 - NLU-only models no longer throw warnings about parsing features not defined in the domain
 - Fixed bug that stopped Dockerfiles from building version 1.4.4.
 - Fixed format guessing for e2e stories with intent restated as ``/intent``
-- Fixed Rasa X not working when any tracker store was configured for Rasa.
 
 [1.4.4] - 2019-11-13
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Fixed
 - NLU-only models no longer throw warnings about parsing features not defined in the domain
 - Fixed bug that stopped Dockerfiles from building version 1.4.4.
 - Fixed format guessing for e2e stories with intent restated as ``/intent``
+- Fixed Rasa X not working when any tracker store was configured for Rasa.
 
 [1.4.4] - 2019-11-13
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -118,7 +118,6 @@ def _overwrite_endpoints_for_local_x(
         wait_time_between_pulls=2,
     )
 
-    overwrite_existing_event_broker = False
     if endpoints.event_broker and not _is_correct_event_broker(endpoints.event_broker):
         cli_utils.print_error(
             "Rasa X currently only supports a SQLite event broker with path '{}' "
@@ -133,8 +132,9 @@ def _overwrite_endpoints_for_local_x(
         if not overwrite_existing_event_broker:
             exit(0)
 
-    if not endpoints.tracker_store or overwrite_existing_event_broker:
-        endpoints.event_broker = EndpointConfig(type="sql", db=DEFAULT_EVENTS_DB)
+    endpoints.event_broker = EndpointConfig(
+        type="sql", db=DEFAULT_EVENTS_DB, dialect="sqlite"
+    )
 
 
 def _is_correct_event_broker(event_broker: EndpointConfig) -> bool:


### PR DESCRIPTION
**Proposed changes**:
When starting Rasa X with `rasa x`, the event broker must be correctly configured to use SQLite pointing to an `events.db` file. However, a bug is preventing this event broker to be setup correctly if the user has configured any tracker store in their `endpoints.yml` file. The configuration for the tracker store and event broker should be completely independent. The problem was introduced [here](https://github.com/RasaHQ/rasa/commit/1bad671b3223041872410b6728d7c4d06c9561d5#diff-105c8c88bfadbf18d0c93ae0defa0da5R133).

This PR fixes the problem by unconditionally overwriting the event broker config when using Rasa X in local mode. If the user had configured an event broker, they will be prompted to check if they are OK with another event broker being used.

cc @btotharye 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
