### PR TITLE
use empty domain in case Domain is None (e.g. if it's a NLU only model)

### DIFF
--- a/changelog/4989.bugfix.rst
+++ b/changelog/4989.bugfix.rst
@@ -1,0 +1,2 @@
+Use an empty domain in case a model is loaded which has no domain
+(avoids errors when accessing ``agent.doman.<some attribute>``.

--- a/changelog/4989.bugfix.rst
+++ b/changelog/4989.bugfix.rst
@@ -1,2 +1,2 @@
 Use an empty domain in case a model is loaded which has no domain
-(avoids errors when accessing ``agent.doman.<some attribute>``.
+(avoids errors when accessing ``agent.doman.<some attribute>``).

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -845,7 +845,7 @@ class Agent:
         )
 
     @staticmethod
-    def _create_domain(domain: Union[Domain, Text]) -> Domain:
+    def _create_domain(domain: Union[Domain, Text, None]) -> Domain:
 
         if isinstance(domain, str):
             domain = Domain.load(domain)

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -336,7 +336,7 @@ class Agent:
         interpreter: Optional[NaturalLanguageInterpreter] = None,
         model_directory: Optional[Text] = None,
     ) -> None:
-        self.domain = domain
+        self.domain = self._create_domain(domain)
         self.policy_ensemble = policy_ensemble
 
         if interpreter:

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -250,13 +250,10 @@ def test_two_stage_fallback_without_deny_suggestion(domain, policy_config):
 async def test_agent_update_model_none_domain(trained_model: Text):
     agent = await load_agent(model_path=trained_model)
     agent.update_model(
-        Domain.empty(),
-        None,
-        agent.fingerprint,
-        agent.interpreter,
-        agent.model_directory,
+        None, None, agent.fingerprint, agent.interpreter, agent.model_directory
     )
 
+    assert agent.domain is not None
     sender_id = "test_sender_id"
     message = UserMessage("hello", sender_id=sender_id)
     await agent.handle_message(message)


### PR DESCRIPTION
**Proposed changes**:
- use an empty domain in case a model is loaded which has no domain (avoids error when access `agent.doman.<some attribute>`

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
