### PR TITLE
removed unused continue training

### DIFF
--- a/changelog/4991.removal.rst
+++ b/changelog/4991.removal.rst
@@ -1,0 +1,2 @@
+Removed ``Agent.continue_training`` and the ``dump_flattened_stories`` parameter
+from ``Agent.persist``.

--- a/rasa/cli/arguments/interactive.py
+++ b/rasa/cli/arguments/interactive.py
@@ -13,7 +13,6 @@ from rasa.cli.arguments.train import (
     add_config_param,
     add_out_param,
     add_debug_plots_param,
-    add_dump_stories_param,
     add_augmentation_param,
     add_persist_nlu_data_param,
 )
@@ -75,6 +74,5 @@ def _add_training_arguments(parser: argparse.ArgumentParser) -> argparse._Argume
     )
     add_augmentation_param(train_arguments)
     add_debug_plots_param(train_arguments)
-    add_dump_stories_param(train_arguments)
 
     return train_arguments

--- a/rasa/cli/arguments/train.py
+++ b/rasa/cli/arguments/train.py
@@ -19,7 +19,6 @@ def set_train_arguments(parser: argparse.ArgumentParser):
 
     add_augmentation_param(parser)
     add_debug_plots_param(parser)
-    add_dump_stories_param(parser)
 
     add_model_name_param(parser)
     add_persist_nlu_data_param(parser)
@@ -34,7 +33,6 @@ def set_train_core_arguments(parser: argparse.ArgumentParser):
 
     add_augmentation_param(parser)
     add_debug_plots_param(parser)
-    add_dump_stories_param(parser)
 
     add_force_param(parser)
 
@@ -106,17 +104,6 @@ def add_augmentation_param(
         type=int,
         default=50,
         help="How much data augmentation to use during training.",
-    )
-
-
-def add_dump_stories_param(
-    parser: Union[argparse.ArgumentParser, argparse._ActionsContainer]
-):
-    parser.add_argument(
-        "--dump-stories",
-        default=False,
-        action="store_true",
-        help="If enabled, save flattened stories to a file.",
     )
 
 

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -146,8 +146,6 @@ def extract_additional_arguments(args: argparse.Namespace) -> Dict:
 
     if "augmentation" in args:
         arguments["augmentation_factor"] = args.augmentation
-    if "dump_stories" in args:
-        arguments["dump_stories"] = args.dump_stories
     if "debug_plots" in args:
         arguments["debug_plots"] = args.debug_plots
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -590,21 +590,6 @@ class Agent:
             if type(p) == MemoizationPolicy:
                 p.toggle(activate)
 
-    def continue_training(
-        self, trackers: List[DialogueStateTracker], **kwargs: Any
-    ) -> None:
-        raise_warning(
-            "Continue training will be removed in the 2.0 release. It won't be "
-            "possible to continue the training, you should probably retrain instead.",
-            FutureWarning,
-        )
-
-        if not self.is_core_ready():
-            raise AgentNotReady("Can't continue training without a policy ensemble.")
-
-        self.policy_ensemble.continue_training(trackers, self.domain, **kwargs)
-        self._set_fingerprint()
-
     def _max_history(self) -> int:
         """Find maximum max_history."""
 
@@ -794,16 +779,8 @@ class Agent:
                 "overwritten.".format(model_path)
             )
 
-    def persist(self, model_path: Text, dump_flattened_stories: bool = False) -> None:
+    def persist(self, model_path: Text) -> None:
         """Persists this agent into a directory for later loading and usage."""
-
-        if dump_flattened_stories:
-            raise_warning(
-                "The `dump_flattened_stories` argument will be removed from "
-                "`Agent.persist` in the 2.0 release. Please dump your "
-                "training data separately if you need it to be part of the model.",
-                FutureWarning,
-            )
 
         if not self.is_core_ready():
             raise AgentNotReady("Can't persist without a policy ensemble.")
@@ -813,7 +790,7 @@ class Agent:
 
         self._clear_model_directory(model_path)
 
-        self.policy_ensemble.persist(model_path, dump_flattened_stories)
+        self.policy_ensemble.persist(model_path)
         self.domain.persist(os.path.join(model_path, DEFAULT_DOMAIN_PATH))
         self.domain.persist_specification(model_path)
 

--- a/rasa/core/policies/embedding_policy.py
+++ b/rasa/core/policies/embedding_policy.py
@@ -506,42 +506,6 @@ class EmbeddingPolicy(Policy):
                 self.attention_weights
             )
 
-    def continue_training(
-        self,
-        training_trackers: List["DialogueStateTracker"],
-        domain: "Domain",
-        **kwargs: Any,
-    ) -> None:
-        """Continue training an already trained policy."""
-
-        batch_size = kwargs.get("batch_size", 5)
-        epochs = kwargs.get("epochs", 50)
-
-        with self.graph.as_default():
-            for _ in range(epochs):
-                training_data = self._training_data_for_continue_training(
-                    batch_size, training_trackers, domain
-                )
-
-                session_data = self._create_session_data(
-                    training_data.X, training_data.y
-                )
-                train_dataset = train_utils.create_tf_dataset(
-                    session_data, batch_size, label_key="action_ids"
-                )
-                train_init_op = self._iterator.make_initializer(train_dataset)
-                self.session.run(train_init_op)
-
-                # fit to one extra example using updated trackers
-                while True:
-                    try:
-                        self.session.run(
-                            self._train_op, feed_dict={self._is_training: True}
-                        )
-
-                    except tf.errors.OutOfRangeError:
-                        break
-
     def tf_feed_dict_for_prediction(
         self, tracker: "DialogueStateTracker", domain: "Domain"
     ) -> Dict["tf.Tensor", "np.ndarray"]:

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -11,7 +11,7 @@ import rasa.core
 import rasa.utils.io
 from rasa.constants import MINIMUM_COMPATIBLE_VERSION, DOCS_BASE_URL, DOCS_URL_POLICIES
 
-from rasa.core import utils, training
+from rasa.core import utils
 from rasa.core.constants import USER_INTENT_BACK, USER_INTENT_RESTART
 from rasa.core.actions.action import (
     ACTION_LISTEN_NAME,
@@ -39,7 +39,6 @@ class PolicyEnsemble:
         self, policies: List[Policy], action_fingerprints: Optional[Dict] = None
     ) -> None:
         self.policies = policies
-        self.training_trackers = None
         self.date_trained = None
 
         if action_fingerprints:
@@ -123,9 +122,11 @@ class PolicyEnsemble:
         if training_trackers:
             for policy in self.policies:
                 policy.train(training_trackers, domain, **kwargs)
+
+            training_events = self._training_events_from_trackers(training_trackers)
+            self.action_fingerprints = self._create_action_fingerprints(training_events)
         else:
             logger.info("Skipped training, because there are no training samples.")
-        self.training_trackers = training_trackers
         self.date_trained = datetime.now().strftime("%Y%m%d-%H%M%S")
 
     def probabilities_using_best_policy(
@@ -172,24 +173,17 @@ class PolicyEnsemble:
             except ImportError:
                 pass
 
-    def _persist_metadata(
-        self, path: Text, dump_flattened_stories: bool = False
-    ) -> None:
+    def _persist_metadata(self, path: Text) -> None:
         """Persists the domain specification to storage."""
 
         # make sure the directory we persist exists
         domain_spec_path = os.path.join(path, "metadata.json")
-        training_data_path = os.path.join(path, "stories.md")
         rasa.utils.io.create_directory_for_file(domain_spec_path)
 
         policy_names = [utils.module_path_from_instance(p) for p in self.policies]
 
-        training_events = self._training_events_from_trackers(self.training_trackers)
-
-        action_fingerprints = self._create_action_fingerprints(training_events)
-
         metadata = {
-            "action_fingerprints": action_fingerprints,
+            "action_fingerprints": self.action_fingerprints,
             "python": ".".join([str(s) for s in sys.version_info[:3]]),
             "max_histories": self._max_histories(),
             "ensemble_name": self.__module__ + "." + self.__class__.__name__,
@@ -201,15 +195,10 @@ class PolicyEnsemble:
 
         rasa.utils.io.dump_obj_as_json_to_file(domain_spec_path, metadata)
 
-        # if there are lots of stories, saving flattened stories takes a long
-        # time, so this is turned off by default
-        if dump_flattened_stories:
-            training.persist_data(self.training_trackers, training_data_path)
-
-    def persist(self, path: Text, dump_flattened_stories: bool = False) -> None:
+    def persist(self, path: Text) -> None:
         """Persists the policy to storage."""
 
-        self._persist_metadata(path, dump_flattened_stories)
+        self._persist_metadata(path)
 
         for i, policy in enumerate(self.policies):
             dir_name = "policy_{}_{}".format(i, type(policy).__name__)
@@ -355,14 +344,6 @@ class PolicyEnsemble:
         )
 
         return state_featurizer_func, state_featurizer_config
-
-    def continue_training(
-        self, trackers: List[DialogueStateTracker], domain: Domain, **kwargs: Any
-    ) -> None:
-
-        self.training_trackers.extend(trackers)
-        for p in self.policies:
-            p.continue_training(self.training_trackers, domain, **kwargs)
 
 
 class SimplePolicyEnsemble(PolicyEnsemble):

--- a/rasa/core/policies/keras_policy.py
+++ b/rasa/core/policies/keras_policy.py
@@ -206,41 +206,6 @@ class KerasPolicy(Policy):
                 self.current_epoch = self.defaults.get("epochs", 1)
                 logger.info("Done fitting keras policy model")
 
-    def continue_training(
-        self,
-        training_trackers: List[DialogueStateTracker],
-        domain: Domain,
-        **kwargs: Any,
-    ) -> None:
-        """Continues training an already trained policy."""
-
-        # takes the new example labelled and learns it
-        # via taking `epochs` samples of n_batch-1 parts of the training data,
-        # inserting our new example and learning them. this means that we can
-        # ask the network to fit the example without overemphasising
-        # its importance (and therefore throwing off the biases)
-
-        batch_size = kwargs.get("batch_size", 5)
-        epochs = kwargs.get("epochs", 50)
-
-        with self.graph.as_default(), self.session.as_default():
-            for _ in range(epochs):
-                training_data = self._training_data_for_continue_training(
-                    batch_size, training_trackers, domain
-                )
-
-                # fit to one extra example using updated trackers
-                self.model.fit(
-                    training_data.X,
-                    training_data.y,
-                    epochs=self.current_epoch + 1,
-                    batch_size=len(training_data.y),
-                    verbose=obtain_verbosity(),
-                    initial_epoch=self.current_epoch,
-                )
-
-                self.current_epoch += 1
-
     def predict_action_probabilities(
         self, tracker: DialogueStateTracker, domain: Domain
     ) -> List[float]:

--- a/rasa/core/policies/memoization.py
+++ b/rasa/core/policies/memoization.py
@@ -163,20 +163,6 @@ class MemoizationPolicy(Policy):
         self._add_states_to_lookup(trackers_as_states, trackers_as_actions, domain)
         logger.debug("Memorized {} unique examples.".format(len(self.lookup)))
 
-    def continue_training(
-        self,
-        training_trackers: List[DialogueStateTracker],
-        domain: Domain,
-        **kwargs: Any,
-    ) -> None:
-
-        # add only the last tracker, because it is the only new one
-        (
-            trackers_as_states,
-            trackers_as_actions,
-        ) = self.featurizer.training_states_and_actions(training_trackers[-1:], domain)
-        self._add_states_to_lookup(trackers_as_states, trackers_as_actions, domain)
-
     def _recall_states(self, states: List[Dict[Text, float]]) -> Optional[int]:
 
         return self.lookup.get(self._create_feature_key(states))

--- a/rasa/core/policies/policy.py
+++ b/rasa/core/policies/policy.py
@@ -87,43 +87,6 @@ class Policy:
 
         raise NotImplementedError("Policy must have the capacity to train.")
 
-    def _training_data_for_continue_training(
-        self,
-        batch_size: int,
-        training_trackers: List[DialogueStateTracker],
-        domain: Domain,
-    ) -> DialogueTrainingData:
-        """Creates training_data for `continue_training` by
-            taking the new labelled example training_trackers[-1:]
-            and inserting it in batch_size-1 parts of the old training data,
-        """
-        import numpy as np
-
-        num_samples = batch_size - 1
-        num_prev_examples = len(training_trackers) - 1
-
-        sampled_idx = np.random.choice(
-            range(num_prev_examples),
-            replace=False,
-            size=min(num_samples, num_prev_examples),
-        )
-        trackers = [training_trackers[i] for i in sampled_idx] + training_trackers[-1:]
-        return self.featurize_for_training(trackers, domain)
-
-    def continue_training(
-        self,
-        training_trackers: List[DialogueStateTracker],
-        domain: Domain,
-        **kwargs: Any,
-    ) -> None:
-        """Continues training an already trained policy.
-
-        This doesn't need to be supported by every policy. If it is supported,
-        the policy can be used for online training and the implementation for
-        the continued training should be put into this function."""
-
-        pass
-
     def predict_action_probabilities(
         self, tracker: DialogueStateTracker, domain: Domain
     ) -> List[float]:

--- a/rasa/core/train.py
+++ b/rasa/core/train.py
@@ -26,7 +26,6 @@ async def train(
     output_path: Text,
     interpreter: Optional["NaturalLanguageInterpreter"] = None,
     endpoints: "AvailableEndpoints" = None,
-    dump_stories: bool = False,
     policy_config: Optional[Union[Text, Dict]] = None,
     exclusion_percentage: int = None,
     additional_arguments: Optional[Dict] = None,
@@ -65,7 +64,7 @@ async def train(
         training_resource, exclusion_percentage=exclusion_percentage, **data_load_args
     )
     agent.train(training_data, **additional_arguments)
-    agent.persist(output_path, dump_stories)
+    agent.persist(output_path)
 
     return agent
 
@@ -77,7 +76,6 @@ async def train_comparison_models(
     exclusion_percentages: Optional[List] = None,
     policy_configs: Optional[List] = None,
     runs: int = 1,
-    dump_stories: bool = False,
     additional_arguments: Optional[Dict] = None,
 ):
     """Train multiple models for comparison of policies"""
@@ -115,7 +113,6 @@ async def train_comparison_models(
                             policy_config=policy_config,
                             exclusion_percentage=percentage,
                             additional_arguments=additional_arguments,
-                            dump_stories=dump_stories,
                         ),
                         model.model_fingerprint(file_importer),
                     )
@@ -154,7 +151,6 @@ async def do_compare_training(
             exclusion_percentages=args.percentages,
             policy_configs=args.config,
             runs=args.runs,
-            dump_stories=args.dump_stories,
             additional_arguments=additional_arguments,
         ),
         get_no_of_stories(args.stories, args.domain),

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -1563,7 +1563,6 @@ async def train_agent_on_start(
         model_directory,
         _interpreter,
         endpoints,
-        args.get("dump_stories"),
         args.get("config")[0],
         None,
         additional_arguments,

--- a/tests/cli/test_rasa_interactive.py
+++ b/tests/cli/test_rasa_interactive.py
@@ -18,8 +18,7 @@ def test_interactive_help(run: Callable[..., RunResult]):
                         [--conversation-id CONVERSATION_ID]
                         [--endpoints ENDPOINTS] [-c CONFIG] [-d DOMAIN]
                         [--out OUT] [--augmentation AUGMENTATION]
-                        [--debug-plots] [--dump-stories] [--force]
-                        [--persist-nlu-data]
+                        [--debug-plots] [--force] [--persist-nlu-data]
                         {core} ... [model-as-positional-argument]"""
 
     lines = help_text.split("\n")
@@ -36,7 +35,7 @@ def test_interactive_core_help(run: Callable[..., RunResult]):
                              [--conversation-id CONVERSATION_ID]
                              [--endpoints ENDPOINTS] [-c CONFIG] [-d DOMAIN]
                              [--out OUT] [--augmentation AUGMENTATION]
-                             [--debug-plots] [--dump-stories]
+                             [--debug-plots]
                              [model-as-positional-argument]"""
 
     lines = help_text.split("\n")

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -322,8 +322,8 @@ def test_train_help(run):
     help_text = """usage: rasa train [-h] [-v] [-vv] [--quiet] [--data DATA [DATA ...]]
                   [-c CONFIG] [-d DOMAIN] [--out OUT]
                   [--augmentation AUGMENTATION] [--debug-plots]
-                  [--dump-stories] [--fixed-model-name FIXED_MODEL_NAME]
-                  [--persist-nlu-data] [--force]
+                  [--fixed-model-name FIXED_MODEL_NAME] [--persist-nlu-data]
+                  [--force]
                   {core,nlu} ..."""
 
     lines = help_text.split("\n")
@@ -350,8 +350,7 @@ def test_train_core_help(run: Callable[..., RunResult]):
 
     help_text = """usage: rasa train core [-h] [-v] [-vv] [--quiet] [-s STORIES] [-d DOMAIN]
                        [-c CONFIG [CONFIG ...]] [--out OUT]
-                       [--augmentation AUGMENTATION] [--debug-plots]
-                       [--dump-stories] [--force]
+                       [--augmentation AUGMENTATION] [--debug-plots] [--force]
                        [--fixed-model-name FIXED_MODEL_NAME]
                        [--percentages [PERCENTAGES [PERCENTAGES ...]]]
                        [--runs RUNS]"""

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -134,12 +134,6 @@ class PolicyTestCollection:
             loaded.featurizer.state_featurizer, BinarySingleStateFeaturizer
         )
 
-    async def test_continue_training(self, trained_policy, default_domain):
-        training_trackers = await train_trackers(default_domain, augmentation_factor=0)
-        trained_policy.continue_training(
-            training_trackers, default_domain, **{"epochs": 1}
-        )
-
     async def test_persist_and_load(self, trained_policy, default_domain, tmpdir):
         trained_policy.persist(tmpdir.strpath)
         loaded = trained_policy.__class__.load(tmpdir.strpath)


### PR DESCRIPTION
**Proposed changes**:
- removed previously deprecated continue training #4990 
- removed `dump_flattened_stories` from `Agent.persist`
- improves memory footprint as the trained agent does not keep a reference to all training trackers as part of the ensemble anymore.

**Status (please check what you already did)**:
- [x] removed some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
