### PR TITLE
Improve warnings: use color and sane defaults

### DIFF
--- a/changelog/4780.misc.rst
+++ b/changelog/4780.misc.rst
@@ -1,0 +1,3 @@
+Colored warning messages. All warnings are now a bit easier to find since they are
+yellow. Where it makes sense, we also added links to the documentation to help you
+fix the warning.

--- a/data/test_domains/default_with_slots_and_no_actions.yml
+++ b/data/test_domains/default_with_slots_and_no_actions.yml
@@ -18,7 +18,7 @@ slots:
   name:
     type: text
 
-templates:
+responses:
   utter_greet:
     - text: "hey there {name}!"  # {name} will be filled by slot (same name) or by custom action
   utter_channel:

--- a/rasa/cli/utils.py
+++ b/rasa/cli/utils.py
@@ -1,9 +1,8 @@
-import os
-import warnings
-import sys
 import json
-from typing import Any, Optional, Text, List, Dict, TYPE_CHECKING
 import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Text
 
 if TYPE_CHECKING:
     from questionary import Question
@@ -42,8 +41,11 @@ def get_validated_path(
             if current is None:
                 reason_str = f"Parameter '{parameter}' not set."
             else:
-                warnings.warn(
-                    f"'{current}' does not exist. Using default value '{default}' instead."
+                from rasa.utils.common import raise_warning  # avoid import cycle
+
+                raise_warning(
+                    f"The path '{current}' does not seem to exist. Using the "
+                    f"default value '{default}' instead."
                 )
 
             logger.debug(f"{reason_str} Using default location '{default}' instead.")

--- a/rasa/constants.py
+++ b/rasa/constants.py
@@ -27,6 +27,16 @@ DEFAULT_RASA_X_PORT = 5002
 DEFAULT_RASA_PORT = 5005
 
 DOCS_BASE_URL = "https://rasa.com/docs/rasa"
+DOCS_URL_POLICIES = DOCS_BASE_URL + "/core/policies/"
+DOCS_URL_DOMAINS = DOCS_BASE_URL + "/core/domains/"
+DOCS_URL_STORIES = DOCS_BASE_URL + "/core/stories/"
+DOCS_URL_ACTIONS = DOCS_BASE_URL + "/core/actions/"
+DOCS_URL_EVENT_BROKERS = DOCS_BASE_URL + "/api/event-brokers/"
+DOCS_URL_PIPELINE = DOCS_BASE_URL + "/nlu/choosing-a-pipeline/"
+DOCS_URL_COMPONENTS = DOCS_BASE_URL + "/nlu/components/"
+DOCS_URL_TRAINING_DATA_NLU = DOCS_BASE_URL + "/nlu/training-data-format/"
+DOCS_URL_MIGRATE_GOOGLE = DOCS_BASE_URL + "/migrate-from/google-dialogflow-to-rasa/"
+
 LEGACY_DOCS_BASE_URL = "http://legacy-docs.rasa.com"
 
 CONFIG_MANDATORY_KEYS_CORE = ["policies"]

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -95,7 +95,7 @@ def combine_user_with_default_actions(user_actions: List[Text]) -> List[Text]:
 def combine_with_templates(
     actions: List[Text], templates: Dict[Text, Any]
 ) -> List[Text]:
-    """Combines actions with utter actions listed in templates section"""
+    """Combines actions with utter actions listed in responses section."""
     unique_template_names = [a for a in list(templates.keys()) if a not in actions]
     return actions + unique_template_names
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -46,7 +46,7 @@ from rasa.model import (
     get_model,
 )
 from rasa.nlu.utils import is_url
-from rasa.utils.common import update_sanic_log_level
+from rasa.utils.common import raise_warning, update_sanic_log_level
 from rasa.utils.endpoints import EndpointConfig
 
 logger = logging.getLogger(__name__)
@@ -273,7 +273,7 @@ async def load_agent(
             )
 
         else:
-            warnings.warn("No valid configuration given to load agent.")
+            raise_warning("No valid configuration given to load agent.")
             return None
 
     except Exception as e:
@@ -463,7 +463,7 @@ class Agent:
         """Handle a single message."""
 
         if not isinstance(message, UserMessage):
-            warnings.warn(
+            raise_warning(
                 "Passing a text to `agent.handle_message(...)` is "
                 "deprecated. Rather use `agent.handle_text(...)`.",
                 DeprecationWarning,
@@ -593,8 +593,8 @@ class Agent:
     def continue_training(
         self, trackers: List[DialogueStateTracker], **kwargs: Any
     ) -> None:
-        warnings.warn(
-            "Continue training will be removed in the next release. It won't be "
+        raise_warning(
+            "Continue training will be removed in the 2.0 release. It won't be "
             "possible to continue the training, you should probably retrain instead.",
             FutureWarning,
         )
@@ -651,7 +651,7 @@ class Agent:
                 unique_last_num_states = max_history
         elif unique_last_num_states < max_history:
             # possibility of data loss
-            warnings.warn(
+            raise_warning(
                 f"unique_last_num_states={unique_last_num_states} but "
                 f"maximum max_history={max_history}. "
                 f"Possibility of data loss. "
@@ -733,7 +733,7 @@ class Agent:
 
         from rasa.core import run
 
-        warnings.warn(
+        raise_warning(
             "Using `handle_channels` is deprecated. "
             "Please use `rasa.run(...)` or see "
             "`rasa.core.run.configure_app(...)` if you want to implement "
@@ -798,9 +798,9 @@ class Agent:
         """Persists this agent into a directory for later loading and usage."""
 
         if dump_flattened_stories:
-            warnings.warn(
+            raise_warning(
                 "The `dump_flattened_stories` argument will be removed from "
-                "`Agent.persist` in the next release. Please dump your "
+                "`Agent.persist` in the 2.0 release. Please dump your "
                 "training data separately if you need it to be part of the model.",
                 FutureWarning,
             )
@@ -943,7 +943,7 @@ class Agent:
             model_archive = get_latest_model(model_path)
 
         if model_archive is None:
-            warnings.warn(f"Could not load local model in '{model_path}'.")
+            raise_warning(f"Could not load local model in '{model_path}'.")
             return Agent()
 
         working_directory = tempfile.mkdtemp()

--- a/rasa/core/brokers/event_channel.py
+++ b/rasa/core/brokers/event_channel.py
@@ -4,8 +4,11 @@ from rasa.core.brokers.broker import EventBroker
 
 
 # noinspection PyAbstractClass
+from rasa.utils.common import raise_warning
+
+
 class EventChannel(EventBroker):
-    warnings.warn(
+    raise_warning(
         "The `EventChannel` class is deprecated, please inherit from "
         "`EventBroker` instead. `EventChannel` will be removed "
         "in future Rasa versions.",

--- a/rasa/core/brokers/file_producer.py
+++ b/rasa/core/brokers/file_producer.py
@@ -1,13 +1,14 @@
 import warnings
 
 from rasa.core.brokers.file import FileEventBroker
+from rasa.utils.common import raise_warning
 
 
 class FileProducer(FileEventBroker):
-    warnings.warn(
+    raise_warning(
         "The `FileProducer` class is deprecated, please inherit from "
         "`FileEventBroker` instead. `FileProducer` will be removed in "
         "future Rasa versions.",
-        DeprecationWarning,
-        stacklevel=2,
+        FutureWarning,
+        docs="/api/event-brokers/",
     )

--- a/rasa/core/brokers/file_producer.py
+++ b/rasa/core/brokers/file_producer.py
@@ -1,5 +1,6 @@
 import warnings
 
+from rasa.constants import DOCS_URL_EVENT_BROKERS
 from rasa.core.brokers.file import FileEventBroker
 from rasa.utils.common import raise_warning
 
@@ -10,5 +11,5 @@ class FileProducer(FileEventBroker):
         "`FileEventBroker` instead. `FileProducer` will be removed in "
         "future Rasa versions.",
         FutureWarning,
-        docs="/api/event-brokers/",
+        docs=DOCS_URL_EVENT_BROKERS,
     )

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -98,7 +98,8 @@ class KafkaProducer(KafkaEventBroker):
             "The `KafkaProducer` class is deprecated, please inherit "
             "from `KafkaEventBroker` instead. `KafkaProducer` will be "
             "removed in future Rasa versions.",
-            DeprecationWarning,
+            FutureWarning,
+            docs="/api/event-brokers/",
         )
 
         super(KafkaProducer, self).__init__(

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -3,6 +3,7 @@ import logging
 import warnings
 from typing import Optional
 
+from rasa.constants import DOCS_URL_EVENT_BROKERS
 from rasa.core.brokers.broker import EventBroker
 from rasa.utils.common import raise_warning
 from rasa.utils.io import DEFAULT_ENCODING
@@ -99,7 +100,7 @@ class KafkaProducer(KafkaEventBroker):
             "from `KafkaEventBroker` instead. `KafkaProducer` will be "
             "removed in future Rasa versions.",
             FutureWarning,
-            docs="/api/event-brokers/",
+            docs=DOCS_URL_EVENT_BROKERS,
         )
 
         super(KafkaProducer, self).__init__(

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Optional
 
 from rasa.core.brokers.broker import EventBroker
+from rasa.utils.common import raise_warning
 from rasa.utils.io import DEFAULT_ENCODING
 
 logger = logging.getLogger(__name__)
@@ -93,12 +94,11 @@ class KafkaProducer(KafkaEventBroker):
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
     ) -> None:
-        warnings.warn(
+        raise_warning(
             "The `KafkaProducer` class is deprecated, please inherit "
             "from `KafkaEventBroker` instead. `KafkaProducer` will be "
             "removed in future Rasa versions.",
             DeprecationWarning,
-            stacklevel=2,
         )
 
         super(KafkaProducer, self).__init__(

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -7,7 +7,11 @@ from collections import deque
 from threading import Thread
 from typing import Callable, Deque, Dict, Optional, Text, Union
 
-from rasa.constants import DEFAULT_LOG_LEVEL_LIBRARIES, ENV_LOG_LEVEL_LIBRARIES
+from rasa.constants import (
+    DEFAULT_LOG_LEVEL_LIBRARIES,
+    ENV_LOG_LEVEL_LIBRARIES,
+    DOCS_URL_EVENT_BROKERS,
+)
 from rasa.core.brokers.broker import EventBroker
 from rasa.utils.common import raise_warning
 from rasa.utils.endpoints import EndpointConfig
@@ -423,7 +427,7 @@ class PikaProducer(PikaEventBroker):
             "from `PikaEventBroker` instead. `PikaProducer` will be "
             "removed in future Rasa versions.",
             FutureWarning,
-            docs="/api/event-brokers/",
+            docs=DOCS_URL_EVENT_BROKERS,
         )
         super(PikaProducer, self).__init__(
             host, username, password, port, queue, loglevel

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -422,7 +422,8 @@ class PikaProducer(PikaEventBroker):
             "The `PikaProducer` class is deprecated, please inherit "
             "from `PikaEventBroker` instead. `PikaProducer` will be "
             "removed in future Rasa versions.",
-            DeprecationWarning,
+            FutureWarning,
+            docs="/api/event-brokers/",
         )
         super(PikaProducer, self).__init__(
             host, username, password, port, queue, loglevel

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -1,16 +1,15 @@
 import json
 import logging
-import typing
 import os
-import warnings
+import time
+import typing
 from collections import deque
 from threading import Thread
-from typing import Dict, Optional, Text, Union, Deque, Callable
+from typing import Callable, Deque, Dict, Optional, Text, Union
 
-import time
-
-from rasa.constants import ENV_LOG_LEVEL_LIBRARIES, DEFAULT_LOG_LEVEL_LIBRARIES
+from rasa.constants import DEFAULT_LOG_LEVEL_LIBRARIES, ENV_LOG_LEVEL_LIBRARIES
 from rasa.core.brokers.broker import EventBroker
+from rasa.utils.common import raise_warning
 from rasa.utils.endpoints import EndpointConfig
 from rasa.utils.io import DEFAULT_ENCODING
 
@@ -419,12 +418,11 @@ class PikaProducer(PikaEventBroker):
             ENV_LOG_LEVEL_LIBRARIES, DEFAULT_LOG_LEVEL_LIBRARIES
         ),
     ):
-        warnings.warn(
+        raise_warning(
             "The `PikaProducer` class is deprecated, please inherit "
             "from `PikaEventBroker` instead. `PikaProducer` will be "
             "removed in future Rasa versions.",
             DeprecationWarning,
-            stacklevel=2,
         )
         super(PikaProducer, self).__init__(
             host, username, password, port, queue, loglevel

--- a/rasa/core/brokers/sql.py
+++ b/rasa/core/brokers/sql.py
@@ -89,6 +89,7 @@ class SQLProducer(SQLEventBroker):
             "The `SQLProducer` class is deprecated, please inherit "
             "from `SQLEventBroker` instead. `SQLProducer` will be "
             "removed in future Rasa versions.",
-            DeprecationWarning,
+            FutureWarning,
+            docs="/api/event-brokers/",
         )
         super(SQLProducer, self).__init__(dialect, host, port, db, username, password)

--- a/rasa/core/brokers/sql.py
+++ b/rasa/core/brokers/sql.py
@@ -1,11 +1,11 @@
+import contextlib
 import json
 import logging
-import warnings
 from typing import Any, Dict, Optional, Text
 
 from rasa.core.brokers.broker import EventBroker
+from rasa.utils.common import raise_warning
 from rasa.utils.endpoints import EndpointConfig
-import contextlib
 
 logger = logging.getLogger(__name__)
 
@@ -85,11 +85,10 @@ class SQLProducer(SQLEventBroker):
         username: Optional[Text] = None,
         password: Optional[Text] = None,
     ):
-        warnings.warn(
+        raise_warning(
             "The `SQLProducer` class is deprecated, please inherit "
             "from `SQLEventBroker` instead. `SQLProducer` will be "
             "removed in future Rasa versions.",
             DeprecationWarning,
-            stacklevel=2,
         )
         super(SQLProducer, self).__init__(dialect, host, port, db, username, password)

--- a/rasa/core/brokers/sql.py
+++ b/rasa/core/brokers/sql.py
@@ -3,6 +3,7 @@ import json
 import logging
 from typing import Any, Dict, Optional, Text
 
+from rasa.constants import DOCS_URL_EVENT_BROKERS
 from rasa.core.brokers.broker import EventBroker
 from rasa.utils.common import raise_warning
 from rasa.utils.endpoints import EndpointConfig
@@ -90,6 +91,6 @@ class SQLProducer(SQLEventBroker):
             "from `SQLEventBroker` instead. `SQLProducer` will be "
             "removed in future Rasa versions.",
             FutureWarning,
-            docs="/api/event-brokers/",
+            docs=DOCS_URL_EVENT_BROKERS,
         )
         super(SQLProducer, self).__init__(dialect, host, port, db, username, password)

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -6,6 +6,7 @@ from fbmessenger import MessengerClient
 from fbmessenger.attachments import Image
 from fbmessenger.elements import Text as FBText
 from fbmessenger.quick_replies import QuickReplies, QuickReply
+from rasa.utils.common import raise_warning
 from sanic import Blueprint, response
 from sanic.request import Request
 from typing import Text, List, Dict, Any, Callable, Awaitable, Iterable, Optional
@@ -169,7 +170,7 @@ class MessengerBot(OutputChannel):
 
         # buttons is a list of tuples: [(option_name,payload)]
         if len(buttons) > 3:
-            warnings.warn(
+            raise_warning(
                 "Facebook API currently allows only up to 3 buttons. "
                 "If you add more, all will be ignored."
             )

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -1,15 +1,14 @@
 import json
-import warnings
 import logging
 import re
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Text
+
+from rasa.core.channels.channel import InputChannel, OutputChannel, UserMessage
+from rasa.utils.common import raise_warning
 from sanic import Blueprint, response
 from sanic.request import Request
 from sanic.response import HTTPResponse
 from slackclient import SlackClient
-from typing import Text, Optional, List, Dict, Any, Callable, Awaitable
-
-from rasa.core.channels.channel import InputChannel
-from rasa.core.channels.channel import UserMessage, OutputChannel
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +79,9 @@ class SlackBot(SlackClient, OutputChannel):
         text_block = {"type": "section", "text": {"type": "plain_text", "text": text}}
 
         if len(buttons) > 5:
-            warnings.warn(
+            raise_warning(
                 "Slack API currently allows only up to 5 buttons. "
-                "If you add more, all will be ignored."
+                "Since you added more than 5, slack will ignore all of them."
             )
             return await self.send_text_message(recipient, text, **kwargs)
 

--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -1,14 +1,13 @@
 import logging
-import warnings
 import uuid
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Text
+
+from rasa.core.channels.channel import InputChannel, OutputChannel, UserMessage
+from rasa.utils.common import raise_warning
 from sanic import Blueprint, response
 from sanic.request import Request
 from sanic.response import HTTPResponse
 from socketio import AsyncServer
-from typing import Optional, Text, Any, List, Dict, Iterable, Callable, Awaitable
-
-from rasa.core.channels.channel import InputChannel
-from rasa.core.channels.channel import UserMessage, OutputChannel
 
 logger = logging.getLogger(__name__)
 
@@ -176,8 +175,8 @@ class SocketIOInput(InputChannel):
 
             if self.session_persistence:
                 if not data.get("session_id"):
-                    warnings.warn(
-                        "A message without a valid sender_id "
+                    raise_warning(
+                        "A message without a valid session_id "
                         "was received. This message will be "
                         "ignored. Make sure to set a proper "
                         "session id using the "

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -1,31 +1,35 @@
 import collections
-import warnings
 import json
 import logging
 import os
 import typing
+import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Text, Tuple, Union, Set, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Text, Tuple, Union
 
 import rasa.core.constants
-import rasa.utils.common as common_utils
+from rasa.utils.common import (
+    raise_warning,
+    lazy_property,
+    sort_list_of_dicts_by_first_key,
+)
 import rasa.utils.io
-from rasa.cli.utils import bcolors
-from rasa.constants import DOMAIN_SCHEMA_FILE, DEFAULT_CARRY_OVER_SLOTS_TO_NEW_SESSION
+from rasa.cli.utils import bcolors, wrap_with_color
+from rasa.constants import DEFAULT_CARRY_OVER_SLOTS_TO_NEW_SESSION, DOMAIN_SCHEMA_FILE
 from rasa.core import utils
 from rasa.core.actions import action  # pytype: disable=pyi-error
 from rasa.core.actions.action import Action  # pytype: disable=pyi-error
 from rasa.core.constants import (
-    REQUESTED_SLOT,
     DEFAULT_KNOWLEDGE_BASE_ACTION,
-    SLOT_LISTED_ITEMS,
-    SLOT_LAST_OBJECT_TYPE,
+    REQUESTED_SLOT,
     SLOT_LAST_OBJECT,
+    SLOT_LAST_OBJECT_TYPE,
+    SLOT_LISTED_ITEMS,
 )
 from rasa.core.events import SlotSet, UserUttered
 from rasa.core.slots import Slot, UnfeaturizedSlot
 from rasa.utils.endpoints import EndpointConfig
-from rasa.utils.validation import validate_yaml_schema, InvalidYamlFileError
+from rasa.utils.validation import InvalidYamlFileError, validate_yaml_schema
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +52,7 @@ class InvalidDomain(Exception):
 
     def __str__(self):
         # return message in error colours
-        return bcolors.FAIL + self.message + bcolors.ENDC
+        return wrap_with_color(self.message, color=bcolors.FAIL)
 
 
 class SessionConfig(NamedTuple):
@@ -125,9 +129,13 @@ class Domain:
     def from_dict(cls, data: Dict) -> "Domain":
         utter_templates = cls.collect_templates(data.get("responses", {}))
         if "templates" in data:
-            warnings.warn(
-                "Your domain file contains the key: 'templates'. This has been deprecated and renamed to 'responses'. The 'templates' key will no longer work in future versions of Rasa. Please replace 'templates' with 'responses'",
+            raise_warning(
+                "Your domain file contains the key: 'templates'. This has been "
+                "deprecated and renamed to 'responses'. The 'templates' key will "
+                "no longer work in future versions of Rasa. Please replace "
+                "'templates' with 'responses'",
                 FutureWarning,
+                docs="/core/domains/",
             )
             utter_templates = cls.collect_templates(data.get("templates", {}))
 
@@ -153,12 +161,13 @@ class Domain:
 
         # TODO: 2.0 reconsider how to apply sessions to old projects and legacy trackers
         if session_expiration_time is None:
-            warnings.warn(
+            raise_warning(
                 "No tracker session configuration was found in the loaded domain. "
                 "Domains without a session config will automatically receive a "
                 "session expiration time of 60 minutes in Rasa version 2.0 if not "
                 "configured otherwise.",
                 FutureWarning,
+                docs="/core/domains/#session-configuration",
             )
             session_expiration_time = 0
 
@@ -300,11 +309,13 @@ class Domain:
 
                 # templates should be a dict with options
                 if isinstance(t, str):
-                    warnings.warn(
+                    raise_warning(
                         f"Templates should not be strings anymore. "
-                        f"Utterance template '{template_key}' should contain either '- text: ' or "
-                        f"'- custom: ' attribute to be a proper template.",
+                        f"Utterance template '{template_key}' should contain "
+                        f"either a '- text: ' or a '- custom: ' "
+                        f"attribute to be a proper template.",
                         FutureWarning,
+                        docs="/core/domains/#utterance-templates",
                     )
                     validated_variations.append({"text": t})
                 elif "text" not in t and "custom" not in t:
@@ -350,7 +361,6 @@ class Domain:
         self._check_domain_sanity()
 
     def __hash__(self) -> int:
-        from rasa.utils.common import sort_list_of_dicts_by_first_key
 
         self_as_dict = self.as_dict()
         self_as_dict["intents"] = sort_list_of_dicts_by_first_key(
@@ -361,20 +371,20 @@ class Domain:
 
         return int(text_hash, 16)
 
-    @common_utils.lazy_property
+    @lazy_property
     def user_actions_and_forms(self):
         """Returns combination of user actions and forms"""
 
         return self.user_actions + self.form_names
 
-    @common_utils.lazy_property
+    @lazy_property
     def num_actions(self):
         """Returns the number of available actions."""
 
         # noinspection PyTypeChecker
         return len(self.action_names)
 
-    @common_utils.lazy_property
+    @lazy_property
     def num_states(self):
         """Number of used input states for the action prediction."""
 
@@ -473,7 +483,7 @@ class Domain:
             return None
 
     # noinspection PyTypeChecker
-    @common_utils.lazy_property
+    @lazy_property
     def slot_states(self) -> List[Text]:
         """Returns all available slot state strings."""
 
@@ -484,28 +494,28 @@ class Domain:
         ]
 
     # noinspection PyTypeChecker
-    @common_utils.lazy_property
+    @lazy_property
     def prev_action_states(self) -> List[Text]:
         """Returns all available previous action state strings."""
 
         return [PREV_PREFIX + a for a in self.action_names]
 
     # noinspection PyTypeChecker
-    @common_utils.lazy_property
+    @lazy_property
     def intent_states(self) -> List[Text]:
         """Returns all available previous action state strings."""
 
         return [f"intent_{i}" for i in self.intents]
 
     # noinspection PyTypeChecker
-    @common_utils.lazy_property
+    @lazy_property
     def entity_states(self) -> List[Text]:
         """Returns all available previous action state strings."""
 
         return [f"entity_{e}" for e in self.entities]
 
     # noinspection PyTypeChecker
-    @common_utils.lazy_property
+    @lazy_property
     def form_states(self) -> List[Text]:
         return [f"active_form_{f}" for f in self.form_names]
 
@@ -514,12 +524,12 @@ class Domain:
 
         return self.input_state_map.get(state_name)
 
-    @common_utils.lazy_property
+    @lazy_property
     def input_state_map(self) -> Dict[Text, int]:
         """Provides a mapping from state names to indices."""
         return {f: i for i, f in enumerate(self.input_states)}
 
-    @common_utils.lazy_property
+    @lazy_property
     def input_states(self) -> List[Text]:
         """Returns all available states."""
 
@@ -588,11 +598,12 @@ class Domain:
         explicitly_included = isinstance(include, list)
         ambiguous_entities = included_entities.intersection(excluded_entities)
         if explicitly_included and ambiguous_entities:
-            warnings.warn(
+            raise_warning(
                 f"Entities: '{ambiguous_entities}' are explicitly included and"
                 f" excluded for intent '{intent_name}'."
                 f"Excluding takes precedence in this case. "
-                f"Please resolve that ambiguity."
+                f"Please resolve that ambiguity.",
+                docs="/core/domains/#ignoring-entities-for-certain-intents",
             )
 
         return entity_names.intersection(wanted_entities)
@@ -608,13 +619,6 @@ class Domain:
             if prev_action_name in self.input_state_map:
                 return {prev_action_name: 1.0}
             else:
-                warnings.warn(
-                    f"Failed to use action '{latest_action}' in history. "
-                    f"Please make sure all actions are listed in the "
-                    f"domains action list. If you recently removed an "
-                    f"action, don't worry about this warning. It "
-                    f"should stop appearing after a while."
-                )
                 return {}
         else:
             return {}
@@ -774,7 +778,7 @@ class Domain:
         """Return the configuration for an intent."""
         return self.intent_properties.get(intent_name, {})
 
-    @common_utils.lazy_property
+    @lazy_property
     def intents(self):
         return sorted(self.intent_properties.keys())
 
@@ -963,11 +967,12 @@ class Domain:
 
         if missing_templates:
             for template in missing_templates:
-                warnings.warn(
+                raise_warning(
                     f"Utterance '{template}' is listed as an "
                     f"action in the domain file, but there is "
                     f"no matching utterance template. Please "
-                    f"check your domain."
+                    f"check your domain.",
+                    docs="/core/domains/#utterance-templates",
                 )
 
     def is_empty(self) -> bool:

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -15,7 +15,11 @@ from rasa.utils.common import (
 )
 import rasa.utils.io
 from rasa.cli.utils import bcolors, wrap_with_color
-from rasa.constants import DEFAULT_CARRY_OVER_SLOTS_TO_NEW_SESSION, DOMAIN_SCHEMA_FILE
+from rasa.constants import (
+    DEFAULT_CARRY_OVER_SLOTS_TO_NEW_SESSION,
+    DOMAIN_SCHEMA_FILE,
+    DOCS_URL_DOMAINS,
+)
 from rasa.core import utils
 from rasa.core.actions import action  # pytype: disable=pyi-error
 from rasa.core.actions.action import Action  # pytype: disable=pyi-error
@@ -135,7 +139,7 @@ class Domain:
                 "no longer work in future versions of Rasa. Please replace "
                 "'templates' with 'responses'",
                 FutureWarning,
-                docs="/core/domains/",
+                docs=DOCS_URL_DOMAINS,
             )
             utter_templates = cls.collect_templates(data.get("templates", {}))
 
@@ -167,7 +171,7 @@ class Domain:
                 "session expiration time of 60 minutes in Rasa version 2.0 if not "
                 "configured otherwise.",
                 FutureWarning,
-                docs="/core/domains/#session-configuration",
+                docs=DOCS_URL_DOMAINS + "#session-configuration",
             )
             session_expiration_time = 0
 
@@ -315,7 +319,7 @@ class Domain:
                         f"either a '- text: ' or a '- custom: ' "
                         f"attribute to be a proper template.",
                         FutureWarning,
-                        docs="/core/domains/#utterance-templates",
+                        docs=DOCS_URL_DOMAINS + "#utterance-templates",
                     )
                     validated_variations.append({"text": t})
                 elif "text" not in t and "custom" not in t:
@@ -603,7 +607,7 @@ class Domain:
                 f" excluded for intent '{intent_name}'."
                 f"Excluding takes precedence in this case. "
                 f"Please resolve that ambiguity.",
-                docs="/core/domains/#ignoring-entities-for-certain-intents",
+                docs=DOCS_URL_DOMAINS + "#ignoring-entities-for-certain-intents",
             )
 
         return entity_names.intersection(wanted_entities)
@@ -972,7 +976,7 @@ class Domain:
                     f"action in the domain file, but there is "
                     f"no matching utterance template. Please "
                     f"check your domain.",
-                    docs="/core/domains/#utterance-templates",
+                    docs=DOCS_URL_DOMAINS + "#utterance-templates",
                 )
 
     def is_empty(self) -> bool:

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -11,6 +11,7 @@ from typing import Text, List, Dict, Any, Union, Optional, Tuple
 from rasa.core import constants
 from rasa.core.trackers import DialogueStateTracker
 from rasa.core.constants import INTENT_MESSAGE_PREFIX
+from rasa.utils.common import raise_warning, class_from_module_path
 from rasa.utils.endpoints import EndpointConfig
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ class NaturalLanguageInterpreter:
         """Factory to create an natural language interpreter."""
 
         if endpoint is not None:
-            warnings.warn(
+            raise_warning(
                 "Calling `NaturalLanguageInterpreter.create` with two parameters"
                 "is deprecated. The `endpoint` parameter will be removed in the "
                 "future. You should replace a call "
@@ -44,7 +45,6 @@ class NaturalLanguageInterpreter:
                 "with the single parameter version "
                 "`NaturalLanguageInterpreter.create(e or s)`.",
                 category=DeprecationWarning,
-                stacklevel=2,
             )
             obj = endpoint or obj
 
@@ -104,12 +104,13 @@ class RegexInterpreter(NaturalLanguageInterpreter):
                     f"(instead parser found '{type(parsed_entities)}')"
                 )
         except Exception as e:
-            warnings.warn(
-                f"Invalid to parse arguments in line "
+            raise_warning(
+                f"Failed to parse arguments in line "
                 f"'{user_input}'. Failed to decode parameters "
                 f"as a json object. Make sure the intent "
                 f"is followed by a proper json object. "
-                f"Error: {e}"
+                f"Error: {e}",
+                docs="/core/stories/",
             )
             return []
 
@@ -121,11 +122,12 @@ class RegexInterpreter(NaturalLanguageInterpreter):
         try:
             return float(confidence_str.strip()[1:])
         except Exception as e:
-            warnings.warn(
+            raise_warning(
                 f"Invalid to parse confidence value in line "
                 f"'{confidence_str}'. Make sure the intent confidence is an "
                 f"@ followed by a decimal number. "
-                f"Error: {e}"
+                f"Error: {e}",
+                docs="/core/stories/",
             )
             return 0.0
 
@@ -312,10 +314,9 @@ def _load_from_module_string(
     endpoint_config: EndpointConfig,
 ) -> "NaturalLanguageInterpreter":
     """Instantiate an event channel based on its class name."""
-    from rasa.utils import common
 
     try:
-        nlu_interpreter_class = common.class_from_module_path(endpoint_config.type)
+        nlu_interpreter_class = class_from_module_path(endpoint_config.type)
         return nlu_interpreter_class(endpoint_config=endpoint_config)
     except (AttributeError, ImportError) as e:
         raise Exception(

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -8,6 +8,7 @@ import re
 import os
 from typing import Text, List, Dict, Any, Union, Optional, Tuple
 
+from rasa.constants import DOCS_URL_STORIES
 from rasa.core import constants
 from rasa.core.trackers import DialogueStateTracker
 from rasa.core.constants import INTENT_MESSAGE_PREFIX
@@ -110,7 +111,7 @@ class RegexInterpreter(NaturalLanguageInterpreter):
                 f"as a json object. Make sure the intent "
                 f"is followed by a proper json object. "
                 f"Error: {e}",
-                docs="/core/stories/",
+                docs=DOCS_URL_STORIES,
             )
             return []
 
@@ -127,7 +128,7 @@ class RegexInterpreter(NaturalLanguageInterpreter):
                 f"'{confidence_str}'. Make sure the intent confidence is an "
                 f"@ followed by a decimal number. "
                 f"Error: {e}",
-                docs="/core/stories/",
+                docs=DOCS_URL_STORIES,
             )
             return 0.0
 

--- a/rasa/core/jobs.py
+++ b/rasa/core/jobs.py
@@ -4,6 +4,7 @@ import logging
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from pytz import UnknownTimeZoneError, utc
+from rasa.utils.common import raise_warning
 
 __scheduler = None
 
@@ -23,7 +24,7 @@ async def scheduler() -> AsyncIOScheduler:
             __scheduler.start()
             return __scheduler
         except UnknownTimeZoneError:
-            warnings.warn(
+            raise_warning(
                 "apscheduler could not find a timezone and is "
                 "defaulting to utc. This is probably because "
                 "your system timezone is not set. "

--- a/rasa/core/policies/embedding_policy.py
+++ b/rasa/core/policies/embedding_policy.py
@@ -24,6 +24,8 @@ from rasa.utils import train_utils
 import tensorflow as tf
 
 # avoid warning println on contrib import - remove for tf 2
+from rasa.utils.common import raise_warning
+
 tf.contrib._warning = None
 logger = logging.getLogger(__name__)
 
@@ -582,7 +584,7 @@ class EmbeddingPolicy(Policy):
         """Persists the policy to a storage."""
 
         if self.session is None:
-            warnings.warn(
+            logger.debug(
                 "Method `persist(...)` was called "
                 "without a trained model present. "
                 "Nothing to persist then!"

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -28,7 +28,7 @@ from rasa.core.policies.fallback import FallbackPolicy
 from rasa.core.policies.memoization import MemoizationPolicy, AugmentedMemoizationPolicy
 from rasa.core.trackers import DialogueStateTracker
 from rasa.core import registry
-from rasa.utils.common import class_from_module_path
+from rasa.utils.common import class_from_module_path, raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -107,12 +107,12 @@ class PolicyEnsemble:
 
         for k, v in priority_dict.items():
             if len(v) > 1:
-                warnings.warn(
+                raise_warning(
                     f"Found policies {v} with same priority {k} "
-                    "in PolicyEnsemble. When personalizing "
-                    "priorities, be sure to give all policies "
-                    "different priorities. More information: "
-                    f"{DOCS_BASE_URL}/core/policies/"
+                    f"in PolicyEnsemble. When personalizing "
+                    f"priorities, be sure to give all policies "
+                    f"different priorities.",
+                    docs="/core/policies/",
                 )
 
     def train(

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -10,7 +10,7 @@ from typing import Text, Optional, Any, List, Dict, Tuple, Set
 
 import rasa.core
 import rasa.utils.io
-from rasa.constants import MINIMUM_COMPATIBLE_VERSION, DOCS_BASE_URL
+from rasa.constants import MINIMUM_COMPATIBLE_VERSION, DOCS_BASE_URL, DOCS_URL_POLICIES
 
 from rasa.core import utils, training
 from rasa.core.constants import USER_INTENT_BACK, USER_INTENT_RESTART
@@ -112,7 +112,7 @@ class PolicyEnsemble:
                     f"in PolicyEnsemble. When personalizing "
                     f"priorities, be sure to give all policies "
                     f"different priorities.",
-                    docs="/core/policies/",
+                    docs=DOCS_URL_POLICIES,
                 )
 
     def train(

--- a/rasa/core/policies/keras_policy.py
+++ b/rasa/core/policies/keras_policy.py
@@ -98,14 +98,6 @@ class KerasPolicy(Policy):
         else:
             return None
 
-    def _build_model(self, num_features, num_actions, max_history_len) -> None:
-        warnings.warn(
-            "Deprecated, use `model_architecture` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return
-
     def model_architecture(
         self, input_shape: Tuple[int, int], output_shape: Tuple[int, Optional[int]]
     ) -> tf.keras.models.Sequential:
@@ -290,7 +282,7 @@ class KerasPolicy(Policy):
             with open(tf_config_file, "wb") as f:
                 pickle.dump(self._tf_config, f)
         else:
-            warnings.warn(
+            logger.debug(
                 "Method `persist(...)` was called "
                 "without a trained model present. "
                 "Nothing to persist then!"

--- a/rasa/core/policies/mapping_policy.py
+++ b/rasa/core/policies/mapping_policy.py
@@ -23,6 +23,7 @@ from rasa.core.events import ActionExecuted
 from rasa.core.policies.policy import Policy
 from rasa.core.trackers import DialogueStateTracker
 from rasa.core.constants import MAPPING_POLICY_PRIORITY
+from rasa.utils.common import raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.core.policies.ensemble import PolicyEnsemble
@@ -105,10 +106,11 @@ class MappingPolicy(Policy):
             if action:
                 idx = domain.index_for_action(action)
                 if idx is None:
-                    warnings.warn(
-                        "MappingPolicy tried to predict unknown "
+                    raise_warning(
+                        f"MappingPolicy tried to predict unknown "
                         f"action '{action}'. Make sure all mapped actions are "
-                        "listed in the domain."
+                        f"listed in the domain.",
+                        docs="/core/policies/#mapping-policy",
                     )
                 else:
                     prediction[idx] = 1

--- a/rasa/core/policies/mapping_policy.py
+++ b/rasa/core/policies/mapping_policy.py
@@ -5,6 +5,7 @@ import os
 import typing
 from typing import Any, List, Text, Optional
 
+from rasa.constants import DOCS_URL_POLICIES
 import rasa.utils.io
 
 from rasa.core.actions.action import (
@@ -110,7 +111,7 @@ class MappingPolicy(Policy):
                         f"MappingPolicy tried to predict unknown "
                         f"action '{action}'. Make sure all mapped actions are "
                         f"listed in the domain.",
-                        docs="/core/policies/#mapping-policy",
+                        docs=DOCS_URL_POLICIES + "#mapping-policy",
                     )
                 else:
                     prediction[idx] = 1

--- a/rasa/core/policies/sklearn_policy.py
+++ b/rasa/core/policies/sklearn_policy.py
@@ -1,12 +1,19 @@
-import typing
 import json
 import logging
-import numpy as np
 import os
 import pickle
-import warnings
+import typing
+from typing import Any, Callable, Dict, List, Optional, Text, Tuple
 
+import numpy as np
+import rasa.utils.io
+from rasa.core.constants import DEFAULT_POLICY_PRIORITY
+from rasa.core.domain import Domain
+from rasa.core.featurizers import MaxHistoryTrackerFeaturizer, TrackerFeaturizer
+from rasa.core.policies.policy import Policy
+from rasa.core.trackers import DialogueStateTracker
 from rasa.core.training.data import DialogueTrainingData
+from rasa.utils.common import raise_warning
 from sklearn.base import clone
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import GridSearchCV
@@ -14,14 +21,6 @@ from sklearn.preprocessing import LabelEncoder
 
 # noinspection PyProtectedMember
 from sklearn.utils import shuffle as sklearn_shuffle
-from typing import Optional, Any, List, Text, Dict, Callable, Tuple
-
-import rasa.utils.io
-from rasa.core.domain import Domain
-from rasa.core.featurizers import TrackerFeaturizer, MaxHistoryTrackerFeaturizer
-from rasa.core.policies.policy import Policy
-from rasa.core.trackers import DialogueStateTracker
-from rasa.core.constants import DEFAULT_POLICY_PRIORITY
 
 logger = logging.getLogger(__name__)
 
@@ -180,7 +179,7 @@ class SklearnPolicy(Policy):
             with open(filename, "wb") as f:
                 pickle.dump(self._state, f)
         else:
-            warnings.warn(
+            raise_warning(
                 "Persist called without a trained model present. "
                 "Nothing to persist then!"
             )

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -6,6 +6,8 @@ from types import LambdaType
 from typing import Any, Dict, List, Optional, Text, Tuple, Union
 
 import numpy as np
+
+from rasa.constants import DOCS_URL_POLICIES, DOCS_URL_DOMAINS
 from rasa.core import jobs
 from rasa.core.actions.action import (
     ACTION_LISTEN_NAME,
@@ -99,7 +101,7 @@ class MessageProcessor:
             raise_warning(
                 "No policy ensemble or domain set. Skipping action prediction "
                 "and execution.",
-                docs="/core/policies/",
+                docs=DOCS_URL_POLICIES,
             )
             return None
 
@@ -129,7 +131,7 @@ class MessageProcessor:
             raise_warning(
                 "No policy ensemble or domain set. Skipping action prediction."
                 "You should set a policy before training a model.",
-                docs="/core/policies/",
+                docs=DOCS_URL_POLICIES,
             )
             return None
 
@@ -402,7 +404,7 @@ class MessageProcessor:
                     f"Interpreter parsed an intent '{intent}' "
                     f"which is not defined in the domain. "
                     f"Please make sure all intents are listed in the domain.",
-                    docs="/core/domains",
+                    docs=DOCS_URL_DOMAINS,
                 )
 
         entities = parse_data["entities"] or []
@@ -413,7 +415,7 @@ class MessageProcessor:
                     f"Interpreter parsed an entity '{entity}' "
                     f"which is not defined in the domain. "
                     f"Please make sure all entities are listed in the domain.",
-                    docs="/core/domains",
+                    docs=DOCS_URL_DOMAINS,
                 )
 
     def _get_action(self, action_name) -> Optional[Action]:

--- a/rasa/core/restore.py
+++ b/rasa/core/restore.py
@@ -1,20 +1,19 @@
 import json
 import logging
-import warnings
+import typing
 from difflib import SequenceMatcher
+from typing import List, Text, Tuple
 
 import rasa.cli.utils
 import rasa.utils.io
-import typing
-from typing import List, Text, Tuple
-
 from rasa.cli import utils as cli_utils
 from rasa.core.actions.action import ACTION_LISTEN_NAME
 from rasa.core.channels import console
-from rasa.core.channels.channel import UserMessage, CollectingOutputChannel
+from rasa.core.channels.channel import CollectingOutputChannel, UserMessage
 from rasa.core.domain import Domain
 from rasa.core.events import ActionExecuted, UserUttered
 from rasa.core.trackers import DialogueStateTracker
+from rasa.utils.common import raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.core.agent import Agent
@@ -29,9 +28,9 @@ def _check_prediction_aligns_with_story(
 
     p, a = align_lists(last_prediction, actions_between_utterances)
     if p != a:
-        warnings.warn(
-            "Model predicted different actions than the "
-            "model used to create the story! Expected: "
+        raise_warning(
+            f"The model predicted different actions than the "
+            f"model used to create the story! Expected: "
             f"{p} but got {a}."
         )
 

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 import shutil
-import warnings
 from functools import partial
 from typing import Any, List, Optional, Text, Union
 
@@ -21,6 +20,7 @@ from rasa.core.interpreter import NaturalLanguageInterpreter
 from rasa.core.lock_store import LockStore
 from rasa.core.tracker_store import TrackerStore
 from rasa.core.utils import AvailableEndpoints
+from rasa.utils.common import raise_warning
 from sanic import Sanic
 
 logger = logging.getLogger()  # get the root logger
@@ -248,7 +248,7 @@ async def load_agent_on_start(
     )
 
     if not app.agent:
-        warnings.warn(
+        raise_warning(
             "Agent could not be loaded with the provided configuration. "
             "Load default agent without any model."
         )

--- a/rasa/core/slots.py
+++ b/rasa/core/slots.py
@@ -1,9 +1,8 @@
 import logging
-import warnings
+from typing import Any, Dict, List, NoReturn, Optional, Text, Type
 
 from rasa.core import utils
-from rasa.utils.common import class_from_module_path
-from typing import Any, Dict, List, NoReturn, Optional, Text, Type
+from rasa.utils.common import class_from_module_path, raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -112,10 +111,10 @@ class FloatSlot(Slot):
             )
 
         if initial_value is not None and not (min_value <= initial_value <= max_value):
-            warnings.warn(
+            raise_warning(
                 f"Float slot ('{self.name}') created with an initial value "
-                f"{self.value} outside of configured min ({self.min_value}) "
-                f"and max ({self.max_value}) values."
+                f"{self.value}. This value is outside of the configured min "
+                f"({self.min_value}) and max ({self.max_value}) values."
             )
 
     def as_feature(self) -> List[float]:
@@ -213,7 +212,7 @@ class CategoricalSlot(Slot):
                     break
             else:
                 if self.value is not None:
-                    warnings.warn(
+                    raise_warning(
                         f"Categorical slot '{self.name}' is set to a value "
                         f"('{self.value}') "
                         "that is not specified in the domain. "

--- a/rasa/core/training/dsl.py
+++ b/rasa/core/training/dsl.py
@@ -23,6 +23,7 @@ from rasa.core.training.structures import (
 )
 from rasa.nlu.training_data.formats import MarkdownReader
 from rasa.core.domain import Domain
+from rasa.utils.common import raise_warning
 
 if TYPE_CHECKING:
     from rasa.nlu.training_data import Message
@@ -36,13 +37,11 @@ class EndToEndReader(MarkdownReader):
         self._regex_interpreter = RegexInterpreter()
 
     def _parse_item(self, line: Text) -> Optional["Message"]:
-        """Parses an md list item line based on the current section type.
+        f"""Parses an md list item line based on the current section type.
 
         Matches expressions of the form `<intent>:<example>. For the
         syntax of <example> see the Rasa docs on NLU training data:
-        {}/nlu/training-data-format/#markdown-format""".format(
-            DOCS_BASE_URL
-        )
+        {DOCS_BASE_URL}/nlu/training-data-format/#markdown-format"""
 
         # Match three groups:
         # 1) Potential "form" annotation
@@ -91,10 +90,11 @@ class StoryStepBuilder:
             self.start_checkpoints.append(Checkpoint(name, conditions))
         else:
             if conditions:
-                warnings.warn(
-                    "End or intermediate checkpoints "
-                    "do not support conditions! "
-                    f"(checkpoint: {name})"
+                raise_warning(
+                    f"End or intermediate checkpoints "
+                    f"do not support conditions! "
+                    f"(checkpoint: {name})",
+                    docs="/core/stories/#checkpoints",
                 )
             additional_steps = []
             for t in self.current_steps:
@@ -302,7 +302,10 @@ class StoryFileReader:
             parameters = StoryFileReader._parameters_from_json_string(slots_str, line)
             return event_name, parameters
         else:
-            warnings.warn(f"Failed to parse action line '{line}'. Ignoring this line.")
+            raise_warning(
+                f"Failed to parse action line '{line}'. Ignoring this line.",
+                docs="/core/stories/",
+            )
             return "", {}
 
     async def process_lines(self, lines: List[Text]) -> List[StoryStep]:
@@ -412,10 +415,12 @@ class StoryFileReader:
         )
         intent_name = utterance.intent.get("name")
         if intent_name not in self.domain.intents:
-            warnings.warn(
+            raise_warning(
                 f"Found unknown intent '{intent_name}' on line {line_num}. "
                 "Please, make sure that all intents are "
-                "listed in your domain yaml."
+                "listed in your domain yaml.",
+                UserWarning,
+                docs="https://rasa.com/docs/rasa/core/domains/",
             )
         return utterance
 

--- a/rasa/core/training/dsl.py
+++ b/rasa/core/training/dsl.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Optional, List, Text, Any, Dict, TYPE_CHECKING, Iterable
 
 import rasa.utils.io as io_utils
-from rasa.constants import DOCS_BASE_URL
+from rasa.constants import DOCS_BASE_URL, DOCS_URL_STORIES, DOCS_URL_DOMAINS
 from rasa.core import utils
 from rasa.core.constants import INTENT_MESSAGE_PREFIX
 from rasa.core.events import ActionExecuted, UserUttered, Event, SlotSet
@@ -94,7 +94,7 @@ class StoryStepBuilder:
                     f"End or intermediate checkpoints "
                     f"do not support conditions! "
                     f"(checkpoint: {name})",
-                    docs="/core/stories/#checkpoints",
+                    docs=DOCS_URL_STORIES + "#checkpoints",
                 )
             additional_steps = []
             for t in self.current_steps:
@@ -304,7 +304,7 @@ class StoryFileReader:
         else:
             raise_warning(
                 f"Failed to parse action line '{line}'. Ignoring this line.",
-                docs="/core/stories/",
+                docs=DOCS_URL_STORIES,
             )
             return "", {}
 
@@ -420,7 +420,7 @@ class StoryFileReader:
                 "Please, make sure that all intents are "
                 "listed in your domain yaml.",
                 UserWarning,
-                docs="https://rasa.com/docs/rasa/core/domains/",
+                docs=DOCS_URL_DOMAINS,
             )
         return utterance
 

--- a/rasa/core/training/generator.py
+++ b/rasa/core/training/generator.py
@@ -24,7 +24,7 @@ from rasa.core.training.structures import (
     StoryStep,
     GENERATED_CHECKPOINT_PREFIX,
 )
-from rasa.utils.common import is_logging_disabled
+from rasa.utils.common import is_logging_disabled, raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -653,12 +653,13 @@ class TrainingDataGenerator:
         that no one provided."""
 
         if STORY_START in unused_checkpoints:
-            warnings.warn(
+            raise_warning(
                 "There is no starting story block "
                 "in the training data. "
                 "All your story blocks start with some checkpoint. "
                 "There should be at least one story block "
-                "that starts without any checkpoint."
+                "that starts without any checkpoint.",
+                docs="/core/stories/#stories",
             )
 
         # running through the steps first will result in only one warning
@@ -680,20 +681,22 @@ class TrainingDataGenerator:
 
         for cp, block_name in collected_start:
             if not cp.startswith(GENERATED_CHECKPOINT_PREFIX):
-                warnings.warn(
+                raise_warning(
                     f"Unsatisfied start checkpoint '{cp}' "
                     f"in block '{block_name}'. "
-                    "Remove this checkpoint or add "
-                    "story blocks that end "
-                    "with this checkpoint."
+                    f"Remove this checkpoint or add "
+                    f"story blocks that end "
+                    f"with this checkpoint.",
+                    docs="/core/stories/#checkpoints",
                 )
 
         for cp, block_name in collected_end:
             if not cp.startswith(GENERATED_CHECKPOINT_PREFIX):
-                warnings.warn(
+                raise_warning(
                     f"Unsatisfied end checkpoint '{cp}' "
                     f"in block '{block_name}'. "
-                    "Remove this checkpoint or add "
-                    "story blocks that start "
-                    "with this checkpoint."
+                    f"Remove this checkpoint or add "
+                    f"story blocks that start "
+                    f"with this checkpoint.",
+                    docs="/core/stories/#checkpoints",
                 )

--- a/rasa/core/training/generator.py
+++ b/rasa/core/training/generator.py
@@ -7,6 +7,7 @@ import random
 from tqdm import tqdm
 from typing import Optional, List, Text, Set, Dict, Tuple
 
+from rasa.constants import DOCS_URL_STORIES
 from rasa.core import utils
 from rasa.core.domain import Domain
 from rasa.core.events import (
@@ -659,7 +660,7 @@ class TrainingDataGenerator:
                 "All your story blocks start with some checkpoint. "
                 "There should be at least one story block "
                 "that starts without any checkpoint.",
-                docs="/core/stories/#stories",
+                docs=DOCS_URL_STORIES + "#stories",
             )
 
         # running through the steps first will result in only one warning
@@ -687,7 +688,7 @@ class TrainingDataGenerator:
                     f"Remove this checkpoint or add "
                     f"story blocks that end "
                     f"with this checkpoint.",
-                    docs="/core/stories/#checkpoints",
+                    docs=DOCS_URL_STORIES + "#checkpoints",
                 )
 
         for cp, block_name in collected_end:
@@ -698,5 +699,5 @@ class TrainingDataGenerator:
                     f"Remove this checkpoint or add "
                     f"story blocks that start "
                     f"with this checkpoint.",
-                    docs="/core/stories/#checkpoints",
+                    docs=DOCS_URL_STORIES + "#checkpoints",
                 )

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -1,15 +1,13 @@
 import logging
-import warnings
-import asyncio
 from collections import defaultdict
 from typing import List, Set, Text
+
+from rasa.core.constants import UTTER_PREFIX
 from rasa.core.domain import Domain
+from rasa.core.training.dsl import ActionExecuted, StoryStep, UserUttered
 from rasa.importers.importer import TrainingDataImporter
 from rasa.nlu.training_data import TrainingData
-from rasa.core.training.dsl import StoryStep
-from rasa.core.training.dsl import UserUttered
-from rasa.core.training.dsl import ActionExecuted
-from rasa.core.constants import UTTER_PREFIX
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -51,10 +49,11 @@ class Validator:
 
         for intent in nlu_data_intents:
             if intent not in self.domain.intents:
-                warnings.warn(
-                    f"The intent '{intent}' is in the NLU training data, but "
-                    f"is not listed in the domain.",
-                    stacklevel=2,
+                raise_warning(
+                    f"There is a message in the training data labelled with intent "
+                    f"'{intent}'. This intent is not listed in your domain. You "
+                    f"should need to add that intent to your domain file!",
+                    docs="/core/domains/",
                 )
                 everything_is_alright = False
 
@@ -77,10 +76,11 @@ class Validator:
             if len(duplication_hash[text]) > 1:
                 everything_is_alright = ignore_warnings and everything_is_alright
                 intents_string = ", ".join(sorted(intents))
-                warnings.warn(
-                    f"The example '{text}' was found in multiple intents: "
-                    f"{intents_string}.",
-                    stacklevel=2,
+                raise_warning(
+                    f"The example '{text}' was found labeled with multiple "
+                    f"different intents in the training data. Each annotated message "
+                    f"should only appear with one intent. You should fix that "
+                    f"conflict The example is labeled with: {intents_string}."
                 )
         return everything_is_alright
 
@@ -101,10 +101,11 @@ class Validator:
 
         for story_intent in stories_intents:
             if story_intent not in self.domain.intents:
-                warnings.warn(
-                    f"The intent '{story_intent}' is used in stories, but is not "
-                    f"listed in the domain file.",
-                    stacklevel=2,
+                raise_warning(
+                    f"The intent '{story_intent}' is used in your stories, but it "
+                    f"is not listed in the domain file. You should add it to your "
+                    f"domain file!",
+                    docs="/core/domains/",
                 )
                 everything_is_alright = False
 
@@ -141,8 +142,12 @@ class Validator:
         for action in actions:
             if action.startswith(UTTER_PREFIX):
                 if action not in utterance_templates:
-                    warnings.warn(
-                        f"There is no template for utterance '{action}'.", stacklevel=2
+                    raise_warning(
+                        f"There is no template for the utterance action '{action}'."
+                        f"The action is listed in your domains action list, but "
+                        f"there is no template defined with this name. You should "
+                        f"add a template with this key.",
+                        docs="/core/actions/#utterance-actions",
                     )
                     everything_is_alright = False
 
@@ -172,10 +177,12 @@ class Validator:
                     continue
 
                 if event.action_name not in utterance_actions:
-                    warnings.warn(
-                        f"The utterance '{event.action_name}' is used in stories, but is not a "
-                        f"valid utterance.",
-                        stacklevel=2,
+                    raise_warning(
+                        f"The action '{event.action_name}' is used in the stories, "
+                        f"but is not a valid utterance action. Please make sure "
+                        f"the action is listed in your domain and there is a "
+                        f"template defined with its name.",
+                        docs="/core/actions/#utterance-actions",
                     )
                     everything_is_alright = False
                 stories_utterances.add(event.action_name)
@@ -203,6 +210,8 @@ class Validator:
         return intents_are_valid and stories_are_valid and there_is_no_duplication
 
     def verify_domain_validity(self) -> bool:
-        """Checks whether the domain returned by the importer is empty, indicating an invalid domain."""
+        """Checks whether the domain returned by the importer is empty.
+
+        An empty domain is invalid."""
 
         return not self.domain.is_empty()

--- a/rasa/core/validator.py
+++ b/rasa/core/validator.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from typing import List, Set, Text
 
+from rasa.constants import DOCS_URL_DOMAINS, DOCS_URL_ACTIONS
 from rasa.core.constants import UTTER_PREFIX
 from rasa.core.domain import Domain
 from rasa.core.training.dsl import ActionExecuted, StoryStep, UserUttered
@@ -53,7 +54,7 @@ class Validator:
                     f"There is a message in the training data labelled with intent "
                     f"'{intent}'. This intent is not listed in your domain. You "
                     f"should need to add that intent to your domain file!",
-                    docs="/core/domains/",
+                    docs=DOCS_URL_DOMAINS,
                 )
                 everything_is_alright = False
 
@@ -105,7 +106,7 @@ class Validator:
                     f"The intent '{story_intent}' is used in your stories, but it "
                     f"is not listed in the domain file. You should add it to your "
                     f"domain file!",
-                    docs="/core/domains/",
+                    docs=DOCS_URL_DOMAINS,
                 )
                 everything_is_alright = False
 
@@ -147,7 +148,7 @@ class Validator:
                         f"The action is listed in your domains action list, but "
                         f"there is no template defined with this name. You should "
                         f"add a template with this key.",
-                        docs="/core/actions/#utterance-actions",
+                        docs=DOCS_URL_ACTIONS + "#utterance-actions",
                     )
                     everything_is_alright = False
 
@@ -182,7 +183,7 @@ class Validator:
                         f"but is not a valid utterance action. Please make sure "
                         f"the action is listed in your domain and there is a "
                         f"template defined with its name.",
-                        docs="/core/actions/#utterance-actions",
+                        docs=DOCS_URL_ACTIONS + "#utterance-actions",
                     )
                     everything_is_alright = False
                 stories_utterances.add(event.action_name)

--- a/rasa/importers/multi_project.py
+++ b/rasa/importers/multi_project.py
@@ -13,7 +13,7 @@ from rasa.importers.importer import TrainingDataImporter
 from rasa.importers import utils
 from rasa.nlu.training_data import TrainingData
 from rasa.core.training.structures import StoryGraph
-import rasa.utils.common
+from rasa.utils.common import raise_warning, mark_as_experimental_feature
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,7 @@ class MultiProjectImporter(TrainingDataImporter):
             "Selected projects: {}".format("".join([f"\n-{i}" for i in self._imports]))
         )
 
-        rasa.utils.common.mark_as_experimental_feature(
-            feature_name="MultiProjectImporter"
-        )
+        mark_as_experimental_feature(feature_name="MultiProjectImporter")
 
     def _init_from_path(self, path: Text) -> None:
         if os.path.isfile(path):
@@ -67,7 +65,7 @@ class MultiProjectImporter(TrainingDataImporter):
             parent_directory = os.path.dirname(path)
             self._init_from_dict(config, parent_directory)
         else:
-            warnings.warn(f"'{path}' does not exist or is not a valid config file.")
+            raise_warning(f"'{path}' does not exist or is not a valid config file.")
 
     def _init_from_dict(self, _dict: Dict[Text, Any], parent_directory: Text) -> None:
         imports = _dict.get("imports") or []

--- a/rasa/importers/rasa.py
+++ b/rasa/importers/rasa.py
@@ -1,17 +1,17 @@
 import logging
-import warnings
 import os
-from typing import Optional, Text, Union, List, Dict
+from typing import Dict, List, Optional, Text, Union
 
 from rasa import data
 from rasa.core.domain import Domain, InvalidDomain
-from rasa.core.interpreter import RegexInterpreter, NaturalLanguageInterpreter
-from rasa.core.training.structures import StoryGraph
+from rasa.core.interpreter import NaturalLanguageInterpreter, RegexInterpreter
 from rasa.core.training.dsl import StoryFileReader
+from rasa.core.training.structures import StoryGraph
 from rasa.importers import utils
 from rasa.importers.importer import TrainingDataImporter
 from rasa.nlu.training_data import TrainingData
 from rasa.utils import io as io_utils
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class RasaFileImporter(TrainingDataImporter):
             domain = Domain.load(self._domain_path)
             domain.check_missing_templates()
         except InvalidDomain as e:
-            warnings.warn(
+            raise_warning(
                 f"Loading domain from '{self._domain_path}' failed. Using "
                 f"empty domain. Error: '{e.message}'"
             )

--- a/rasa/nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa/nlu/classifiers/embedding_intent_classifier.py
@@ -23,6 +23,8 @@ from rasa.nlu.constants import (
 import tensorflow as tf
 
 # avoid warning println on contrib import - remove for tf 2
+from rasa.utils.common import raise_warning
+
 tf.contrib._warning = None
 
 logger = logging.getLogger(__name__)
@@ -131,7 +133,7 @@ class EmbeddingIntentClassifier(Component):
         ]
         for removed_param in removed_tokenization_params:
             if removed_param in config:
-                warnings.warn(
+                raise_warning(
                     f"Intent tokenization has been moved to Tokenizer components. "
                     f"Your config still mentions '{removed_param}'. "
                     f"Tokenization may fail if you specify the parameter here. "
@@ -981,8 +983,8 @@ class EmbeddingIntentClassifier(Component):
             )
 
         else:
-            warnings.warn(
+            raise_warning(
                 f"Failed to load nlu model. "
-                f"Maybe path '{os.path.abspath(model_dir)}' doesn't exist."
+                f"Maybe the path '{os.path.abspath(model_dir)}' doesn't exist?",
             )
             return cls(component_config=meta)

--- a/rasa/nlu/classifiers/keyword_intent_classifier.py
+++ b/rasa/nlu/classifiers/keyword_intent_classifier.py
@@ -9,6 +9,7 @@ from rasa.nlu import utils
 from rasa.nlu.components import Component
 from rasa.nlu.training_data import Message
 from rasa.nlu.constants import INTENT_ATTRIBUTE
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +58,13 @@ class KeywordIntentClassifier(Component):
                 and ex.get(INTENT_ATTRIBUTE) != self.intent_keyword_map[ex.text]
             ):
                 duplicate_examples.add(ex.text)
-                warnings.warn(
-                    f"Keyword '{ex.text}' is a keyword of intent "
-                    f"'{self.intent_keyword_map[ex.text]}' and of "
-                    f"intent '{ex.get(INTENT_ATTRIBUTE)}', it will be removed from "
-                    f"the list of keywords.\n"
-                    f"Remove (one of) the duplicates from the training data."
+                raise_warning(
+                    f"Keyword '{ex.text}' is a keyword to trigger intent "
+                    f"'{self.intent_keyword_map[ex.text]}' and also "
+                    f"intent '{ex.get(INTENT_ATTRIBUTE)}', it will be removed "
+                    f"from the list of keywords for both of them. "
+                    f"Remove (one of) the duplicates from the training data.",
+                    docs="/nlu/components/#keyword-intent-classifier",
                 )
             else:
                 self.intent_keyword_map[ex.text] = ex.get(INTENT_ATTRIBUTE)
@@ -86,13 +88,14 @@ class KeywordIntentClassifier(Component):
                     and intent1 != intent2
                 ):
                     ambiguous_mappings.append((intent1, keyword1))
-                    warnings.warn(
+                    raise_warning(
                         f"Keyword '{keyword1}' is a keyword of intent '{intent1}', "
                         f"but also a substring of '{keyword2}', which is a "
                         f"keyword of intent '{intent2}."
                         f" '{keyword1}' will be removed from the list of keywords.\n"
                         "Remove (one of) the conflicting keywords from the"
-                        " training data."
+                        " training data.",
+                        docs="/nlu/components/#keyword-intent-classifier",
                     )
         for intent, keyword in ambiguous_mappings:
             self.intent_keyword_map.pop(keyword)
@@ -152,8 +155,14 @@ class KeywordIntentClassifier(Component):
             if os.path.exists(keyword_file):
                 intent_keyword_map = utils.read_json_file(keyword_file)
             else:
-                warnings.warn(
-                    f"Failed to load IntentKeywordClassifier, maybe "
-                    "{keyword_file} does not exist."
+                raise_warning(
+                    f"Failed to load key word file for `IntentKeywordClassifier`, "
+                    f"maybe {keyword_file} does not exist?",
                 )
-        return cls(meta, intent_keyword_map)
+                intent_keyword_map = None
+            return cls(meta, intent_keyword_map)
+        else:
+            raise Exception(
+                f"Failed to load keyword intent classifier model. "
+                f"Path {os.path.abspath(meta.get('file'))} doesn't exist."
+            )

--- a/rasa/nlu/classifiers/keyword_intent_classifier.py
+++ b/rasa/nlu/classifiers/keyword_intent_classifier.py
@@ -5,6 +5,7 @@ import typing
 import re
 from typing import Any, Dict, Optional, Text
 
+from rasa.constants import DOCS_URL_COMPONENTS
 from rasa.nlu import utils
 from rasa.nlu.components import Component
 from rasa.nlu.training_data import Message
@@ -64,7 +65,7 @@ class KeywordIntentClassifier(Component):
                     f"intent '{ex.get(INTENT_ATTRIBUTE)}', it will be removed "
                     f"from the list of keywords for both of them. "
                     f"Remove (one of) the duplicates from the training data.",
-                    docs="/nlu/components/#keyword-intent-classifier",
+                    docs=DOCS_URL_COMPONENTS + "#keyword-intent-classifier",
                 )
             else:
                 self.intent_keyword_map[ex.text] = ex.get(INTENT_ATTRIBUTE)
@@ -95,7 +96,7 @@ class KeywordIntentClassifier(Component):
                         f" '{keyword1}' will be removed from the list of keywords.\n"
                         "Remove (one of) the conflicting keywords from the"
                         " training data.",
-                        docs="/nlu/components/#keyword-intent-classifier",
+                        docs=DOCS_URL_COMPONENTS + "#keyword-intent-classifier",
                     )
         for intent, keyword in ambiguous_mappings:
             self.intent_keyword_map.pop(keyword)

--- a/rasa/nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa/nlu/classifiers/sklearn_intent_classifier.py
@@ -1,18 +1,19 @@
 import logging
-import warnings
-import numpy as np
 import os
 import typing
+import warnings
 from typing import Any, Dict, List, Optional, Text, Tuple
 
-from rasa.nlu.featurizers.featurizer import sequence_to_sentence_features
+import numpy as np
 from rasa.nlu import utils
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
 from rasa.nlu.components import Component
 from rasa.nlu.config import RasaNLUModelConfig
+from rasa.nlu.constants import DENSE_FEATURE_NAMES, TEXT_ATTRIBUTE
+from rasa.nlu.featurizers.featurizer import sequence_to_sentence_features
 from rasa.nlu.model import Metadata
 from rasa.nlu.training_data import Message, TrainingData
-from rasa.nlu.constants import DENSE_FEATURE_NAMES, TEXT_ATTRIBUTE
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -88,10 +89,11 @@ class SklearnIntentClassifier(Component):
         labels = [e.get("intent") for e in training_data.intent_examples]
 
         if len(set(labels)) < 2:
-            warnings.warn(
-                "Can not train an intent classifier. "
-                "Need at least 2 different classes. "
-                "Skipping training of intent classifier."
+            raise_warning(
+                "Can not train an intent classifier as there are not "
+                "enough intents. Need at least 2 different intents. "
+                "Skipping training of intent classifier.",
+                docs="/nlu/training-data-format/",
             )
         else:
             y = self.transform_labels_str2num(labels)
@@ -108,7 +110,12 @@ class SklearnIntentClassifier(Component):
 
             self.clf = self._create_classifier(num_threads, y)
 
-            self.clf.fit(X, y)
+            with warnings.catch_warnings():
+                # sklearn raises lots of
+                # "UndefinedMetricWarning: F - score is ill - defined"
+                # if there are few intent examples, this is needed to prevent it
+                warnings.simplefilter("ignore")
+                self.clf.fit(X, y)
 
     def _num_cv_splits(self, y) -> int:
         folds = self.component_config["max_cross_validation_folds"]
@@ -140,6 +147,7 @@ class SklearnIntentClassifier(Component):
             cv=cv_splits,
             scoring=self.component_config["scoring_function"],
             verbose=1,
+            iid=False,
         )
 
     def process(self, message: Message, **kwargs: Any) -> None:

--- a/rasa/nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa/nlu/classifiers/sklearn_intent_classifier.py
@@ -5,6 +5,8 @@ import warnings
 from typing import Any, Dict, List, Optional, Text, Tuple
 
 import numpy as np
+
+from rasa.constants import DOCS_URL_TRAINING_DATA_NLU
 from rasa.nlu import utils
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
 from rasa.nlu.components import Component
@@ -93,7 +95,7 @@ class SklearnIntentClassifier(Component):
                 "Can not train an intent classifier as there are not "
                 "enough intents. Need at least 2 different intents. "
                 "Skipping training of intent classifier.",
-                docs="/nlu/training-data-format/",
+                docs=DOCS_URL_TRAINING_DATA_NLU,
             )
         else:
             y = self.transform_labels_str2num(labels)

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -1,11 +1,12 @@
 import logging
 import typing
-from typing import Any, Dict, Hashable, List, Optional, Set, Text, Tuple
 import warnings
+from typing import Any, Dict, Hashable, List, Optional, Set, Text, Tuple
 
 from rasa.nlu.config import RasaNLUModelConfig, override_defaults
-from rasa.nlu.training_data import TrainingData, Message
 from rasa.nlu.constants import RESPONSE_ATTRIBUTE
+from rasa.nlu.training_data import Message, TrainingData
+from rasa.utils.common import raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.nlu.model import Metadata
@@ -124,7 +125,7 @@ def validate_required_components_from_data(
             response_selector_exists = True
 
     if len(data.response_examples) and not response_selector_exists:
-        warnings.warn(
+        raise_warning(
             "Training data consists examples for training a response selector but "
             "no response selector component specified inside NLU pipeline."
         )

--- a/rasa/nlu/config.py
+++ b/rasa/nlu/config.py
@@ -6,7 +6,7 @@ import ruamel.yaml as yaml
 from typing import Any, Dict, List, Optional, Text, Union, Tuple
 
 import rasa.utils.io
-from rasa.constants import DEFAULT_CONFIG_PATH
+from rasa.constants import DEFAULT_CONFIG_PATH, DOCS_URL_PIPELINE
 from rasa.nlu.utils import json_to_string
 from rasa.utils.common import raise_warning
 
@@ -73,7 +73,7 @@ def component_config_from_pipeline(
             f"Tried to get configuration value for component "
             f"number {index} which is not part of your pipeline. "
             f"Returning `defaults`.",
-            docs="/nlu/choosing-a-pipeline/",
+            docs=DOCS_URL_PIPELINE,
         )
         return override_defaults(defaults, {})
 
@@ -112,7 +112,7 @@ class RasaNLUModelConfig:
                     f"longer work with future versions of "
                     f"Rasa.",
                     FutureWarning,
-                    docs="/nlu/choosing-a-pipeline/",
+                    docs=DOCS_URL_PIPELINE,
                 )
                 template_name = new_names[template_name]
 
@@ -185,7 +185,7 @@ class RasaNLUModelConfig:
             raise_warning(
                 f"Tried to set configuration value for component "
                 f"number {index} which is not part of the pipeline.",
-                docs="/nlu/choosing-a-pipeline/",
+                docs=DOCS_URL_PIPELINE,
             )
 
     def override(self, config) -> None:

--- a/rasa/nlu/config.py
+++ b/rasa/nlu/config.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Text, Union, Tuple
 import rasa.utils.io
 from rasa.constants import DEFAULT_CONFIG_PATH
 from rasa.nlu.utils import json_to_string
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -68,10 +69,11 @@ def component_config_from_pipeline(
         c = pipeline[index]
         return override_defaults(defaults, c)
     except IndexError:
-        warnings.warn(
+        raise_warning(
             f"Tried to get configuration value for component "
-            f"number {index} which is not part of the pipeline. "
-            f"Returning `defaults`."
+            f"number {index} which is not part of your pipeline. "
+            f"Returning `defaults`.",
+            docs="/nlu/choosing-a-pipeline/",
         )
         return override_defaults(defaults, {})
 
@@ -102,14 +104,15 @@ class RasaNLUModelConfig:
                 "tensorflow_embedding": "supervised_embeddings",
             }
             if template_name in new_names:
-                warnings.warn(
+                raise_warning(
                     f"You have specified the pipeline template "
                     f"'{template_name}' which has been renamed to "
                     f"'{new_names[template_name]}'. "
-                    f"Please update your code as it will no "
+                    f"Please update your configuration as it will no "
                     f"longer work with future versions of "
                     f"Rasa.",
                     FutureWarning,
+                    docs="/nlu/choosing-a-pipeline/",
                 )
                 template_name = new_names[template_name]
 
@@ -179,9 +182,10 @@ class RasaNLUModelConfig:
         try:
             self.pipeline[index].update(kwargs)
         except IndexError:
-            warnings.warn(
+            raise_warning(
                 f"Tried to set configuration value for component "
-                f"number {index} which is not part of the pipeline."
+                f"number {index} which is not part of the pipeline.",
+                docs="/nlu/choosing-a-pipeline/",
             )
 
     def override(self, config) -> None:

--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -18,6 +18,7 @@ from rasa.nlu.constants import (
     ENTITIES_ATTRIBUTE,
 )
 from rasa.constants import DOCS_BASE_URL
+from rasa.utils.common import raise_warning
 
 try:
     import spacy
@@ -518,14 +519,15 @@ class CRFEntityExtractor(EntityExtractor):
                 collected.append(t)
             elif collected:
                 collected_text = " ".join([t.text for t in collected])
-                warnings.warn(
+                raise_warning(
                     f"Misaligned entity annotation for '{collected_text}' "
                     f"in sentence '{message.text}' with intent "
                     f"'{message.get('intent')}'. "
                     f"Make sure the start and end values of the "
                     f"annotated training examples end at token "
                     f"boundaries (e.g. don't include trailing "
-                    f"whitespaces or punctuation)."
+                    f"whitespaces or punctuation).",
+                    docs="/nlu/training-data-format/",
                 )
                 collected = []
 
@@ -593,12 +595,13 @@ class CRFEntityExtractor(EntityExtractor):
 
         tokens = message.get(TOKENS_NAMES[TEXT_ATTRIBUTE], [])
         if len(tokens) != len(features):
-            warnings.warn(
+            raise_warning(
                 f"Number of features ({len(features)}) for attribute "
                 f"'{DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE]}' "
                 f"does not match number of tokens ({len(tokens)}). Set "
                 f"'return_sequence' to true in the corresponding featurizer in order "
-                f"to make use of the features in 'CRFEntityExtractor'."
+                f"to make use of the features in 'CRFEntityExtractor'.",
+                docs="/nlu/components/#crfentityextractor",
             )
             return None
 

--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -17,7 +17,11 @@ from rasa.nlu.constants import (
     SPACY_DOCS,
     ENTITIES_ATTRIBUTE,
 )
-from rasa.constants import DOCS_BASE_URL
+from rasa.constants import (
+    DOCS_BASE_URL,
+    DOCS_URL_TRAINING_DATA_NLU,
+    DOCS_URL_COMPONENTS,
+)
 from rasa.utils.common import raise_warning
 
 try:
@@ -527,7 +531,7 @@ class CRFEntityExtractor(EntityExtractor):
                     f"annotated training examples end at token "
                     f"boundaries (e.g. don't include trailing "
                     f"whitespaces or punctuation).",
-                    docs="/nlu/training-data-format/",
+                    docs=DOCS_URL_TRAINING_DATA_NLU,
                 )
                 collected = []
 
@@ -601,7 +605,7 @@ class CRFEntityExtractor(EntityExtractor):
                 f"does not match number of tokens ({len(tokens)}). Set "
                 f"'return_sequence' to true in the corresponding featurizer in order "
                 f"to make use of the features in 'CRFEntityExtractor'.",
-                docs="/nlu/components/#crfentityextractor",
+                docs=DOCS_URL_COMPONENTS + "#crfentityextractor",
             )
             return None
 

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -6,6 +6,7 @@ import os
 import requests
 from typing import Any, List, Optional, Text, Dict
 
+from rasa.constants import DOCS_URL_COMPONENTS
 from rasa.nlu.constants import ENTITIES_ATTRIBUTE
 from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.extractors import EntityExtractor
@@ -184,7 +185,7 @@ class DucklingHTTPExtractor(EntityExtractor):
                 "`url` configuration in the config "
                 "file nor is `RASA_DUCKLING_HTTP_URL` "
                 "set as an environment variable. No entities will be extracted!",
-                docs="/nlu/components/#ducklinghttpextractor",
+                docs=DOCS_URL_COMPONENTS + "#ducklinghttpextractor",
             )
 
         extracted = self.add_extractor_name(extracted)

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -11,6 +11,7 @@ from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.extractors import EntityExtractor
 from rasa.nlu.model import Metadata
 from rasa.nlu.training_data import Message
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -178,11 +179,12 @@ class DucklingHTTPExtractor(EntityExtractor):
             )
         else:
             extracted = []
-            warnings.warn(
+            raise_warning(
                 "Duckling HTTP component in pipeline, but no "
                 "`url` configuration in the config "
                 "file nor is `RASA_DUCKLING_HTTP_URL` "
-                "set as an environment variable."
+                "set as an environment variable. No entities will be extracted!",
+                docs="/nlu/components/#ducklinghttpextractor",
             )
 
         extracted = self.add_extractor_name(extracted)

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -9,6 +9,7 @@ from rasa.nlu.model import Metadata
 from rasa.nlu.training_data import Message, TrainingData
 from rasa.nlu.utils import write_json_to_file
 import rasa.utils.io
+from rasa.utils.common import raise_warning
 
 
 class EntitySynonymMapper(EntityExtractor):
@@ -75,8 +76,9 @@ class EntitySynonymMapper(EntityExtractor):
             synonyms = rasa.utils.io.read_json_file(entity_synonyms_file)
         else:
             synonyms = None
-            warnings.warn(
-                f"Failed to load synonyms file from '{entity_synonyms_file}'."
+            raise_warning(
+                f"Failed to load synonyms file from '{entity_synonyms_file}'.",
+                docs="/nlu/training-data-format/#entity-synonyms",
             )
         return cls(meta, synonyms)
 
@@ -96,14 +98,15 @@ class EntitySynonymMapper(EntityExtractor):
             if original != replacement:
                 original = original.lower()
                 if original in self.synonyms and self.synonyms[original] != replacement:
-                    warnings.warn(
-                        "Found conflicting synonym definitions "
+                    raise_warning(
+                        f"Found conflicting synonym definitions "
                         f"for {repr(original)}. Overwriting target "
                         f"{repr(self.synonyms[original])} with "
                         f"{repr(replacement)}. "
-                        "Check your training data and remove "
-                        "conflicting synonym definitions to "
-                        "prevent this from happening."
+                        f"Check your training data and remove "
+                        f"conflicting synonym definitions to "
+                        f"prevent this from happening.",
+                        docs="/nlu/training-data-format/#entity-synonyms",
                     )
 
                 self.synonyms[original] = replacement

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -2,6 +2,7 @@ import os
 import warnings
 from typing import Any, Dict, Optional, Text
 
+from rasa.constants import DOCS_URL_TRAINING_DATA_NLU
 from rasa.nlu.constants import ENTITIES_ATTRIBUTE
 from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.extractors import EntityExtractor
@@ -78,7 +79,7 @@ class EntitySynonymMapper(EntityExtractor):
             synonyms = None
             raise_warning(
                 f"Failed to load synonyms file from '{entity_synonyms_file}'.",
-                docs="/nlu/training-data-format/#entity-synonyms",
+                docs=DOCS_URL_TRAINING_DATA_NLU + "#entity-synonyms",
             )
         return cls(meta, synonyms)
 
@@ -106,7 +107,7 @@ class EntitySynonymMapper(EntityExtractor):
                         f"Check your training data and remove "
                         f"conflicting synonym definitions to "
                         f"prevent this from happening.",
-                        docs="/nlu/training-data-format/#entity-synonyms",
+                        docs=DOCS_URL_TRAINING_DATA_NLU + "#entity-synonyms",
                     )
 
                 self.synonyms[original] = replacement

--- a/rasa/nlu/extractors/mitie_entity_extractor.py
+++ b/rasa/nlu/extractors/mitie_entity_extractor.py
@@ -10,6 +10,7 @@ from rasa.nlu.extractors import EntityExtractor
 from rasa.nlu.model import Metadata
 from rasa.nlu.tokenizers.tokenizer import Token
 from rasa.nlu.training_data import Message, TrainingData
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -105,16 +106,21 @@ class MitieEntityExtractor(EntityExtractor):
                 # if the token is not aligned an exception will be raised
                 start, end = MitieEntityExtractor.find_entity(ent, text, tokens)
             except ValueError as e:
-                warnings.warn(f"Example skipped: {e}")
+                raise_warning(
+                    f"Failed to use example '{text}' to train MITIE "
+                    f"entity extractor. Example will be skipped."
+                    f"Error: {e}"
+                )
                 continue
             try:
                 # mitie will raise an exception on malicious
                 # input - e.g. on overlapping entities
                 sample.add_entity(list(range(start, end)), ent["entity"])
             except Exception as e:
-                warnings.warn(
-                    "Failed to add entity example "
-                    f"'{str(e)}' of sentence '{str(text)}'. Reason: "
+                raise_warning(
+                    f"Failed to add entity example "
+                    f"'{str(e)}' of sentence '{str(text)}'. "
+                    f"Example will be ignored. Reason: "
                     f"{e}"
                 )
                 continue

--- a/rasa/nlu/featurizers/dense_featurizer/convert_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/convert_featurizer.py
@@ -15,6 +15,8 @@ from rasa.nlu.constants import (
 import numpy as np
 import tensorflow as tf
 
+from rasa.utils.common import raise_warning
+
 logger = logging.getLogger(__name__)
 
 
@@ -174,11 +176,12 @@ class ConveRTFeaturizer(Featurizer):
     ) -> None:
 
         if config is not None and config.language != "en":
-            warnings.warn(
+            raise_warning(
                 f"Since ``ConveRT`` model is trained only on an english "
                 f"corpus of conversations, this featurizer should only be "
                 f"used if your training data is in english language. "
-                f"However, you are training in '{config.language}'."
+                f"However, you are training in '{config.language}'.",
+                docs="/nlu/components/#convertfeaturizer",
             )
 
         batch_size = 64

--- a/rasa/nlu/featurizers/dense_featurizer/convert_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/convert_featurizer.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 from typing import Any, Dict, List, Optional, Text, Tuple
 
+from rasa.constants import DOCS_URL_COMPONENTS
 from rasa.nlu.tokenizers.tokenizer import Token
 from rasa.nlu.featurizers.featurizer import Featurizer
 from rasa.nlu.config import RasaNLUModelConfig
@@ -181,7 +182,7 @@ class ConveRTFeaturizer(Featurizer):
                 f"corpus of conversations, this featurizer should only be "
                 f"used if your training data is in english language. "
                 f"However, you are training in '{config.language}'.",
-                docs="/nlu/components/#convertfeaturizer",
+                docs=DOCS_URL_COMPONENTS + "#convertfeaturizer",
             )
 
         batch_size = 64

--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -3,6 +3,8 @@ import os
 import re
 import scipy.sparse
 from typing import Any, Dict, List, Optional, Text
+
+from rasa.constants import DOCS_URL_COMPONENTS
 from rasa.utils.common import raise_warning
 
 from sklearn.feature_extraction.text import CountVectorizer
@@ -296,7 +298,7 @@ class CountVectorsFeaturizer(Featurizer):
                 f"The out of vocabulary token '{self.OOV_token}' was configured, but "
                 f"could not be found in any one of the NLU message training examples. "
                 f"All unseen words will be ignored during prediction.",
-                docs="/nlu/components/#countvectorsfeaturizer",
+                docs=DOCS_URL_COMPONENTS + "#countvectorsfeaturizer",
             )
 
     def _get_all_attributes_processed_tokens(

--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -3,6 +3,7 @@ import os
 import re
 import scipy.sparse
 from typing import Any, Dict, List, Optional, Text
+from rasa.utils.common import raise_warning
 
 from sklearn.feature_extraction.text import CountVectorizer
 from rasa.nlu import utils
@@ -291,10 +292,11 @@ class CountVectorsFeaturizer(Featurizer):
 
         if any(text for tokens in all_tokens for text in tokens):
             # if there is some text in tokens, warn if there is no oov token
-            logger.warning(
-                f"OOV_token='{self.OOV_token}' was given, but it is not present "
-                "in the training data. All unseen words "
-                "will be ignored during prediction."
+            raise_warning(
+                f"The out of vocabulary token '{self.OOV_token}' was configured, but "
+                f"could not be found in any one of the NLU message training examples. "
+                f"All unseen words will be ignored during prediction.",
+                docs="/nlu/components/#countvectorsfeaturizer",
             )
 
     def _get_all_attributes_processed_tokens(

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -5,6 +5,8 @@ import typing
 from typing import Any, Dict, List, Optional, Text, Union
 
 import numpy as np
+
+from rasa.constants import DOCS_URL_TRAINING_DATA_NLU
 import rasa.utils.io
 import rasa.utils.io
 import scipy.sparse
@@ -131,7 +133,7 @@ class RegexFeaturizer(Featurizer):
                 f"Directly including lookup tables as a list is deprecated since Rasa "
                 f"1.6.",
                 FutureWarning,
-                docs="/nlu/training-data-format/#lookup-tables",
+                docs=DOCS_URL_TRAINING_DATA_NLU + "#lookup-tables",
             )
 
         # otherwise it's a file path.

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -1,26 +1,25 @@
 import logging
-import warnings
-
-import numpy as np
 import os
 import re
 import typing
-import scipy.sparse
-from typing import Any, Dict, Optional, Text, Union, List
+from typing import Any, Dict, List, Optional, Text, Union
 
+import numpy as np
+import rasa.utils.io
+import rasa.utils.io
+import scipy.sparse
 from rasa.nlu import utils
 from rasa.nlu.config import RasaNLUModelConfig
-from rasa.nlu.featurizers.featurizer import Featurizer
-from rasa.nlu.training_data import Message, TrainingData
-import rasa.utils.io
 from rasa.nlu.constants import (
-    TOKENS_NAMES,
-    TEXT_ATTRIBUTE,
+    CLS_TOKEN,
     RESPONSE_ATTRIBUTE,
     SPARSE_FEATURE_NAMES,
-    CLS_TOKEN,
+    TEXT_ATTRIBUTE,
+    TOKENS_NAMES,
 )
-from rasa.constants import DOCS_BASE_URL
+from rasa.nlu.featurizers.featurizer import Featurizer
+from rasa.nlu.training_data import Message, TrainingData
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -128,11 +127,11 @@ class RegexFeaturizer(Featurizer):
         # if it's a list, it should be the elements directly
         if isinstance(lookup_elements, list):
             elements_to_regex = lookup_elements
-            warnings.warn(
+            raise_warning(
                 f"Directly including lookup tables as a list is deprecated since Rasa "
-                f"1.6. See {DOCS_BASE_URL}/nlu/training-data-format/#lookup-tables "
-                f"how to do so.",
+                f"1.6.",
                 FutureWarning,
+                docs="/nlu/training-data-format/#lookup-tables",
             )
 
         # otherwise it's a file path.

--- a/rasa/nlu/registry.py
+++ b/rasa/nlu/registry.py
@@ -5,7 +5,6 @@ Hence, it imports all of the components. To avoid cycles, no component should
 import this in module scope."""
 
 import logging
-import warnings
 import typing
 from typing import Any, Dict, List, Optional, Text, Type
 
@@ -13,29 +12,28 @@ from rasa.nlu.classifiers.embedding_intent_classifier import EmbeddingIntentClas
 from rasa.nlu.classifiers.keyword_intent_classifier import KeywordIntentClassifier
 from rasa.nlu.classifiers.mitie_intent_classifier import MitieIntentClassifier
 from rasa.nlu.classifiers.sklearn_intent_classifier import SklearnIntentClassifier
-from rasa.nlu.selectors.embedding_response_selector import ResponseSelector
 from rasa.nlu.extractors.crf_entity_extractor import CRFEntityExtractor
 from rasa.nlu.extractors.duckling_http_extractor import DucklingHTTPExtractor
 from rasa.nlu.extractors.entity_synonyms import EntitySynonymMapper
 from rasa.nlu.extractors.mitie_entity_extractor import MitieEntityExtractor
 from rasa.nlu.extractors.spacy_entity_extractor import SpacyEntityExtractor
+from rasa.nlu.featurizers.dense_featurizer.convert_featurizer import ConveRTFeaturizer
+from rasa.nlu.featurizers.dense_featurizer.mitie_featurizer import MitieFeaturizer
+from rasa.nlu.featurizers.dense_featurizer.spacy_featurizer import SpacyFeaturizer
 from rasa.nlu.featurizers.sparse_featurizer.count_vectors_featurizer import (
     CountVectorsFeaturizer,
 )
-from rasa.nlu.featurizers.dense_featurizer.mitie_featurizer import MitieFeaturizer
 from rasa.nlu.featurizers.sparse_featurizer.regex_featurizer import RegexFeaturizer
-from rasa.nlu.featurizers.dense_featurizer.spacy_featurizer import SpacyFeaturizer
-from rasa.nlu.featurizers.dense_featurizer.convert_featurizer import ConveRTFeaturizer
 from rasa.nlu.model import Metadata
+from rasa.nlu.selectors.embedding_response_selector import ResponseSelector
+from rasa.nlu.tokenizers.convert_tokenizer import ConveRTTokenizer
 from rasa.nlu.tokenizers.jieba_tokenizer import JiebaTokenizer
 from rasa.nlu.tokenizers.mitie_tokenizer import MitieTokenizer
-from rasa.nlu.tokenizers.convert_tokenizer import ConveRTTokenizer
 from rasa.nlu.tokenizers.spacy_tokenizer import SpacyTokenizer
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.utils.mitie_utils import MitieNLP
 from rasa.nlu.utils.spacy_utils import SpacyNLP
-from rasa.utils.common import class_from_module_path
-
+from rasa.utils.common import class_from_module_path, raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.nlu.components import Component
@@ -182,12 +180,13 @@ def get_component_class(component_name: Text) -> Type["Component"]:
                 raise ModuleNotFoundError(exception_message)
         else:
             # DEPRECATED ensures compatibility, remove in future versions
-            warnings.warn(
-                "Your nlu config file "
+            raise_warning(
+                f"Your nlu config file "
                 f"contains old style component name `{component_name}`, "
-                f"you should change it to its class name: "
+                f"you should change it to its new class name: "
                 f"`{old_style_names[component_name]}`.",
                 FutureWarning,
+                docs="/nlu/components/",
             )
             component_name = old_style_names[component_name]
 

--- a/rasa/nlu/registry.py
+++ b/rasa/nlu/registry.py
@@ -8,6 +8,7 @@ import logging
 import typing
 from typing import Any, Dict, List, Optional, Text, Type
 
+from rasa.constants import DOCS_URL_COMPONENTS
 from rasa.nlu.classifiers.embedding_intent_classifier import EmbeddingIntentClassifier
 from rasa.nlu.classifiers.keyword_intent_classifier import KeywordIntentClassifier
 from rasa.nlu.classifiers.mitie_intent_classifier import MitieIntentClassifier
@@ -186,7 +187,7 @@ def get_component_class(component_name: Text) -> Type["Component"]:
                 f"you should change it to its new class name: "
                 f"`{old_style_names[component_name]}`.",
                 FutureWarning,
-                docs="/nlu/components/",
+                docs=DOCS_URL_COMPONENTS,
             )
             component_name = old_style_names[component_name]
 

--- a/rasa/nlu/training_data/formats/dialogflow.py
+++ b/rasa/nlu/training_data/formats/dialogflow.py
@@ -4,6 +4,7 @@ import typing
 import warnings
 from typing import Any, Dict, Optional, Text, List, Tuple
 
+from rasa.constants import DOCS_URL_MIGRATE_GOOGLE
 import rasa.utils.io
 from rasa.nlu import utils
 from rasa.nlu.training_data.formats.readerwriter import TrainingDataReader
@@ -43,7 +44,7 @@ class DialogflowReader(TrainingDataReader):
         if not examples_js:
             raise_warning(
                 f"No training examples found for dialogflow file {fn}!",
-                docs="/migrate-from/google-dialogflow-to-rasa/",
+                docs=DOCS_URL_MIGRATE_GOOGLE,
             )
             return TrainingData()
         elif fformat == DIALOGFLOW_INTENT:

--- a/rasa/nlu/training_data/formats/dialogflow.py
+++ b/rasa/nlu/training_data/formats/dialogflow.py
@@ -8,6 +8,7 @@ import rasa.utils.io
 from rasa.nlu import utils
 from rasa.nlu.training_data.formats.readerwriter import TrainingDataReader
 from rasa.nlu.training_data.util import transform_entity_synonyms
+from rasa.utils.common import raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.nlu.training_data import TrainingData
@@ -40,7 +41,10 @@ class DialogflowReader(TrainingDataReader):
         examples_js = self._read_examples_js(fn, language, fformat)
 
         if not examples_js:
-            warnings.warn(f"No training examples found for dialogflow file {fn}!")
+            raise_warning(
+                f"No training examples found for dialogflow file {fn}!",
+                docs="/migrate-from/google-dialogflow-to-rasa/",
+            )
             return TrainingData()
         elif fformat == DIALOGFLOW_INTENT:
             return self._read_intent(root_js, examples_js)

--- a/rasa/nlu/training_data/formats/luis.py
+++ b/rasa/nlu/training_data/formats/luis.py
@@ -4,6 +4,7 @@ import typing
 from typing import Any, Dict, Text
 
 from rasa.nlu.training_data.formats.readerwriter import JsonTrainingDataReader
+from rasa.utils.common import raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.nlu.training_data import Message, TrainingData
@@ -22,7 +23,7 @@ class LuisReader(JsonTrainingDataReader):
         max_tested_luis_schema_version = 5
         major_version = int(js["luis_schema_version"].split(".")[0])
         if major_version > max_tested_luis_schema_version:
-            warnings.warn(
+            raise_warning(
                 f"Your luis data schema version {js['luis_schema_version']} "
                 f"is higher than 5.x.x. "
                 f"Training may not be performed correctly. "

--- a/rasa/nlu/training_data/formats/rasa.py
+++ b/rasa/nlu/training_data/formats/rasa.py
@@ -1,9 +1,7 @@
-from collections import defaultdict
-
 import logging
-import warnings
 import typing
-from typing import Any, Dict, Text, Tuple
+from collections import defaultdict
+from typing import Any, Dict, Text
 
 from rasa.constants import DOCS_BASE_URL
 from rasa.nlu.training_data.formats.readerwriter import (
@@ -12,12 +10,7 @@ from rasa.nlu.training_data.formats.readerwriter import (
 )
 from rasa.nlu.training_data.util import transform_entity_synonyms
 from rasa.nlu.utils import json_to_string
-from rasa.nlu.constants import (
-    INTENT_ATTRIBUTE,
-    RESPONSE_KEY_ATTRIBUTE,
-    RESPONSE_ATTRIBUTE,
-    RESPONSE_IDENTIFIER_DELIMITER,
-)
+from rasa.utils.common import raise_warning
 
 if typing.TYPE_CHECKING:
     from rasa.nlu.training_data import Message, TrainingData
@@ -43,7 +36,7 @@ class RasaReader(JsonTrainingDataReader):
         entity_synonyms = transform_entity_synonyms(entity_synonyms)
 
         if intent_examples or entity_examples:
-            warnings.warn(
+            raise_warning(
                 "Your rasa data "
                 "contains 'intent_examples' "
                 "or 'entity_examples' which will be "
@@ -51,6 +44,7 @@ class RasaReader(JsonTrainingDataReader):
                 "putting all your examples "
                 "into the 'common_examples' section.",
                 FutureWarning,
+                docs="/nlu/training-data-format/",
             )
 
         all_examples = common_examples + intent_examples + entity_examples

--- a/rasa/nlu/training_data/formats/rasa.py
+++ b/rasa/nlu/training_data/formats/rasa.py
@@ -3,7 +3,7 @@ import typing
 from collections import defaultdict
 from typing import Any, Dict, Text
 
-from rasa.constants import DOCS_BASE_URL
+from rasa.constants import DOCS_BASE_URL, DOCS_URL_TRAINING_DATA_NLU
 from rasa.nlu.training_data.formats.readerwriter import (
     JsonTrainingDataReader,
     TrainingDataWriter,
@@ -44,7 +44,7 @@ class RasaReader(JsonTrainingDataReader):
                 "putting all your examples "
                 "into the 'common_examples' section.",
                 FutureWarning,
-                docs="/nlu/training-data-format/",
+                docs=DOCS_URL_TRAINING_DATA_NLU,
             )
 
         all_examples = common_examples + intent_examples + entity_examples

--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -1,14 +1,13 @@
 import logging
 import os
 import random
-import warnings
 from collections import Counter, OrderedDict
 from copy import deepcopy
 from os.path import relpath
 from typing import Any, Dict, List, Optional, Set, Text, Tuple
 
 import rasa.nlu.utils
-import rasa.utils.common as rasa_utils
+from rasa.utils.common import raise_warning, lazy_property
 from rasa.nlu.constants import RESPONSE_ATTRIBUTE, RESPONSE_KEY_ATTRIBUTE
 from rasa.nlu.training_data.message import Message
 from rasa.nlu.training_data.util import check_duplicate_synonym
@@ -114,29 +113,29 @@ class TrainingData:
 
         return list(OrderedDict.fromkeys(examples))
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def intent_examples(self) -> List[Message]:
         return [ex for ex in self.training_examples if ex.get("intent")]
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def response_examples(self) -> List[Message]:
         return [ex for ex in self.training_examples if ex.get("response")]
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def entity_examples(self) -> List[Message]:
         return [ex for ex in self.training_examples if ex.get("entities")]
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def intents(self) -> Set[Text]:
         """Returns the set of intents in the training data."""
         return {ex.get("intent") for ex in self.training_examples} - {None}
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def responses(self) -> Set[Text]:
         """Returns the set of responses in the training data."""
         return {ex.get("response") for ex in self.training_examples} - {None}
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def retrieval_intents(self) -> Set[Text]:
         """Returns the total number of response types in the training data"""
         return {
@@ -145,24 +144,24 @@ class TrainingData:
             if ex.get("response") is not None
         }
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def examples_per_intent(self) -> Dict[Text, int]:
         """Calculates the number of examples per intent."""
         intents = [ex.get("intent") for ex in self.training_examples]
         return dict(Counter(intents))
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def examples_per_response(self) -> Dict[Text, int]:
         """Calculates the number of examples per response."""
         return dict(Counter(self.responses))
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def entities(self) -> Set[Text]:
         """Returns the set of entity types in the training data."""
         entity_types = [e.get("entity") for e in self.sorted_entities()]
         return set(entity_types)
 
-    @rasa_utils.lazy_property
+    @lazy_property
     def examples_per_entity(self) -> Dict[Text, int]:
         """Calculates the number of examples per entity."""
         entity_types = [e.get("entity") for e in self.sorted_entities()]
@@ -206,7 +205,7 @@ class TrainingData:
 
     def as_json(self) -> Text:
 
-        warnings.warn(
+        raise_warning(
             "Function 'as_json()' is deprecated and will be removed "
             "in future versions. Use 'nlu_as_json()' instead.",
             DeprecationWarning,
@@ -234,7 +233,7 @@ class TrainingData:
 
     def as_markdown(self) -> Text:
 
-        warnings.warn(
+        raise_warning(
             "Function 'as_markdown()' is deprecated and will be removed "
             "in future versions. Use 'nlu_as_markdown()' and 'nlg_as_markdown()' "
             "instead.",
@@ -310,14 +309,14 @@ class TrainingData:
 
         logger.debug("Validating training data...")
         if "" in self.intents:
-            warnings.warn(
+            raise_warning(
                 "Found empty intent, please check your "
                 "training data. This may result in wrong "
                 "intent predictions."
             )
 
         if "" in self.responses:
-            warnings.warn(
+            raise_warning(
                 "Found empty response, please check your "
                 "training data. This may result in wrong "
                 "response predictions."
@@ -326,7 +325,7 @@ class TrainingData:
         # emit warnings for intents with only a few training samples
         for intent, count in self.examples_per_intent.items():
             if count < self.MIN_EXAMPLES_PER_INTENT:
-                warnings.warn(
+                raise_warning(
                     f"Intent '{intent}' has only {count} training examples! "
                     f"Minimum is {self.MIN_EXAMPLES_PER_INTENT}, training may fail."
                 )
@@ -334,9 +333,10 @@ class TrainingData:
         # emit warnings for entities with only a few training samples
         for entity_type, count in self.examples_per_entity.items():
             if count < self.MIN_EXAMPLES_PER_ENTITY:
-                warnings.warn(
+                raise_warning(
                     f"Entity '{entity_type}' has only {count} training examples! "
-                    f"minimum is {self.MIN_EXAMPLES_PER_ENTITY}, training may fail."
+                    f"The minimum is {self.MIN_EXAMPLES_PER_ENTITY}, because of "
+                    f"this the training may fail."
                 )
 
     def train_test_split(

--- a/rasa/nlu/training_data/util.py
+++ b/rasa/nlu/training_data/util.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import warnings
 from typing import Any, Dict, Optional, Text
 
 import rasa.utils.io as io_utils
@@ -10,6 +9,7 @@ from rasa.nlu.constants import (
     EXTRACTOR_ATTRIBUTE,
     PRETRAINED_EXTRACTORS,
 )
+from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def check_duplicate_synonym(
     entity_synonyms: Dict[Text, Any], text: Text, syn: Text, context_str: Text = ""
 ) -> None:
     if text in entity_synonyms and entity_synonyms[text] != syn:
-        warnings.warn(
+        raise_warning(
             f"Found inconsistent entity synonyms while {context_str}, "
             f"overwriting {text}->{entity_synonyms[text]} "
             f"with {text}->{syn} during merge."

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -1,38 +1,31 @@
 import logging
-import warnings
 import multiprocessing
 import os
 import tempfile
 import traceback
 import typing
-from functools import wraps, reduce
+from functools import reduce, wraps
 from inspect import isawaitable
 from typing import Any, Callable, List, Optional, Text, Union
 
-from sanic import Sanic, response
-from sanic.request import Request
-from sanic.response import HTTPResponse
-from sanic_cors import CORS
-from sanic_jwt import Initialize, exceptions
-
 import rasa
 import rasa.core.utils
-import rasa.utils.common
+from rasa.utils.common import raise_warning, arguments_of
 import rasa.utils.endpoints
 import rasa.utils.io
 from rasa import model
 from rasa.constants import (
-    MINIMUM_COMPATIBLE_VERSION,
-    DEFAULT_MODELS_PATH,
     DEFAULT_DOMAIN_PATH,
+    DEFAULT_MODELS_PATH,
     DOCS_BASE_URL,
+    MINIMUM_COMPATIBLE_VERSION,
 )
-from rasa.core.agent import load_agent, Agent
+from rasa.core.agent import Agent, load_agent
 from rasa.core.brokers.broker import EventBroker
 from rasa.core.channels.channel import (
-    UserMessage,
     CollectingOutputChannel,
     OutputChannel,
+    UserMessage,
 )
 from rasa.core.domain import InvalidDomain
 from rasa.core.events import Event
@@ -44,6 +37,11 @@ from rasa.core.utils import AvailableEndpoints
 from rasa.nlu.emulators.no_emulator import NoEmulator
 from rasa.nlu.test import run_evaluation
 from rasa.utils.endpoints import EndpointConfig
+from sanic import Sanic, Sanic, response, response
+from sanic.request import Request, Request
+from sanic.response import HTTPResponse
+from sanic_cors import CORS, CORS
+from sanic_jwt import Initialize, Initialize, exceptions, exceptions
 
 if typing.TYPE_CHECKING:
     from ssl import SSLContext
@@ -117,7 +115,7 @@ def requires_auth(app: Sanic, token: Optional[Text] = None) -> Callable[[Any], A
 
     def decorator(f: Callable[[Any, Any], Any]) -> Callable[[Any, Any], Any]:
         def conversation_id_from_args(args: Any, kwargs: Any) -> Optional[Text]:
-            argnames = rasa.utils.common.arguments_of(f)
+            argnames = arguments_of(f)
 
             try:
                 sender_id_arg_idx = argnames.index("conversation_id")
@@ -500,7 +498,7 @@ def create_app(
         events = [event for event in events if event]
 
         if not events:
-            warnings.warn(
+            raise_warning(
                 f"Append event called, but could not extract a valid event. "
                 f"Request JSON: {request.json}"
             )
@@ -583,9 +581,11 @@ def create_app(
             )
 
         # Deprecation warning
-        warnings.warn(
+        raise_warning(
             "Triggering actions via the execute endpoint is deprecated. "
-            "Trigger an intent via the `/conversations/<conversation_id>/trigger_intent` endpoint instead.",
+            "Trigger an intent via the "
+            "`/conversations/<conversation_id>/trigger_intent` "
+            "endpoint instead.",
             FutureWarning,
         )
 

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -310,7 +310,7 @@ def raise_warning(
 
     original_formatter = warnings.formatwarning
 
-    def should_show_source_line():
+    def should_show_source_line() -> bool:
         if "stacklevel" not in kwargs:
             if category == UserWarning or category is None:
                 return False
@@ -318,7 +318,13 @@ def raise_warning(
                 return False
         return True
 
-    def formatwarning(message, category, filename, lineno, line=None):
+    def formatwarning(
+        message: Text,
+        category: Optional[Type[Warning]],
+        filename: Text,
+        lineno: Optional[int],
+        line: Optional[Text] = None,
+    ):
         """Function to format a warning the standard way."""
 
         if not should_show_source_line():
@@ -327,8 +333,10 @@ def raise_warning(
             else:
                 line = ""
 
-        msg = original_formatter(message, category, filename, lineno, line)
-        return utils.wrap_with_color(msg, color=bcolors.WARNING)
+        formatted_message = original_formatter(
+            message, category, filename, lineno, line
+        )
+        return utils.wrap_with_color(formatted_message, color=bcolors.WARNING)
 
     if "stacklevel" not in kwargs:
         # try to set useful defaults for the most common warning categories

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -15,7 +15,6 @@ from rasa.constants import (
     ENV_LOG_LEVEL,
     ENV_LOG_LEVEL_LIBRARIES,
     GLOBAL_USER_CONFIG_PATH,
-    DOCS_BASE_URL,
 )
 
 logger = logging.getLogger(__name__)
@@ -324,7 +323,7 @@ def raise_warning(
 
         if not should_show_source_line():
             if docs:
-                line = f"More info at {DOCS_BASE_URL}{docs}"
+                line = f"More info at {docs}"
             else:
                 line = ""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ codestyle_exclude =
     rasa/core/policies/__init__.py
 filterwarnings =
     ignore::ResourceWarning:ruamel[.*]
+    #error
 
 log_cli = true
 log_cli_level = WARNING

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -13,7 +13,6 @@ from rasa.cli.utils import (
     parse_last_positional_argument_as_model_path,
     get_validated_path,
 )
-from tests.conftest import assert_log_emitted
 
 
 @contextlib.contextmanager
@@ -98,31 +97,9 @@ def test_validate_with_invalid_directory_if_default_is_valid(caplog: LogCaptureF
     with pytest.warns(UserWarning) as record:
         assert get_validated_path(invalid_directory, "out", tempdir) == tempdir
     assert len(record) == 1
-    assert "does not exist" in record[0].message.args[0]
+    assert "does not seem to exist" in record[0].message.args[0]
 
 
 def test_print_error_and_exit():
     with pytest.raises(SystemExit):
         rasa.cli.utils.print_error_and_exit("")
-
-
-def test_logging_capture(caplog: LogCaptureFixture):
-    logger = logging.getLogger(__name__)
-
-    # make a random INFO log and ensure it passes decorator
-    info_text = "SOME INFO"
-    logger.info(info_text)
-    with assert_log_emitted(caplog, logger.name, logging.INFO, info_text):
-        pass
-
-
-def test_logging_capture_failure(caplog: LogCaptureFixture):
-    logger = logging.getLogger(__name__)
-
-    # make a random INFO log
-    logger.info("SOME INFO")
-
-    # test for string in log that wasn't emitted
-    with pytest.raises(AssertionError):
-        with assert_log_emitted(caplog, logger.name, logging.INFO, "NONONO"):
-            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,14 +34,6 @@ DEFAULT_CONFIG_PATH = "rasa/cli/default_config.yml"
 pytest_plugins = ["pytester"]
 
 
-@pytest.fixture(autouse=True)
-def set_log_level_debug(caplog: LogCaptureFixture) -> None:
-    # Set the post-test log level to DEBUG for failing tests.  For all tests
-    # (failing and successful), the live log level can be additionally set in
-    # `setup.cfg`. It should be set to WARNING.
-    caplog.set_level(logging.DEBUG)
-
-
 @pytest.fixture
 async def default_agent(tmpdir_factory: TempdirFactory) -> Agent:
     model_path = tmpdir_factory.mktemp("model").strpath
@@ -220,50 +212,3 @@ def get_test_client(server):
     test_client = server.test_client
     test_client.port = None
     return test_client
-
-
-@contextmanager
-def assert_log_emitted(
-    _caplog: LogCaptureFixture, logger_name: Text, log_level: int, text: Text = None
-) -> None:
-    """Context manager testing whether a logging message has been emitted.
-
-    Provides a context in which an assertion is made about a logging message.
-    Raises an `AssertionError` if the log isn't emitted as expected.
-
-    Example usage:
-
-    ```
-    with assert_log_emitted(caplog, LOGGER_NAME, LOGGING_LEVEL, TEXT):
-        <method supposed to emit TEXT at level LOGGING_LEVEL>
-    ```
-
-    Args:
-        _caplog: `LogCaptureFixture` used to capture logs.
-        logger_name: Name of the logger being examined.
-        log_level: Log level to be tested.
-        text: Logging message to be tested (optional). If left blank, assertion is made
-            only about `log_level` and `logger_name`.
-
-    Yields:
-        `None`
-
-    """
-
-    yield
-
-    record_tuples = _caplog.record_tuples
-
-    if not any(
-        (
-            record[0] == logger_name
-            and record[1] == log_level
-            and (text in record[2] if text else True)
-        )
-        for record in record_tuples
-    ):
-        raise AssertionError(
-            f"Did not detect expected logging output.\nExpected output is (logger "
-            f"name, log level, text): ({logger_name}, {log_level}, {text})\n"
-            f"Instead found records:\n{record_tuples}"
-        )

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -78,13 +78,14 @@ async def test_log_unseen_feature(default_processor: MessageProcessor):
     with pytest.warns(UserWarning) as record:
         default_processor._log_unseen_features(parsed)
     assert len(record) == 2
+
     assert (
-        record[0].message.args[0]
-        == "Interpreter parsed an intent 'dislike' that is not defined in the domain."
+        record[0].message.args[0].startswith("Interpreter parsed an intent 'dislike'")
     )
     assert (
-        record[1].message.args[0]
-        == "Interpreter parsed an entity 'test_entity' that is not defined in the domain."
+        record[1]
+        .message.args[0]
+        .startswith("Interpreter parsed an entity 'test_entity'")
     )
 
 

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -163,7 +163,7 @@ def test_tracker_store_deprecated_url_argument_from_string(default_domain: Domai
     store_config = read_endpoint_config(endpoints_path, "tracker_store")
     store_config.type = "tests.core.test_tracker_stores.URLExampleTrackerStore"
 
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         tracker_store = TrackerStore.create(store_config, default_domain)
 
     assert isinstance(tracker_store, URLExampleTrackerStore)

--- a/tests/core/test_validator.py
+++ b/tests/core/test_validator.py
@@ -81,10 +81,7 @@ async def test_verify_logging_message_for_repetition_in_intents(caplog):
     with pytest.warns(UserWarning) as record:
         validator.verify_example_repetition_in_intents(False)
     assert len(record) == 1
-    assert (
-        "The example 'good afternoon' was found in "
-        "multiple intents: goodbye, greet" in record[0].message.args[0]
-    )
+    assert "You should fix that conflict " in record[0].message.args[0]
 
 
 async def test_early_exit_on_invalid_domain():

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -1,10 +1,29 @@
-import rasa.utils.common as common_utils
+import pytest
+
+from rasa.utils.common import raise_warning, sort_list_of_dicts_by_first_key
 
 
 def test_sort_dicts_by_keys():
     test_data = [{"Z": 1}, {"A": 10}]
 
     expected = [{"A": 10}, {"Z": 1}]
-    actual = common_utils.sort_list_of_dicts_by_first_key(test_data)
+    actual = sort_list_of_dicts_by_first_key(test_data)
 
     assert actual == expected
+
+
+def test_raise_warning():
+    with pytest.warns(UserWarning) as record:
+        raise_warning("My warning.")
+
+    assert len(record) == 1
+    assert record[0].message.args[0] == "My warning."
+
+
+def test_raise_deprecation():
+    with pytest.warns(DeprecationWarning) as record:
+        raise_warning("My warning.", DeprecationWarning)
+
+    assert len(record) == 1
+    assert record[0].message.args[0] == "My warning."
+    assert isinstance(record[0].message, DeprecationWarning)


### PR DESCRIPTION
**Proposed changes**:
- Improve warnings: use color and sane defaults when emitting warnings for our users
- Makes sure the warning messages are colored and use a sane stack level for the warning message (e.g. by default this would be the line emitting the warning, which in most cases doesn't make sense).
- If the code line is not relevant (e.g. if the warning is about an intent that should be listed in the domain but is not) we add a link to some relevant documentation page.
- related to https://github.com/RasaHQ/rasa/issues/4356

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
