### PR TITLE
Allow metadata to be attached to any tracker Event

### DIFF
--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -566,6 +566,21 @@ def test_last_executed_has_not_name():
     assert tracker.last_executed_action_has("another") is False
 
 
+def test_events_metadata():
+    # It should be possible to attach arbitrary metadata to any event and then
+    # retrieve it after getting the tracker dict representation.
+    events = [
+        ActionExecuted("one", metadata={"one": 1}),
+        user_uttered("two", 1, metadata={"two": 2}),
+        ActionExecuted(ACTION_LISTEN_NAME, metadata={"three": 3}),
+    ]
+
+    events = get_tracker(events).current_state(EventVerbosity.ALL)["events"]
+    assert events[0]["metadata"] == {"one": 1}
+    assert events[1]["metadata"] == {"two": 2}
+    assert events[2]["metadata"] == {"three": 3}
+
+
 @pytest.mark.parametrize("key, value", [("asfa", 1), ("htb", None)])
 def test_tracker_without_slots(key, value, caplog):
     event = SlotSet(key, value)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,4 +1,6 @@
 import os
+import random
+
 from decimal import Decimal
 from typing import Optional, Text, Union
 
@@ -173,3 +175,17 @@ def test_lock_store_is_redis_lock_store(
 ):
     # noinspection PyProtectedMember
     assert rasa.core.utils._lock_store_is_redis_lock_store(lock_store) == expected
+
+
+def test_all_subclasses():
+    num = random.randint(1, 10)
+
+    class TestClass:
+        pass
+
+    classes = [
+        type(f"TestClass{i}", (TestClass,), {})
+        for i in range(num)
+    ]
+
+    assert utils.all_subclasses(TestClass) == classes

--- a/tests/core/utilities.py
+++ b/tests/core/utilities.py
@@ -2,7 +2,7 @@ import itertools
 
 import contextlib
 import typing
-from typing import Text, List, Optional
+from typing import Text, List, Optional, Text, Any, Dict
 
 import jsonpickle
 import os
@@ -65,10 +65,15 @@ def mocked_cmd_input(package, text: Text):
         package.get_user_input = i
 
 
-def user_uttered(text: Text, confidence: float) -> UserUttered:
+def user_uttered(
+    text: Text, confidence: float, metadata: Dict[Text, Any] = None
+) -> UserUttered:
     parse_data = {"intent": {"name": text, "confidence": confidence}}
     return UserUttered(
-        text="Random", intent=parse_data["intent"], parse_data=parse_data
+        text="Random",
+        intent=parse_data["intent"],
+        parse_data=parse_data,
+        metadata=metadata,
     )
 
 


### PR DESCRIPTION
**Proposed changes**:
- Allow attaching a `metadata` object to any `Event` subclass.
- The `metadata` object should be JSON-serializable.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
