### PR TITLE
fix rasa init uvloop error

### DIFF
--- a/changelog/5111.bugfix.rst
+++ b/changelog/5111.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes ``Exception 'Loop' object has no attribute '_ready'`` error when running 
+``rasa init``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,8 @@ sanic-plugins-framework==0.8.2
 multidict==4.6.1
 aiohttp==3.5.4
 questionary==1.1.1
+# needed because of https://github.com/prompt-toolkit/python-prompt-toolkit/issues/951
+prompt-toolkit==2.0.10
 python-socketio==4.3.1
 # the below can be unpinned when python-socketio pins >=3.9.3
 python-engineio==3.9.3

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ install_requires = [
     "multidict==4.6.1",
     "aiohttp~=3.5",
     "questionary>=1.1.0",
+    # needed because of https://github.com/prompt-toolkit/python-prompt-toolkit/issues/951
+    "prompt-toolkit<3.0",
     "python-socketio>=4.3.1",
     # the below can be unpinned when python-socketio pins >=3.9.3
     "python-engineio>=3.9.3",


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/5111 by pinning prompt-toolkit version
- workaround until https://github.com/prompt-toolkit/python-prompt-toolkit/issues/951 is fixed

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
