### PR TITLE
use tf without gpu support by default

### DIFF
--- a/changelog/4989.improvement.rst
+++ b/changelog/4989.improvement.rst
@@ -1,3 +1,3 @@
 Switching back to a TensorFlow release which only includes CPU support to reduce the
 size of the dependencies. If you want to use the TensorFlow package with GPU support,
-please run ``tensorflow==1.15.0``.
+please run ``tensorflow-gpu==1.15.0``.

--- a/changelog/4989.improvement.rst
+++ b/changelog/4989.improvement.rst
@@ -1,0 +1,3 @@
+Switching back to a TensorFlow release which only includes CPU support to reduce the
+size of the dependencies. If you want to use the TensorFlow package with GPU support,
+please run ``tensorflow==1.15.0``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ redis==3.3.5
 pymongo[tls,srv]==3.8.0
 numpy==1.16.3
 scipy==1.2.1
-tensorflow-cpu=1.15.0
+tensorflow-cpu==1.15.0
 absl-py>=0.8.0
 # setuptools comes from tensorboard requirement:
 # https://github.com/tensorflow/tensorboard/blob/1.14/tensorboard/pip_package/setup.py#L33

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ redis==3.3.5
 pymongo[tls,srv]==3.8.0
 numpy==1.16.3
 scipy==1.2.1
-tensorflow==1.15.0
+tensorflow-cpu=1.15.0
 absl-py>=0.8.0
 # setuptools comes from tensorboard requirement:
 # https://github.com/tensorflow/tensorboard/blob/1.14/tensorboard/pip_package/setup.py#L33

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     "pymongo[tls,srv]~=3.8",
     "numpy~=1.16",
     "scipy~=1.2",
-    "tensorflow~=1.15.0",
+    "tensorflow-cpu~=1.15.0",
     # absl is a tensorflow dependency, but produces double logging before 0.8
     # should be removed once tensorflow requires absl > 0.8 on its own
     "absl-py>=0.8.0",


### PR DESCRIPTION
**Proposed changes**:
- TensorFlow 1.15 for some reason includes the binaries for cpu and gpu which makes our docker images huge. Switching to the cpu only package.
- Rasa part of https://github.com/RasaHQ/rasa-x/issues/1643
- more information here https://www.tensorflow.org/install/pip

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
