### PR TITLE
deprecated continue training

### DIFF
--- a/changelog/4990.removal.rst
+++ b/changelog/4990.removal.rst
@@ -1,0 +1,1 @@
+Deprecated ``Agent.continue_training``. Instead, a model should be retrained.

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -579,6 +579,11 @@ class Agent:
     def continue_training(
         self, trackers: List[DialogueStateTracker], **kwargs: Any
     ) -> None:
+        warnings.warn(
+            "Continue training will be removed in the next release. It won't be "
+            "possible to continue the training, you should probably retrain instead.",
+            FutureWarning,
+        )
 
         if not self.is_core_ready():
             raise AgentNotReady("Can't continue training without a policy ensemble.")


### PR DESCRIPTION
**Proposed changes**:
- deprecated `agent.continue_training` it is not used anywhere, not even for interactive learning.

**Status (please check what you already did)**:
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
