### PR TITLE
Allow metadata to be attached to any tracker Event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 
 Added
 -----
+- Arbitrary metadata can now be attached to any ``Event`` subclass. The data must
+  be stored under the ``metadata`` key when reading an event from a JSON object or
+  dictionary.
 
 Changed
 -------

--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -32,6 +32,7 @@
   "events": [
     {
       "timestamp": 1517821726.211031,
+      "metadata": {},
       "event": "action",
       "name": "action_listen",
       "policy": null,
@@ -39,6 +40,7 @@
     },
     {
       "timestamp": 1517821726.200036,
+      "metadata": {},
       "parse_data": {
         "entities": [],
         "intent": {
@@ -63,10 +65,11 @@
       },
       "event": "user",
       "text": "/greet",
-      "input_channel": null, "message_id": null, "metadata": null
+      "input_channel": null, "message_id": null, "metadata": {}
     },
     {
       "timestamp": 1517821726.200373,
+      "metadata": {},
       "event": "action",
       "name": "utter_greet",
       "policy": null,
@@ -74,6 +77,7 @@
     },
     {
       "timestamp": 1517821726.211038,
+      "metadata": {},
       "event": "action",
       "name": "action_listen",
       "policy": null,
@@ -81,6 +85,7 @@
     },
     {
       "timestamp": 1517821726.209836,
+      "metadata": {},
       "parse_data": {
         "entities": [],
         "intent": {
@@ -105,10 +110,11 @@
       },
       "event": "user",
       "text": "/mood_great",
-      "input_channel": null, "message_id": null, "metadata": null
+      "input_channel": null, "message_id": null, "metadata": {}
     },
     {
       "timestamp": 1517821726.209908,
+      "metadata": {},
       "event": "action",
       "name": "utter_happy",
       "policy": "policy_1_KerasPolicy",
@@ -116,6 +122,7 @@
     },
     {
       "timestamp": 1517821726.211042,
+      "metadata": {},
       "event": "action",
       "name": "action_listen",
       "policy": "policy_2_MemoizationPolicy",

--- a/rasa/core/events/__init__.py
+++ b/rasa/core/events/__init__.py
@@ -86,6 +86,15 @@ class Event:
         self.timestamp = timestamp or time.time()
         self._metadata = metadata or {}
 
+    @property
+    def metadata(self):
+        # needed for backwards compatibility <1.0.0 - previously pickled events
+        # won't have the `_metadata` attribute
+        if hasattr(self, "_metadata"):
+            return self._metadata
+        else:
+            return {}
+
     def __ne__(self, other: Any) -> bool:
         # Not strictly necessary, but to avoid having both x==y and x!=y
         # True at the same time
@@ -134,7 +143,7 @@ class Event:
         return {
             "event": self.type_name,
             "timestamp": self.timestamp,
-            "metadata": self._metadata,
+            "metadata": self.metadata,
         }
 
     @classmethod
@@ -331,15 +340,6 @@ class BotUttered(Event):
         self.text = text
         self.data = data or {}
         super().__init__(timestamp, metadata)
-
-    @property
-    def metadata(self):
-        # needed for backwards compatibility <1.0.0 - previously pickled events
-        # won't have the `_metadata` attribute
-        if hasattr(self, "_metadata"):
-            return self._metadata
-        else:
-            return {}
 
     def __members(self):
         data_no_nones = utils.remove_none_values(self.data)

--- a/rasa/core/events/__init__.py
+++ b/rasa/core/events/__init__.py
@@ -1,6 +1,5 @@
 import time
 import typing
-from abc import ABC, abstractmethod
 
 import json
 import jsonpickle
@@ -74,7 +73,7 @@ def first_key(d, default_key):
 
 
 # noinspection PyProtectedMember
-class Event(ABC):
+class Event:
     """Events describe everything that occurs in
     a conversation and tell the :class:`rasa.core.trackers.DialogueStateTracker`
     how to update its state."""
@@ -92,7 +91,6 @@ class Event(ABC):
         # True at the same time
         return not (self == other)
 
-    @abstractmethod
     def as_story_string(self) -> Text:
         raise NotImplementedError
 
@@ -102,12 +100,12 @@ class Event(ABC):
         parameters: Dict[Text, Any],
         default: Optional[Type["Event"]] = None,
     ) -> Optional[List["Event"]]:
-        event = Event.resolve_by_type(event_name, default)
+        event_class = Event.resolve_by_type(event_name, default)
 
-        if event:
-            return event._from_story_string(parameters)
-        else:
+        if not event_class:
             return None
+
+        return event_class._from_story_string(parameters)
 
     @staticmethod
     def from_parameters(

--- a/rasa/core/events/__init__.py
+++ b/rasa/core/events/__init__.py
@@ -219,7 +219,6 @@ class UserUttered(Event):
                 "entities": self.entities,
                 "text": text,
                 "message_id": self.message_id,
-                "metadata": metadata,
             }
 
         super().__init__(timestamp, metadata)

--- a/rasa/core/events/__init__.py
+++ b/rasa/core/events/__init__.py
@@ -1,5 +1,6 @@
 import time
 import typing
+from abc import ABC, abstractmethod
 
 import json
 import jsonpickle
@@ -32,8 +33,8 @@ def deserialise_events(serialized_events: List[Dict[Text, Any]]) -> List["Event"
                 deserialised.append(event)
             else:
                 logger.warning(
-                    "Ignoring event ({}) while deserialising "
-                    "events. Couldn't parse it."
+                    f"Unable to parse event '{event}' while deserialising. The event"
+                    " will be ignored."
                 )
 
     return deserialised
@@ -73,21 +74,25 @@ def first_key(d, default_key):
 
 
 # noinspection PyProtectedMember
-class Event:
+class Event(ABC):
     """Events describe everything that occurs in
     a conversation and tell the :class:`rasa.core.trackers.DialogueStateTracker`
     how to update its state."""
 
     type_name = "event"
 
-    def __init__(self, timestamp: Optional[float] = None):
-        self.timestamp = timestamp if timestamp else time.time()
+    def __init__(
+        self, timestamp: Optional[float] = None, metadata: Optional[Dict] = None
+    ):
+        self.timestamp = timestamp or time.time()
+        self._metadata = metadata or {}
 
     def __ne__(self, other: Any) -> bool:
         # Not strictly necessary, but to avoid having both x==y and x!=y
         # True at the same time
         return not (self == other)
 
+    @abstractmethod
     def as_story_string(self) -> Text:
         raise NotImplementedError
 
@@ -110,25 +115,29 @@ class Event:
     ) -> Optional["Event"]:
 
         event_name = parameters.get("event")
-        if event_name is not None:
-            copied = parameters.copy()
-            del copied["event"]
-
-            event = Event.resolve_by_type(event_name, default)
-            if event:
-                return event._from_parameters(parameters)
-            else:
-                return None
-        else:
+        if event_name is None:
             return None
+
+        copied = parameters.copy()
+        del copied["event"]
+
+        event_class = Event.resolve_by_type(event_name, default)
+        if not event_class:
+            return None
+
+        return event_class._from_parameters(parameters)
 
     @classmethod
     def _from_story_string(cls, parameters: Dict[Text, Any]) -> Optional[List["Event"]]:
         """Called to convert a parsed story line into an event."""
-        return [cls(parameters.get("timestamp"))]
+        return [cls(parameters.get("timestamp"), parameters.get("metadata"))]
 
     def as_dict(self):
-        return {"event": self.type_name, "timestamp": self.timestamp}
+        return {
+            "event": self.type_name,
+            "timestamp": self.timestamp,
+            "metadata": self._metadata,
+        }
 
     @classmethod
     def _from_parameters(cls, parameters: Dict[Text, Any]) -> Optional["Event"]:
@@ -194,7 +203,6 @@ class UserUttered(Event):
         self.entities = entities if entities else []
         self.input_channel = input_channel
         self.message_id = message_id
-        self.metadata = metadata
 
         if parse_data:
             self.parse_data = parse_data
@@ -204,10 +212,10 @@ class UserUttered(Event):
                 "entities": self.entities,
                 "text": text,
                 "message_id": self.message_id,
-                "metadata": self.metadata,
+                "metadata": metadata,
             }
 
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     @staticmethod
     def _from_parse_data(
@@ -265,7 +273,6 @@ class UserUttered(Event):
                 "parse_data": self.parse_data,
                 "input_channel": getattr(self, "input_channel", None),
                 "message_id": getattr(self, "message_id", None),
-                "metadata": getattr(self, "metadata", None),
             }
         )
         return _dict
@@ -325,8 +332,7 @@ class BotUttered(Event):
     def __init__(self, text=None, data=None, metadata=None, timestamp=None):
         self.text = text
         self.data = data or {}
-        self._metadata = metadata or {}
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     @property
     def metadata(self):
@@ -423,10 +429,10 @@ class SlotSet(Event):
 
     type_name = "slot"
 
-    def __init__(self, key, value=None, timestamp=None):
+    def __init__(self, key, value=None, timestamp=None, metadata=None):
         self.key = key
         self.value = value
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __str__(self):
         return f"SlotSet(key: {self.key}, value: {self.value})"
@@ -468,6 +474,7 @@ class SlotSet(Event):
                 parameters.get("name"),
                 parameters.get("value"),
                 parameters.get("timestamp"),
+                parameters.get("metadata"),
             )
         except KeyError as e:
             raise ValueError(f"Failed to parse set slot event. {e}")
@@ -576,6 +583,7 @@ class ReminderScheduled(Event):
         name=None,
         kill_on_user_message=True,
         timestamp=None,
+        metadata=None,
     ):
         """Creates the reminder
 
@@ -588,13 +596,14 @@ class ReminderScheduled(Event):
             kill_on_user_message: ``True`` means a user message before the
                  trigger date will abort the reminder
             timestamp: creation date of the event
+            metadata: optional event metadata
         """
 
         self.action_name = action_name
         self.trigger_date_time = trigger_date_time
         self.kill_on_user_message = kill_on_user_message
         self.name = name if name is not None else str(uuid.uuid1())
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __hash__(self):
         return hash(
@@ -647,6 +656,7 @@ class ReminderScheduled(Event):
                 parameters.get("name", None),
                 parameters.get("kill_on_user_msg", True),
                 parameters.get("timestamp"),
+                parameters.get("metadata"),
             )
         ]
 
@@ -657,14 +667,15 @@ class ReminderCancelled(Event):
 
     type_name = "cancel_reminder"
 
-    def __init__(self, action_name, timestamp=None):
+    def __init__(self, action_name, timestamp=None, metadata=None):
         """
         Args:
             action_name: name of the scheduled action to be cancelled
+            metadata: optional event metadata
         """
 
         self.action_name = action_name
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __hash__(self):
         return hash(self.action_name)
@@ -682,7 +693,11 @@ class ReminderCancelled(Event):
     @classmethod
     def _from_story_string(cls, parameters: Dict[Text, Any]) -> Optional[List[Event]]:
         return [
-            ReminderCancelled(parameters.get("action"), parameters.get("timestamp"))
+            ReminderCancelled(
+                parameters.get("action"),
+                parameters.get("timestamp"),
+                parameters.get("metadata"),
+            )
         ]
 
 
@@ -721,9 +736,9 @@ class StoryExported(Event):
 
     type_name = "export"
 
-    def __init__(self, path=None, timestamp=None):
+    def __init__(self, path=None, timestamp=None, metadata=None):
         self.path = path
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __hash__(self):
         return hash(32143124319)
@@ -733,6 +748,16 @@ class StoryExported(Event):
 
     def __str__(self):
         return "StoryExported()"
+
+    @classmethod
+    def _from_story_string(cls, parameters: Dict[Text, Any]) -> Optional[List[Event]]:
+        return [
+            StoryExported(
+                parameters.get("path"),
+                parameters.get("timestamp"),
+                parameters.get("metadata"),
+            )
+        ]
 
     def as_story_string(self):
         return self.type_name
@@ -748,9 +773,9 @@ class FollowupAction(Event):
 
     type_name = "followup"
 
-    def __init__(self, name, timestamp=None):
+    def __init__(self, name, timestamp=None, metadata=None):
         self.action_name = name
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __hash__(self):
         return hash(self.action_name)
@@ -771,7 +796,13 @@ class FollowupAction(Event):
     @classmethod
     def _from_story_string(cls, parameters: Dict[Text, Any]) -> Optional[List[Event]]:
 
-        return [FollowupAction(parameters.get("name"), parameters.get("timestamp"))]
+        return [
+            FollowupAction(
+                parameters.get("name"),
+                parameters.get("timestamp"),
+                parameters.get("metadata"),
+            )
+        ]
 
     def as_dict(self):
         d = super().as_dict()
@@ -847,12 +878,13 @@ class ActionExecuted(Event):
         policy: Optional[Text] = None,
         confidence: Optional[float] = None,
         timestamp: Optional[int] = None,
+        metadata: Optional[Dict] = None,
     ):
         self.action_name = action_name
         self.policy = policy
         self.confidence = confidence
         self.unpredictable = False
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __str__(self):
         return "ActionExecuted(action: {}, policy: {}, confidence: {})".format(
@@ -880,6 +912,7 @@ class ActionExecuted(Event):
                 parameters.get("policy"),
                 parameters.get("confidence"),
                 parameters.get("timestamp"),
+                parameters.get("metadata"),
             )
         ]
 
@@ -909,10 +942,10 @@ class AgentUttered(Event):
 
     type_name = "agent"
 
-    def __init__(self, text=None, data=None, timestamp=None):
+    def __init__(self, text=None, data=None, timestamp=None, metadata=None):
         self.text = text
         self.data = data
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __hash__(self):
         return hash((self.text, jsonpickle.encode(self.data)))
@@ -954,6 +987,7 @@ class AgentUttered(Event):
                 parameters.get("text"),
                 parameters.get("data"),
                 parameters.get("timestamp"),
+                parameters.get("metadata"),
             )
         except KeyError as e:
             raise ValueError(f"Failed to parse agent uttered event. {e}")
@@ -966,9 +1000,9 @@ class Form(Event):
 
     type_name = "form"
 
-    def __init__(self, name, timestamp=None):
+    def __init__(self, name, timestamp=None, metadata=None):
         self.name = name
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __str__(self):
         return f"Form({self.name})"
@@ -989,7 +1023,13 @@ class Form(Event):
     @classmethod
     def _from_story_string(cls, parameters):
         """Called to convert a parsed story line into an event."""
-        return [Form(parameters.get("name"), parameters.get("timestamp"))]
+        return [
+            Form(
+                parameters.get("name"),
+                parameters.get("timestamp"),
+                parameters.get("metadata"),
+            )
+        ]
 
     def as_dict(self):
         d = super().as_dict()
@@ -1006,9 +1046,9 @@ class FormValidation(Event):
 
     type_name = "form_validation"
 
-    def __init__(self, validate, timestamp=None):
+    def __init__(self, validate, timestamp=None, metadata=None):
         self.validate = validate
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __str__(self):
         return f"FormValidation({self.validate})"
@@ -1024,7 +1064,11 @@ class FormValidation(Event):
 
     @classmethod
     def _from_parameters(cls, parameters):
-        return FormValidation(parameters.get("validate"), parameters.get("timestamp"))
+        return FormValidation(
+            parameters.get("validate"),
+            parameters.get("timestamp"),
+            parameters.get("metadata"),
+        )
 
     def as_dict(self):
         d = super().as_dict()
@@ -1040,11 +1084,13 @@ class ActionExecutionRejected(Event):
 
     type_name = "action_execution_rejected"
 
-    def __init__(self, action_name, policy=None, confidence=None, timestamp=None):
+    def __init__(
+        self, action_name, policy=None, confidence=None, timestamp=None, metadata=None
+    ):
         self.action_name = action_name
         self.policy = policy
         self.confidence = confidence
-        super().__init__(timestamp)
+        super().__init__(timestamp, metadata)
 
     def __str__(self):
         return (
@@ -1069,6 +1115,7 @@ class ActionExecutionRejected(Event):
             parameters.get("policy"),
             parameters.get("confidence"),
             parameters.get("timestamp"),
+            parameters.get("metadata"),
         )
 
     def as_story_string(self):

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -296,8 +296,3 @@ def test_event_default_metadata(event_class):
         }
     )
     assert event.as_dict()["metadata"] == {}
-
-
-def test_instance_event_error():
-    with pytest.raises(TypeError):
-        Event()

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -566,6 +566,21 @@ def test_last_executed_has_not_name():
     assert tracker.last_executed_action_has("another") is False
 
 
+def test_events_metadata():
+    # It should be possible to attach arbitrary metadata to any event and then
+    # retrieve it after getting the tracker dict representation.
+    events = [
+        ActionExecuted("one", metadata={"one": 1}),
+        user_uttered("two", 1, metadata={"two": 2}),
+        ActionExecuted(ACTION_LISTEN_NAME, metadata={"three": 3}),
+    ]
+
+    events = get_tracker(events).current_state(EventVerbosity.ALL)["events"]
+    assert events[0]["metadata"] == {"one": 1}
+    assert events[1]["metadata"] == {"two": 2}
+    assert events[2]["metadata"] == {"three": 3}
+
+
 @pytest.mark.parametrize("key, value", [("asfa", 1), ("htb", None)])
 def test_tracker_without_slots(key, value, caplog):
     event = SlotSet(key, value)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,4 +1,6 @@
 import os
+import random
+
 from decimal import Decimal
 from typing import Optional, Text, Union
 
@@ -173,3 +175,14 @@ def test_lock_store_is_redis_lock_store(
 ):
     # noinspection PyProtectedMember
     assert rasa.core.utils._lock_store_is_redis_lock_store(lock_store) == expected
+
+
+def test_all_subclasses():
+    num = random.randint(1, 10)
+
+    class TestClass:
+        pass
+
+    classes = [type(f"TestClass{i}", (TestClass,), {}) for i in range(num)]
+
+    assert utils.all_subclasses(TestClass) == classes

--- a/tests/core/utilities.py
+++ b/tests/core/utilities.py
@@ -2,7 +2,7 @@ import itertools
 
 import contextlib
 import typing
-from typing import Text, List, Optional
+from typing import Text, List, Optional, Text, Any, Dict
 
 import jsonpickle
 import os
@@ -65,10 +65,15 @@ def mocked_cmd_input(package, text: Text):
         package.get_user_input = i
 
 
-def user_uttered(text: Text, confidence: float) -> UserUttered:
+def user_uttered(
+    text: Text, confidence: float, metadata: Dict[Text, Any] = None
+) -> UserUttered:
     parse_data = {"intent": {"name": text, "confidence": confidence}}
     return UserUttered(
-        text="Random", intent=parse_data["intent"], parse_data=parse_data
+        text="Random",
+        intent=parse_data["intent"],
+        parse_data=parse_data,
+        metadata=metadata,
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -538,6 +538,7 @@ def test_requesting_non_existent_tracker(rasa_app: SanicTestClient):
             "policy": None,
             "confidence": None,
             "timestamp": 1514764800,
+            "metadata": {},
         }
     ]
     assert content["latest_message"] == {


### PR DESCRIPTION
**Proposed changes**:
- Allow attaching a metadata object to any Event subclass.
- The metadata object should be JSON-serializable.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
