### PR TITLE
feat: expose slack message on metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Improvements
 ------------
 - When NLU training data is dumped as Markdown file the intents are not longer ordered
   alphabetically, but in the original order of given training data
+- Override get_metadata on slack to expose `request.json`
 
 Bugfixes
 --------

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -362,5 +362,8 @@ class SlackInput(InputChannel):
 
         return slack_webhook
 
+    def get_metadata(self, request: Request) -> Optional[Dict[Text, Any]]:
+        return request.json
+
     def get_output_channel(self) -> OutputChannel:
         return SlackBot(self.slack_token, self.slack_channel)


### PR DESCRIPTION
**Description of Problem**:
It's not possible to know exactly which user is talking to the bot.

**Overview of the Solution**:
The ideal solution would be to expose the details of the slack message

**Definition of Done**:
- [x] Feature mentioned in the changelog
- [x] Override `get_metadata` in the slack channel