### PR TITLE
add socket logging libraries to set_log_level

### DIFF
--- a/changelog/4792.improvement.rst
+++ b/changelog/4792.improvement.rst
@@ -1,1 +1,3 @@
-The log level for SocketIO loggers, including ``websockets.protocol``, ``engineio.server``, and ``socketio.server``, is now handled by the ``LOG_LEVEL_LIBRARIES`` environment variable, where the default log level is ``ERROR``.
+The log level for SocketIO loggers, including ``websockets.protocol``, ``engineio.server``,
+and ``socketio.server``, is now handled by the ``LOG_LEVEL_LIBRARIES`` environment variable,
+where the default log level is ``ERROR``.

--- a/changelog/4792.improvement.rst
+++ b/changelog/4792.improvement.rst
@@ -1,0 +1,1 @@
+The log level for SocketIO loggers, including ``websockets.protocol``, ``engineio.server``, and ``socketio.server``, is now handled by the ``LOG_LEVEL_LIBRARIES`` environment variable, where the default log level is ``ERROR``.

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -68,6 +68,7 @@ def set_log_level(log_level: Optional[int] = None):
     update_tensorflow_log_level()
     update_asyncio_log_level()
     update_apscheduler_log_level()
+    update_socketio_log_level()
 
     os.environ[ENV_LOG_LEVEL] = logging.getLevelName(log_level)
 
@@ -83,6 +84,20 @@ def update_apscheduler_log_level() -> None:
     ]
 
     for logger_name in apscheduler_loggers:
+        logging.getLogger(logger_name).setLevel(log_level)
+        logging.getLogger(logger_name).propagate = False
+
+
+def update_socketio_log_level() -> None:
+    log_level = os.environ.get(ENV_LOG_LEVEL_LIBRARIES, DEFAULT_LOG_LEVEL_LIBRARIES)
+
+    socketio_loggers = [
+        "websockets.protocol",
+        "engineio.server",
+        "socketio.server",
+    ]
+
+    for logger_name in socketio_loggers:
         logging.getLogger(logger_name).setLevel(log_level)
         logging.getLogger(logger_name).propagate = False
 


### PR DESCRIPTION
**Proposed changes**:
- add library loggers from socketio connector to `set_log_level` to be set by the `LOG_LEVEL_LIBRARIES` env var or default
- fix #4792

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
