### PR TITLE
Fix 5032

### DIFF
--- a/changelog/5032.bugfix.rst
+++ b/changelog/5032.bugfix.rst
@@ -1,0 +1,5 @@
+Fix wrong calculation of additional conversation events when saving the conversation.
+This led to conversation events not being saved.
+
+Fix wrong order of conversadtion events when pushing events to conversations via
+``POST /conversations/<conversation_id>/tracker/events``.

--- a/changelog/5032.bugfix.rst
+++ b/changelog/5032.bugfix.rst
@@ -1,5 +1,5 @@
 Fix wrong calculation of additional conversation events when saving the conversation.
 This led to conversation events not being saved.
 
-Fix wrong order of conversadtion events when pushing events to conversations via
+Fix wrong order of conversation events when pushing events to conversations via
 ``POST /conversations/<conversation_id>/tracker/events``.

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -745,6 +745,15 @@ class SQLTrackerStore(TrackerStore):
                 return None
 
     def _event_query(self, session: "Session", sender_id: Text) -> "Query":
+        """Provide the query to retrieve the conversation events for a specific sender.
+
+        Args:
+            session: Current database session.
+            sender_id: Sender id whose conversation events should be retrieved.
+
+        Returns:
+            Query to get the conversation events.
+        """
         import sqlalchemy as sa
 
         # Subquery to find the timestamp of the latest `SessionStarted` event

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -474,6 +474,8 @@ def create_app(
                     app.agent.create_processor(), conversation_id
                 )
 
+                # Get events after tracker initialization to ensure that generated
+                # timestamps are after potential session events.
                 events = _get_events_from_request_body(request)
 
                 for event in events:

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -466,7 +466,30 @@ def create_app(
             "to the state of a conversation.",
         )
 
+        verbosity = event_verbosity_parameter(request, EventVerbosity.AFTER_RESTART)
+
+        try:
+            async with app.agent.lock_store.lock(conversation_id):
+                tracker = await get_tracker(
+                    app.agent.create_processor(), conversation_id
+                )
+
+                events = _get_events_from_request_body(request)
+
+                for event in events:
+                    tracker.update(event, app.agent.domain)
+                app.agent.tracker_store.save(tracker)
+
+            return response.json(tracker.current_state(verbosity))
+        except Exception as e:
+            logger.debug(traceback.format_exc())
+            raise ErrorResponse(
+                500, "ConversationError", f"An unexpected error occurred. Error: {e}"
+            )
+
+    def _get_events_from_request_body(request: Request) -> List[Event]:
         events = request.json
+
         if not isinstance(events, list):
             events = [events]
 
@@ -485,23 +508,7 @@ def create_app(
                 {"parameter": "", "in": "body"},
             )
 
-        verbosity = event_verbosity_parameter(request, EventVerbosity.AFTER_RESTART)
-
-        try:
-            async with app.agent.lock_store.lock(conversation_id):
-                tracker = await get_tracker(
-                    app.agent.create_processor(), conversation_id
-                )
-                for event in events:
-                    tracker.update(event, app.agent.domain)
-                app.agent.tracker_store.save(tracker)
-
-            return response.json(tracker.current_state(verbosity))
-        except Exception as e:
-            logger.debug(traceback.format_exc())
-            raise ErrorResponse(
-                500, "ConversationError", f"An unexpected error occurred. Error: {e}"
-            )
+        return events
 
     @app.put("/conversations/<conversation_id>/tracker/events")
     @requires_auth(app, auth_token)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@ from mock import MagicMock
 import rasa
 import rasa.constants
 from rasa.core import events, utils
+from rasa.core.agent import Agent
 from rasa.core.channels import CollectingOutputChannel, RestInput, SlackInput
 from rasa.core.channels.slack import SlackBot
 from rasa.core.events import Event, UserUttered, SlotSet, BotUttered
@@ -563,25 +564,31 @@ def test_requesting_non_existent_tracker(rasa_app: SanicTestClient):
 
 @pytest.mark.parametrize("event", test_events)
 def test_pushing_event(rasa_app, event):
-    cid = str(uuid.uuid1())
-    conversation = f"/conversations/{cid}"
+    sender_id = str(uuid.uuid1())
+    conversation = f"/conversations/{sender_id}"
+
+    serialized_event = event.as_dict()
+    # Remove timestamp so that a new one is assigned on the server
+    serialized_event.pop("timestamp")
 
     _, response = rasa_app.post(
         f"{conversation}/tracker/events",
-        json=event.as_dict(),
+        json=serialized_event,
         headers={"Content-Type": "application/json"},
     )
     assert response.json is not None
     assert response.status == 200
 
-    _, tracker_response = rasa_app.get(f"/conversations/{cid}/tracker")
+    _, tracker_response = rasa_app.get(f"/conversations/{sender_id}/tracker")
     tracker = tracker_response.json
     assert tracker is not None
 
     assert len(tracker.get("events")) == 4
 
     evt = tracker.get("events")[3]
-    assert Event.from_parameters(evt) == event
+    deserialised_event = Event.from_parameters(evt)
+    assert deserialised_event == event
+    assert deserialised_event.timestamp > tracker.get("events")[2]["timestamp"]
 
 
 def test_push_multiple_events(rasa_app: SanicTestClient):
@@ -684,7 +691,7 @@ def test_get_tracker_with_jwt(rasa_secured_app):
     assert response.status == 200
 
 
-def test_list_routes(default_agent):
+def test_list_routes(default_agent: Agent):
     from rasa import server
 
     app = server.create_app(default_agent, auth_token=None)


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/5032
- Fix wrong calculation of additional conversation events when saving the conversation.
This led to conversation events not being saved (we always calculated number of events from the start, but the retrieved tracker only contains the events since the last session start)
- Fix wrong order of conversation events when pushing events to conversations via
``POST /conversations/<conversation_id>/tracker/events``.


**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
