### PR TITLE
Test split data location

### DIFF
--- a/docs/user-guide/evaluating-models.rst
+++ b/docs/user-guide/evaluating-models.rst
@@ -35,7 +35,7 @@ If you've done this, you can see how well your NLU model predicts the test cases
 
 .. code-block:: bash
 
-   rasa test nlu -u test_set.md --model models/nlu-20180323-145833.tar.gz
+   rasa test nlu -u train_test_split/test_data.md --model models/nlu-20180323-145833.tar.gz
 
 
 If you don't want to create a separate test set, you can


### PR DESCRIPTION
**Proposed changes**:
- After running the code block ``rasa data split nlu``, your test data can be found at ``train_test_split/test_data.md`` instead of at ``test_set.md``.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [* ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
