### PR TITLE
Make order of files loaded consistent

### DIFF
--- a/changelog/4898.bugfix.rst
+++ b/changelog/4898.bugfix.rst
@@ -1,0 +1,1 @@
+Training data files now get loaded in the same order (especially relevant to subdirectories) each time to ensure training consistency when using a random seed.

--- a/rasa/data.py
+++ b/rasa/data.py
@@ -103,7 +103,7 @@ def _find_core_nlu_files_in_directory(directory: Text,) -> Tuple[Set[Text], Set[
     nlu_data_files = set()
 
     for root, _, files in os.walk(directory):
-        for f in files:
+        for f in sorted(files):
             full_path = os.path.join(root, f)
 
             if not _is_valid_filetype(full_path):

--- a/rasa/data.py
+++ b/rasa/data.py
@@ -103,6 +103,7 @@ def _find_core_nlu_files_in_directory(directory: Text,) -> Tuple[Set[Text], Set[
     nlu_data_files = set()
 
     for root, _, files in os.walk(directory):
+        # we sort the files here to ensure consistent order for repeatable training results
         for f in sorted(files):
             full_path = os.path.join(root, f)
 


### PR DESCRIPTION
**Proposed changes**:
- When you have subdirectories in your training data directory `os.walk` won't return the files in the same order each time. This leads to inconsistent training results when using a random_seed. 
- Now we sort the files to ensure consistency

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
