### PR TITLE
pin sanic-plugins-framework to 0.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ terminaltables==3.1.0
 sanic==19.9.0
 sanic-cors==0.9.9.post1
 sanic-jwt==1.3.2
+# https://github.com/RasaHQ/rasa/pull/5064
 sanic-plugins-framework==0.8.2
 # needed because of https://github.com/huge-success/sanic/issues/1729
 multidict==4.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ terminaltables==3.1.0
 sanic==19.9.0
 sanic-cors==0.9.9.post1
 sanic-jwt==1.3.2
+sanic-plugins-framework==0.8.2
 # needed because of https://github.com/huge-success/sanic/issues/1729
 multidict==4.6.1
 aiohttp==3.5.4


### PR DESCRIPTION
**Proposed changes**:
Master currently fails with 
```
pkg_resources.ContextualVersionConflict: (sanic 19.9.0 (/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages), Requirement.parse('sanic<=19.6.3,>=0.8.3'), {'sanic-plugins-framework'})
```
As a workaround pin the version of `sanic-plugins-framework` to 0.8.2.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
