### PR TITLE
Use pip 19 when installing dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ install:
   # The instructions listed here should be equivalent to the ones
   # listed in README.md!
   - sudo apt-get update -qq
-  - python -m pip install -U pip
+  # Pip 20.0.1 breaks our build script when installing one of the
+  # dependencies in requirements-dev.txt (ninja 1.9.0.post1).  For the
+  # moment, use pip 19 to install them.
+  - python -m pip install -U 'pip<20'
   - pip install -r requirements-dev.txt
   - pip install -e .
   - make prepare-tests-ubuntu


### PR DESCRIPTION
**Proposed changes**:
- Try to fix the Travis build by using pip 19 to install the dependencies when testing Rasa.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
