### PR TITLE
fix wrong link to endpoint

### DIFF
--- a/docs/core/actions.rst
+++ b/docs/core/actions.rst
@@ -184,7 +184,7 @@ for example to display the output of a long running background operation
 or notify the user of an external event.
 
 To do so, you can ``POST`` to this
-`endpoint <../../api/http-api.html/#operation/executeConversationAction>`_ ,
+`endpoint <../../api/http-api/#operation/executeConversationAction>`_ ,
 specifying the action which should be run for a specific user in the request body. Use the
 ``output_channel`` query parameter to specify which output
 channel should be used to communicate the assistant's responses back to the user.


### PR DESCRIPTION
Community member pointed out that link to the endpoint does not work. It is because of the `.html` after `http-api`. The current link works when you run `make livehtml`; however, it does not work when the docs are deployed on `rasa.com/docs`. Not sure how to make sure my change works

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
