### PR TITLE
Fix end-to-end warning url

### DIFF
--- a/changelog/5126.bugfix.rst
+++ b/changelog/5126.bugfix.rst
@@ -1,0 +1,2 @@
+Updated the end-to-end ValueError you recieve when you have a invalid story format to point
+to the updated doc link.

--- a/rasa/core/training/dsl.py
+++ b/rasa/core/training/dsl.py
@@ -58,7 +58,7 @@ class EndToEndReader(MarkdownReader):
                 "Encountered invalid end-to-end format for message "
                 "`{}`. Please visit the documentation page on "
                 "end-to-end evaluation at {}/user-guide/evaluating-models/"
-                "end-to-end-evaluation/".format(line, DOCS_BASE_URL)
+                "#end-to-end-evaluation/".format(line, DOCS_BASE_URL)
             )
 
         intent = match.group(2)


### PR DESCRIPTION
**Proposed changes**:
- Change the warning message in the `rasa/core/training/dsl.py` file for the ValueError on end-to-end testing to be the proper updated doc link.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [X] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
