### PR TITLE
Random seed split

### DIFF
--- a/changelog/4647.improvement.rst
+++ b/changelog/4647.improvement.rst
@@ -1,0 +1,2 @@
+Add the option ```random_seed``` to the ```rasa data split nlu``` command to generate
+reproducible train/test splits.

--- a/rasa/cli/arguments/data.py
+++ b/rasa/cli/arguments/data.py
@@ -39,6 +39,13 @@ def set_split_arguments(parser: argparse.ArgumentParser):
         help="Percentage of the data which should be in the training data.",
     )
 
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=None,
+        help="Seed to generate the same train/test split.",
+    )
+
     add_out_param(
         parser,
         default="train_test_split",

--- a/rasa/cli/data.py
+++ b/rasa/cli/data.py
@@ -85,7 +85,7 @@ def split_nlu_data(args) -> None:
     nlu_data = load_data(data_path)
     fformat = get_file_format(data_path)
 
-    train, test = nlu_data.train_test_split(args.training_fraction)
+    train, test = nlu_data.train_test_split(args.training_fraction, args.random_seed)
 
     train.persist(args.out, filename=f"training_data.{fformat}")
     test.persist(args.out, filename=f"test_data.{fformat}")

--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -399,7 +399,7 @@ class TrainingData:
         train, test = [], []
         for intent, count in self.examples_per_intent.items():
             ex = [e for e in self.intent_examples if e.data["intent"] == intent]
-            if seed is not None:
+            if random_seed is not None:
                 random.Random(random_seed).shuffle(ex)
             else:
                 random.shuffle(ex)

--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -343,13 +343,13 @@ class TrainingData:
                 )
 
     def train_test_split(
-        self, train_frac: float = 0.8
+        self, train_frac: float = 0.8, random_seed: int = None
     ) -> Tuple["TrainingData", "TrainingData"]:
         """Split into a training and test dataset,
         preserving the fraction of examples per intent."""
 
         # collect all nlu data
-        test, train = self.split_nlu_examples(train_frac)
+        test, train = self.split_nlu_examples(train_frac, random_seed)
 
         # collect all nlg stories
         test_nlg_stories, train_nlg_stories = self.split_nlg_responses(test, train)
@@ -395,11 +395,15 @@ class TrainingData:
                 ]
         return nlg_stories
 
-    def split_nlu_examples(self, train_frac) -> Tuple[list, list]:
+    def split_nlu_examples(self, train_frac, random_seed=None):
         train, test = [], []
         for intent, count in self.examples_per_intent.items():
             ex = [e for e in self.intent_examples if e.data["intent"] == intent]
-            random.shuffle(ex)
+            if seed is not None:
+                random.Random(random_seed).shuffle(ex)
+            else:
+                random.shuffle(ex)
+
             n_train = int(count * train_frac)
             train.extend(ex[:n_train])
             test.extend(ex[n_train:])

--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -343,7 +343,7 @@ class TrainingData:
                 )
 
     def train_test_split(
-        self, train_frac: float = 0.8, random_seed: int = None
+        self, train_frac: float = 0.8, random_seed: Optional[int] = None
     ) -> Tuple["TrainingData", "TrainingData"]:
         """Split into a training and test dataset,
         preserving the fraction of examples per intent."""
@@ -395,7 +395,9 @@ class TrainingData:
                 ]
         return nlg_stories
 
-    def split_nlu_examples(self, train_frac, random_seed=None):
+    def split_nlu_examples(
+        self, train_frac: float, random_seed: Optional[int] = None
+    ) -> Tuple[list, list]:
         train, test = [], []
         for intent, count in self.examples_per_intent.items():
             ex = [e for e in self.intent_examples if e.data["intent"] == intent]

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -36,7 +36,8 @@ def test_data_split_help(run: Callable[..., RunResult]):
     output = run("data", "split", "nlu", "--help")
 
     help_text = """usage: rasa data split nlu [-h] [-v] [-vv] [--quiet] [-u NLU]
-                           [--training-fraction TRAINING_FRACTION] [--out OUT]"""
+                           [--training-fraction TRAINING_FRACTION]
+                           [--random-seed RANDOM_SEED] [--out OUT]"""
 
     lines = help_text.split("\n")
 

--- a/tests/nlu/base/test_training_data.py
+++ b/tests/nlu/base/test_training_data.py
@@ -188,6 +188,39 @@ def test_train_test_split(filepaths):
 
 
 @pytest.mark.parametrize(
+    "filepaths",
+    [["data/examples/rasa/demo-rasa.md", "data/examples/rasa/demo-rasa-responses.md"]],
+)
+def test_train_test_split_with_random_seed(filepaths):
+    from rasa.importers.utils import training_data_from_paths
+
+    td = training_data_from_paths(filepaths, language="en")
+
+    first_td_train, td_test = td.train_test_split(train_frac=0.8, random_seed=1)
+    second_td_train, td_test = td.train_test_split(train_frac=0.8, random_seed=1)
+    first_intents = []
+    second_intents = []
+    for intent, count in first_td_train.examples_per_intent.items():
+        first_intents.extend(
+            [
+                e.text
+                for e in first_td_train.intent_examples
+                if e.data["intent"] == intent
+            ]
+        )
+
+    for intent, count in second_td_train.examples_per_intent.items():
+        second_intents.extend(
+            [
+                e.text
+                for e in second_td_train.intent_examples
+                if e.data["intent"] == intent
+            ]
+        )
+    assert first_intents == second_intents
+
+
+@pytest.mark.parametrize(
     "files",
     [
         ("data/examples/rasa/demo-rasa.json", "data/test/multiple_files_json"),

--- a/tests/nlu/base/test_training_data.py
+++ b/tests/nlu/base/test_training_data.py
@@ -196,28 +196,16 @@ def test_train_test_split_with_random_seed(filepaths):
 
     td = training_data_from_paths(filepaths, language="en")
 
-    first_td_train, td_test = td.train_test_split(train_frac=0.8, random_seed=1)
-    second_td_train, td_test = td.train_test_split(train_frac=0.8, random_seed=1)
-    first_intents = []
-    second_intents = []
-    for intent, count in first_td_train.examples_per_intent.items():
-        first_intents.extend(
-            [
-                e.text
-                for e in first_td_train.intent_examples
-                if e.data["intent"] == intent
-            ]
-        )
+    td_train_1, td_test_1 = td.train_test_split(train_frac=0.8, random_seed=1)
+    td_train_2, td_test_2 = td.train_test_split(train_frac=0.8, random_seed=1)
+    train_1_intent_examples = [e.text for e in td_train_1.intent_examples]
+    train_2_intent_examples = [e.text for e in td_train_2.intent_examples]
 
-    for intent, count in second_td_train.examples_per_intent.items():
-        second_intents.extend(
-            [
-                e.text
-                for e in second_td_train.intent_examples
-                if e.data["intent"] == intent
-            ]
-        )
-    assert first_intents == second_intents
+    test_1_intent_examples = [e.text for e in td_test_1.intent_examples]
+    test_2_intent_examples = [e.text for e in td_test_2.intent_examples]
+
+    assert train_1_intent_examples == train_2_intent_examples
+    assert test_1_intent_examples == test_2_intent_examples
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Proposed changes**:
- Enable the user to set a seed to split the NLU data into test and training.
- Close https://github.com/RasaHQ/rasa/issues/4647

**Expected behavior**:
- When a user is splitting the NLU data, a new argument specifying a random seed (in sklearn, known  as random_state) could be passed, as shown below:
```rasa data split nlu --random-seed=42```

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
