### PR TITLE
Update training-data-format.rst

### DIFF
--- a/docs/nlu/training-data-format.rst
+++ b/docs/nlu/training-data-format.rst
@@ -177,6 +177,9 @@ Alternatively, lookup elements may be directly included as a list
     - rice
     - tacos
     - cheese
+    
+.. note::
+    Lookup elements in the NLU file are ignored in Rasa X after version `0.22.2`. A lookup table file is automatically created.
 
 When lookup tables are supplied in training data, the contents are combined
 into a large, case-insensitive regex pattern that looks for exact matches in


### PR DESCRIPTION
Rasa x 0.2.22 gives this warning when uploading a nlu.md file which contains lookup elements:
> Lookup Tables in nlu.md will be ignored
> To include lookup tables, please upload lookup table files separately. Lookup tables within nlu.md will no longer be recognized.

**Proposed changes**:
- Add a note that Rasa X will not accept lookup tables within the nlu.md file, but rather convert the list to a separate file and remove the table from the file. Not a major issue.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
