### PR TITLE
let failsafe tracker store set wrapped tracker store domain

### DIFF
--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -785,11 +785,22 @@ class FailSafeTrackerStore(TrackerStore):
                 in the primary tracker store.
         """
 
-        super().__init__(tracker_store.domain, tracker_store.event_broker)
-
         self._fallback_tracker_store: Optional[TrackerStore] = fallback_tracker_store
         self._tracker_store = tracker_store
         self._on_tracker_store_error = on_tracker_store_error
+
+        super().__init__(tracker_store.domain, tracker_store.event_broker)
+
+    @property
+    def domain(self) -> Optional[Domain]:
+        return self._tracker_store.domain
+
+    @domain.setter
+    def domain(self, domain: Optional[Domain]) -> None:
+        self._tracker_store.domain = domain
+
+        if self._fallback_tracker_store:
+            self._fallback_tracker_store.domain = domain
 
     @property
     def fallback_tracker_store(self) -> TrackerStore:

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -370,10 +370,12 @@ def test_fail_safe_tracker_store_with_retrieve_error():
     on_error_callback.assert_called_once()
 
 
-def test_set_fail_safe_tracker_store_domain(default_domain):
+def test_set_fail_safe_tracker_store_domain(default_domain: Domain):
     tracker_store = InMemoryTrackerStore(domain)
-    failsafe_store = FailSafeTrackerStore(tracker_store, None)
+    fallback_tracker_store = InMemoryTrackerStore(None)
+    failsafe_store = FailSafeTrackerStore(tracker_store, None, fallback_tracker_store)
 
     failsafe_store.domain = default_domain
+    assert failsafe_store.domain == default_domain
     assert tracker_store.domain is failsafe_store.domain
-    assert tracker_store.domain == default_domain
+    assert fallback_tracker_store.domain is failsafe_store.domain

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -376,6 +376,6 @@ def test_set_fail_safe_tracker_store_domain(default_domain: Domain):
     failsafe_store = FailSafeTrackerStore(tracker_store, None, fallback_tracker_store)
 
     failsafe_store.domain = default_domain
-    assert failsafe_store.domain == default_domain
+    assert failsafe_store.domain is default_domain
     assert tracker_store.domain is failsafe_store.domain
     assert fallback_tracker_store.domain is failsafe_store.domain

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -368,3 +368,12 @@ def test_fail_safe_tracker_store_with_retrieve_error():
 
     assert tracker_store.retrieve("sender_id") is None
     on_error_callback.assert_called_once()
+
+
+def test_set_fail_safe_tracker_store_domain(default_domain):
+    tracker_store = InMemoryTrackerStore(domain)
+    failsafe_store = FailSafeTrackerStore(tracker_store, None)
+
+    failsafe_store.domain = default_domain
+    assert tracker_store.domain is failsafe_store.domain
+    assert tracker_store.domain == default_domain


### PR DESCRIPTION
**Proposed changes**:
- fix issue where slots in the domain are lost in local rasa x mode
- when the failsafe tracker store's domain is updated, update the wrapped tracker store's domain

Still needs a changelog entry

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
