### PR TITLE
Add any_of helper method to component

### DIFF
--- a/changelog/5029.feature.rst
+++ b/changelog/5029.feature.rst
@@ -1,4 +1,4 @@
-Add ``any_of`` to component. Should be used inside ``requires``.
+Add ``any_of`` function to the ``Component`` class. Should be used inside ``requires``.
 
 ``any_of`` allows you to define multiple attributes of a message for a component.
 At least one of those attributes needs to be present.

--- a/changelog/5029.feature.rst
+++ b/changelog/5029.feature.rst
@@ -1,5 +1,5 @@
-Add ``requires_one_of`` to component.
+Add ``one_of`` to component. Should be used inside ``requires``.
 
-``requires_one_of`` allows you to define multiple attributes of a message for a component.
+``one_of`` allows you to define multiple attributes of a message for a component.
 At least one of those attributes needs to be present.
 Otherwise, the component cannot be trained and an error is raised.

--- a/changelog/5029.feature.rst
+++ b/changelog/5029.feature.rst
@@ -1,5 +1,5 @@
-Add ``one_of`` to component. Should be used inside ``requires``.
+Add ``any_of`` to component. Should be used inside ``requires``.
 
-``one_of`` allows you to define multiple attributes of a message for a component.
+``any_of`` allows you to define multiple attributes of a message for a component.
 At least one of those attributes needs to be present.
 Otherwise, the component cannot be trained and an error is raised.

--- a/changelog/5029.feature.rst
+++ b/changelog/5029.feature.rst
@@ -1,0 +1,5 @@
+Add ``requires_one_of`` to component.
+
+``requires_one_of`` allows you to define multiple attributes of a message for a component.
+At least one of those attributes needs to be present.
+Otherwise, the component cannot be trained and an error is raised.

--- a/rasa/nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa/nlu/classifiers/embedding_intent_classifier.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Text, Tuple, Union
 import warnings
 
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
-from rasa.nlu.components import Component
+from rasa.nlu.components import Component, one_of
 from rasa.utils import train_utils
 from rasa.utils.train_utils import SessionDataType
 from rasa.nlu.constants import (
@@ -54,9 +54,10 @@ class EmbeddingIntentClassifier(Component):
 
     provides = ["intent", "intent_ranking"]
 
-    requires_one_of = [
-        DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE],
-        SPARSE_FEATURE_NAMES[TEXT_ATTRIBUTE],
+    requires = [
+        one_of(
+            DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE], SPARSE_FEATURE_NAMES[TEXT_ATTRIBUTE]
+        )
     ]
 
     # default properties (DOC MARKER - don't remove)

--- a/rasa/nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa/nlu/classifiers/embedding_intent_classifier.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Text, Tuple, Union
 import warnings
 
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
-from rasa.nlu.components import Component, one_of
+from rasa.nlu.components import Component, any_of
 from rasa.utils import train_utils
 from rasa.utils.train_utils import SessionDataType
 from rasa.nlu.constants import (
@@ -55,7 +55,7 @@ class EmbeddingIntentClassifier(Component):
     provides = ["intent", "intent_ranking"]
 
     requires = [
-        one_of(
+        any_of(
             DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE], SPARSE_FEATURE_NAMES[TEXT_ATTRIBUTE]
         )
     ]

--- a/rasa/nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa/nlu/classifiers/embedding_intent_classifier.py
@@ -54,7 +54,10 @@ class EmbeddingIntentClassifier(Component):
 
     provides = ["intent", "intent_ranking"]
 
-    requires = []
+    requires_one_of = [
+        DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE],
+        SPARSE_FEATURE_NAMES[TEXT_ATTRIBUTE],
+    ]
 
     # default properties (DOC MARKER - don't remove)
     defaults = {

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -110,7 +110,7 @@ def validate_requires_any_of(
 
     if not property_present:
         raise Exception(
-            f"Failed to validate component {component_name}. "
+            f"Failed to validate component '{component_name}'. "
             f"Missing one of the following properties: "
             f"{required_properties}."
         )

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -94,7 +94,9 @@ def any_of(*args):
 
 
 def validate_requires_any_of(
-    required_properties: Tuple[Text], provided_properties: Set[Text], component_name: Text
+    required_properties: Tuple[Text],
+    provided_properties: Set[Text],
+    component_name: Text,
 ):
     """Validates that at least one of the given properties is present in
     the provided properties."""

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -97,7 +97,7 @@ def validate_requires_any_of(
     required_properties: Tuple[Text],
     provided_properties: Set[Text],
     component_name: Text,
-):
+) -> None:
     """Validates that at least one of the given required properties is present in
     the provided properties."""
 

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -94,7 +94,7 @@ def one_of(*args):
 
 
 def validate_requires_one_of(
-    properties: Tuple[Text], provided_properties: Set[Text], component_name: Text
+    required_properties: Tuple[Text], provided_properties: Set[Text], component_name: Text
 ):
     """Validates that at least one of the given properties is present in
     the provided properties."""

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -64,8 +64,8 @@ def validate_arguments(
         raise ValueError(
             "Can not train an empty pipeline. "
             "Make sure to specify a proper pipeline in "
-            "the configuration using the `pipeline` key. "
-            "The `backend` configuration key is "
+            "the configuration using the 'pipeline' key. "
+            "The 'backend' configuration key is "
             "NOT supported anymore."
         )
 
@@ -164,7 +164,9 @@ class UnsupportedLanguageError(Exception):
         super().__init__(component, language)
 
     def __str__(self) -> Text:
-        return f"component '{self.component}' does not support language '{self.language}'."
+        return (
+            f"component '{self.component}' does not support language '{self.language}'."
+        )
 
 
 class ComponentMetaclass(type):
@@ -495,7 +497,7 @@ class ComponentBuilder:
             return component
         except MissingArgumentError as e:  # pragma: no cover
             raise Exception(
-                f"Failed to load component from file `{component_meta.get('file')}`. "
+                f"Failed to load component from file '{component_meta.get('file')}'. "
                 f"Error: {e}"
             )
 
@@ -517,6 +519,6 @@ class ComponentBuilder:
             return component
         except MissingArgumentError as e:  # pragma: no cover
             raise Exception(
-                f"Failed to create component `{component_config['name']}`. "
+                f"Failed to create component '{component_config['name']}'. "
                 f"Error: {e}"
             )

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -98,7 +98,7 @@ def validate_requires_any_of(
     provided_properties: Set[Text],
     component_name: Text,
 ):
-    """Validates that at least one of the given properties is present in
+    """Validates that at least one of the given required properties is present in
     the provided properties."""
 
     property_present = False

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -74,7 +74,7 @@ def validate_arguments(
     for component in pipeline:
         for r in component.requires:
             if isinstance(r, Tuple):
-                validate_requires_one_of(r, provided_properties, str(component.name))
+                validate_requires_any_of(r, provided_properties, str(component.name))
             else:
                 if r not in provided_properties:
                     raise Exception(
@@ -85,7 +85,7 @@ def validate_arguments(
         provided_properties.update(component.provides)
 
 
-def one_of(*args):
+def any_of(*args):
     """Helper function to define that one of the given arguments is required
     by a component.
 
@@ -93,7 +93,7 @@ def one_of(*args):
     return args
 
 
-def validate_requires_one_of(
+def validate_requires_any_of(
     required_properties: Tuple[Text], provided_properties: Set[Text], component_name: Text
 ):
     """Validates that at least one of the given properties is present in
@@ -101,7 +101,7 @@ def validate_requires_one_of(
 
     property_present = False
 
-    for property in properties:
+    for property in required_properties:
         if property in provided_properties:
             property_present = True
             break
@@ -110,7 +110,7 @@ def validate_requires_one_of(
         raise Exception(
             f"Failed to validate component {component_name}. "
             f"Missing one of the following properties: "
-            f"{properties}."
+            f"{required_properties}."
         )
 
 
@@ -217,7 +217,7 @@ class Component(metaclass=ComponentMetaclass):
     # component. E.g. if requires contains "tokens", than a
     # previous component in the pipeline needs to have "tokens"
     # within the above described `provides` property.
-    # Use `one_of("option_1", "option_2")` to define that either
+    # Use `any_of("option_1", "option_2")` to define that either
     # "option_1" or "option_2" needs to be present in the
     # provided properties from the previous components.
     requires = []

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -85,7 +85,7 @@ def validate_arguments(
         provided_properties.update(component.provides)
 
 
-def any_of(*args):
+def any_of(*args) -> Tuple[Any]:
     """Helper function to define that one of the given arguments is required
     by a component.
 
@@ -101,12 +101,9 @@ def validate_requires_any_of(
     """Validates that at least one of the given required properties is present in
     the provided properties."""
 
-    property_present = False
-
-    for property in required_properties:
-        if property in provided_properties:
-            property_present = True
-            break
+    property_present = any(
+        [property in provided_properties for property in required_properties]
+    )
 
     if not property_present:
         raise Exception(

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -164,7 +164,7 @@ class UnsupportedLanguageError(Exception):
         super().__init__(component, language)
 
     def __str__(self) -> Text:
-        return f"component {self.component} does not support language {self.language}"
+        return f"component '{self.component}' does not support language '{self.language}'."
 
 
 class ComponentMetaclass(type):

--- a/tests/nlu/base/test_components.py
+++ b/tests/nlu/base/test_components.py
@@ -1,5 +1,6 @@
 import pytest
 
+from typing import Tuple
 from rasa.nlu import registry
 from rasa.nlu.components import find_unavailable_packages
 from rasa.nlu.config import RasaNLUModelConfig
@@ -44,7 +45,15 @@ def test_all_arguments_can_be_satisfied(component_class):
     }
 
     for req in component_class.requires:
-        assert req in provided_properties, "No component provides required property."
+        if isinstance(req, Tuple):
+            for r in req:
+                assert (
+                    r in provided_properties
+                ), "No component provides required property."
+        else:
+            assert (
+                req in provided_properties
+            ), "No component provides required property."
 
 
 def test_find_unavailable_packages():

--- a/tests/nlu/classifiers/test_embedding_intent_classifier.py
+++ b/tests/nlu/classifiers/test_embedding_intent_classifier.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import scipy.sparse
 
+from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.constants import (
     TEXT_ATTRIBUTE,
     SPARSE_FEATURE_NAMES,
@@ -10,6 +11,7 @@ from rasa.nlu.constants import (
 )
 from rasa.nlu.classifiers.embedding_intent_classifier import EmbeddingIntentClassifier
 from rasa.nlu.training_data import Message
+from tests.nlu.conftest import DEFAULT_DATA_PATH
 
 
 def test_compute_default_label_features():
@@ -104,3 +106,25 @@ def test_check_labels_features_exist(messages, expected):
         EmbeddingIntentClassifier._check_labels_features_exist(messages, attribute)
         == expected
     )
+
+
+async def test_raise_error_on_incorrect_pipeline(component_builder, tmpdir):
+    from rasa.nlu import train
+
+    _config = RasaNLUModelConfig(
+        {
+            "pipeline": [
+                {"name": "WhitespaceTokenizer"},
+                {"name": "EmbeddingIntentClassifier"},
+            ],
+            "language": "en",
+        }
+    )
+
+    with pytest.raises(Exception):
+        await train(
+            _config,
+            path=tmpdir.strpath,
+            data=DEFAULT_DATA_PATH,
+            component_builder=component_builder,
+        )

--- a/tests/nlu/classifiers/test_embedding_intent_classifier.py
+++ b/tests/nlu/classifiers/test_embedding_intent_classifier.py
@@ -121,10 +121,15 @@ async def test_raise_error_on_incorrect_pipeline(component_builder, tmpdir):
         }
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as e:
         await train(
             _config,
             path=tmpdir.strpath,
             data=DEFAULT_DATA_PATH,
             component_builder=component_builder,
         )
+
+    assert (
+        "Failed to validate component 'EmbeddingIntentClassifier'. Missing one of "
+        "the following properties: " in str(e.value)
+    )

--- a/tests/nlu/example_component.py
+++ b/tests/nlu/example_component.py
@@ -22,6 +22,13 @@ class MyComponent(Component):
     # within the above described `provides` property.
     requires = []
 
+    # At least one of the attributes on a message is required by this
+    # component. E.g. if requires_one_of contains "text_dense_features" and
+    # "text_sparse_features", than a previous component in the pipeline needs
+    # to have "text_dense_features" or "text_sparse_features"
+    # within the above described `provides` property.
+    requires_one_of = []
+
     # Defines the default configuration parameters of a component
     # these values can be overwritten in the pipeline configuration
     # of the model. The component should choose sensible defaults

--- a/tests/nlu/example_component.py
+++ b/tests/nlu/example_component.py
@@ -17,17 +17,13 @@ class MyComponent(Component):
     provides = []
 
     # Which attributes on a message are required by this
-    # component. e.g. if requires contains "tokens", than a
+    # component. E.g. if requires contains "tokens", than a
     # previous component in the pipeline needs to have "tokens"
     # within the above described `provides` property.
+    # Use `one_of("option_1", "option_2")` to define that either
+    # "option_1" or "option_2" needs to be present in the
+    # provided properties from the previous components.
     requires = []
-
-    # At least one of the attributes on a message is required by this
-    # component. E.g. if requires_one_of contains "text_dense_features" and
-    # "text_sparse_features", than a previous component in the pipeline needs
-    # to have "text_dense_features" or "text_sparse_features"
-    # within the above described `provides` property.
-    requires_one_of = []
 
     # Defines the default configuration parameters of a component
     # these values can be overwritten in the pipeline configuration

--- a/tests/nlu/example_component.py
+++ b/tests/nlu/example_component.py
@@ -20,7 +20,7 @@ class MyComponent(Component):
     # component. E.g. if requires contains "tokens", than a
     # previous component in the pipeline needs to have "tokens"
     # within the above described `provides` property.
-    # Use `one_of("option_1", "option_2")` to define that either
+    # Use `any_of("option_1", "option_2")` to define that either
     # "option_1" or "option_2" needs to be present in the
     # provided properties from the previous components.
     requires = []


### PR DESCRIPTION
**Proposed changes**:
- Add `one_of` to component. It allows you to say that the component requires either X, Y, or Z.

closes #5029

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
