### PR TITLE
[bug] Round Decimal to 9 places to support DynamoDB constraints

### DIFF
--- a/changelog/5092.bugfix.rst
+++ b/changelog/5092.bugfix.rst
@@ -1,0 +1,1 @@
+DynamoDB tracker store decimal values will now be rounded on save. Previously values exceeding 38 digits caused an unhandled error.

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -458,9 +458,7 @@ def create_task_error_logger(error_message: Text = "") -> Callable[[Future], Non
     return handler
 
 
-def replace_floats_with_decimals(
-    obj: Union[List, Dict], round_digits: int = 9
-) -> Any:
+def replace_floats_with_decimals(obj: Union[List, Dict], round_digits: int = 9) -> Any:
     """
     Utility method to recursively walk a dictionary or list converting all `float` to `Decimal` as required by DynamoDb.
 

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -465,7 +465,7 @@ def replace_floats_with_decimals(obj: Union[List, Dict]) -> Any:
     Args:
         obj: A `List` or `Dict` object.
 
-    Returns: An object with all matching values and `float` type replaced by `Decimal`.
+    Returns: An object with all matching values and `float` type replaced by `Decimal` rounded to 9 decimal places.
 
     """
     if isinstance(obj, list):
@@ -477,7 +477,7 @@ def replace_floats_with_decimals(obj: Union[List, Dict]) -> Any:
             obj[j] = replace_floats_with_decimals(obj[j])
         return obj
     elif isinstance(obj, float):
-        return Decimal(obj)
+        return round(Decimal(obj), 9)
     else:
         return obj
 

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -466,7 +466,7 @@ def replace_floats_with_decimals(obj: Union[List, Dict], round_digits: int = 9) 
         obj: A `List` or `Dict` object.
         round_digits: A int value to set the rounding precision of Decimal values.
 
-    Returns: An object with all matching values and `float` types replaced by `Decimal`s rounded to 9 decimal places.
+    Returns: An object with all matching values and `float` types replaced by `Decimal`s rounded to `round_digits` decimal places.
 
     """
     if isinstance(obj, list):

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -458,14 +458,17 @@ def create_task_error_logger(error_message: Text = "") -> Callable[[Future], Non
     return handler
 
 
-def replace_floats_with_decimals(obj: Union[List, Dict]) -> Any:
+def replace_floats_with_decimals(
+    obj: Union[List, Dict], round_digits: int = 9
+) -> Any:
     """
     Utility method to recursively walk a dictionary or list converting all `float` to `Decimal` as required by DynamoDb.
 
     Args:
         obj: A `List` or `Dict` object.
+        round_digits: A int value to set the rounding precision of Decimal values.
 
-    Returns: An object with all matching values and `float` type replaced by `Decimal` rounded to 9 decimal places.
+    Returns: An object with all matching values and `float` types replaced by `Decimal`s rounded to 9 decimal places.
 
     """
     if isinstance(obj, list):
@@ -477,7 +480,7 @@ def replace_floats_with_decimals(obj: Union[List, Dict]) -> Any:
             obj[j] = replace_floats_with_decimals(obj[j])
         return obj
     elif isinstance(obj, float):
-        return round(Decimal(obj), 9)
+        return round(Decimal(obj), round_digits)
     else:
         return obj
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -98,7 +98,7 @@ def test_float_conversion_to_decimal():
     d = {
         "int": -1,
         "float": 2.1,
-        "float_round": 0.918040672051180450807805755175650119781494140625,
+        "float_round": 1579507733.1107571125030517578125,
         "list": ["one", "two"],
         "list_of_floats": [1.0, -2.1, 3.2],
         "nested_dict_with_floats": {"list_with_floats": [4.5, -5.6], "float": 6.7},
@@ -107,7 +107,7 @@ def test_float_conversion_to_decimal():
 
     assert isinstance(d_replaced["int"], int)
     assert isinstance(d_replaced["float"], Decimal)
-    assert d_replaced["float_round"] == Decimal('0.918040672')
+    assert d_replaced["float_round"] == Decimal("1579507733.110757113")
     for t in d_replaced["list"]:
         assert isinstance(t, str)
     for f in d_replaced["list_of_floats"]:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -98,6 +98,7 @@ def test_float_conversion_to_decimal():
     d = {
         "int": -1,
         "float": 2.1,
+        "float_round": 0.918040672051180450807805755175650119781494140625,
         "list": ["one", "two"],
         "list_of_floats": [1.0, -2.1, 3.2],
         "nested_dict_with_floats": {"list_with_floats": [4.5, -5.6], "float": 6.7},
@@ -106,6 +107,7 @@ def test_float_conversion_to_decimal():
 
     assert isinstance(d_replaced["int"], int)
     assert isinstance(d_replaced["float"], Decimal)
+    assert d_replaced["float_round"] == Decimal('0.918040672')
     for t in d_replaced["list"]:
         assert isinstance(t, str)
     for f in d_replaced["list_of_floats"]:


### PR DESCRIPTION
**Proposed changes**:
No rounding is currently performed prior to saving to DynamoDB tracker on Decimal values. This can result in saving errors if a value is greater than [38 characters](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-data-types).

Rounded to 9 decimal places as per @akelad's recommendation 🙂 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
