### PR TITLE
ISSUE-2760 Resolving compatibility issues with Microsoft Bot Framework emulator

### DIFF
--- a/changelog/5057.bugfix.rst
+++ b/changelog/5057.bugfix.rst
@@ -1,0 +1,1 @@
+Addressing ISSUE-2760 to resolve compatibility issues with Microsoft Bot Framework Emulator.

--- a/changelog/5057.bugfix.rst
+++ b/changelog/5057.bugfix.rst
@@ -1,1 +1,1 @@
-Addressing ISSUE-2760 to resolve compatibility issues with Microsoft Bot Framework Emulator.
+Fixed compatibility issue with Microsoft Bot Framework Emulator if ``service_url`` lacked a trailing ``/``.

--- a/rasa/core/channels/botframework.py
+++ b/rasa/core/channels/botframework.py
@@ -36,6 +36,10 @@ class BotFramework(OutputChannel):
         service_url: Text,
     ) -> None:
 
+        service_url = (
+            f"{service_url}/" if not service_url.endswith("/") else service_url
+        )
+
         self.app_id = app_id
         self.app_password = app_password
         self.conversation = conversation


### PR DESCRIPTION
**Proposed changes**:
- Updated BotFramework connector to address https://github.com/RasaHQ/rasa/issues/5056
- fixed https://github.com/RasaHQ/rasa/issues/5056 