### PR TITLE
Update note in pretrained_embeddings_convert section - 1.5.x

### DIFF
--- a/docs/nlu/choosing-a-pipeline.rst
+++ b/docs/nlu/choosing-a-pipeline.rst
@@ -66,7 +66,7 @@ examples are already very similar, the intent classified for both is highly like
 large enough training data.
 
     .. note::
-        To use ``pretrained_embeddings_convert`` pipeline, you should install ``tensorflow_text==1.15.1`` and ``tensorflow_hub==0.6.0``. Otherwise, you can also pip install Rasa with ``pip install rasa[convert]``
+        To use ``pretrained_embeddings_convert`` pipeline, you should install ``tensorflow-text==1.15.1`` and ``tensorflow-hub==0.6.0``. Otherwise, you can also pip install Rasa with ``pip install rasa[convert]``. Please also note that tensorflow_text is only currently supported on Linux platforms.
 
 supervised_embeddings
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/nlu/choosing-a-pipeline.rst
+++ b/docs/nlu/choosing-a-pipeline.rst
@@ -66,7 +66,7 @@ examples are already very similar, the intent classified for both is highly like
 large enough training data.
 
     .. note::
-        To use ``pretrained_embeddings_convert`` pipeline, you should install ``tensorflow-text==1.15.1`` and ``tensorflow-hub==0.6.0``. Otherwise, you can also pip install Rasa with ``pip install rasa[convert]``. Please also note that tensorflow_text is only currently supported on Linux platforms.
+        To use ``pretrained_embeddings_convert`` pipeline, you should install ``tensorflow-text==1.15.1`` and ``tensorflow-hub==0.6.0``. Otherwise, you can also pip install Rasa with ``pip install rasa[convert]``. Please also note that tensorflow-text is only currently supported on Linux platforms.
 
 supervised_embeddings
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
@dakshvar22 Re: Update note in pretrained_embeddings_convert section #4920

**Proposed changes**:

I believe it is tensorflow-text and tensorflow-hub rather than tensorflow_text and tensorflow_hub (although apparently these should resolve to the same packages anyhow).
Unfortunately, I don't think you can install tensorflow-text on Windows or other non-Linux platforms.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [* ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
