### PR TITLE
docs(fix): change the prefix of the slack token

### DIFF
--- a/docs/user-guide/connectors/slack.rst
+++ b/docs/user-guide/connectors/slack.rst
@@ -26,7 +26,7 @@ Getting Credentials
      the argument to post DMs to the bot.
   4. Use the entry for ``Bot User OAuth Access Token`` in the
      "OAuth & Permissions" tab as your ``slack_token``. It should start
-     with ``xoxob``.
+     with ``xoxb``.
 
 
 For more detailed steps, visit the


### PR DESCRIPTION
**Proposed changes**:

- fix: **change the prefix of the slack token** form xoxob to xoxb to ease the reading of the documentation

- source : https://rasa.com/docs/rasa/user-guide/connectors/slack/

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [X] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
