### PR TITLE
Automatically set a matplotli backend if no default backend is config…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,5 @@ events.db
 *.swp
 *.coverage*
 env
-venv
 .dir-locals.el
 .history

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.6 

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ lint:
 types:
 	pytype --keep-going rasa
 
-prepare-tests-macos: prepare-tests-files
-	brew install graphviz wget || true
+prepare-tests-macos: prepare-wget-macos prepare-tests-files
+	brew install graphviz || true
+
+prepare-wget-macos:
+	brew install wget || true
 
 prepare-tests-ubuntu: prepare-tests-files
 	sudo apt-get -y install graphviz graphviz-dev python3-tk

--- a/changelog/4086.improvement.rst
+++ b/changelog/4086.improvement.rst
@@ -1,0 +1,1 @@
+If matplotlib couldn't set up a default backend, it will be set automatically to TkAgg/Agg one

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -12,18 +12,25 @@ from rasa.core.events import ActionExecuted, UserUttered
 from rasa.nlu.training_data.formats.markdown import MarkdownWriter
 from rasa.core.trackers import DialogueStateTracker
 from rasa.utils.io import DEFAULT_ENCODING
-import matplotlib
 
 if typing.TYPE_CHECKING:
     from rasa.core.agent import Agent
 
-try:
-    # If the `tkinter` package is available, we can use the `TkAgg` backend
-    import tkinter
+import matplotlib
 
-    matplotlib.use("TkAgg")
-except ImportError:
-    matplotlib.use("agg")
+# At first, matplotlib will be initialized with default OS-specific available backend
+# if that didn't happen, we'll try to set it up manually
+if matplotlib.get_backend() is not None:
+    pass
+else:  # pragma: no cover
+    try:
+        # If the `tkinter` package is available, we can use the `TkAgg` backend
+        import tkinter
+
+        matplotlib.use("TkAgg")
+    except ImportError:
+        matplotlib.use("agg")
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
**Proposed changes**:

- Fix #4086

Automatically set a matplotli backend if no default backend is configured

- Added a check for default backend
- Fallback to TkAgg/Agg in case no default is available

Minor:

 - removed duplicated path from .gitignore
 - removed explicit python version from pre-commit hook

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
