### PR TITLE
remove build stage, no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,11 +96,6 @@ jobs:
     - git remote set-url --push origin "git@github.com:$TRAVIS_REPO_SLUG"
     - export ${!TRAVIS*}
     - sphinx-versioning push docs docs . -- -b dirhtml -A html_theme=rasabaster
-  - stage: docs-netlify
-    if: branch = master AND type != pull_request OR tag IS present
-    install: skip
-    script:
-    - curl -X POST -d "docs" https://api.netlify.com/build_hooks/${NETLIFY_HOOK_ID}
   - stage: deploy
     name: "Deploy to PyPI"
     python: 3.6

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ We use `sphinx-versioning` to build docs for tagged versions and for the master 
 The static site that gets built is pushed to the `docs` branch of this repo, which doesn't contain
 any code, only the site.
 
-We host the site on netlify. When there is a reason to update the docs (e.g. master has changed or we have
-tagged a new version) we trigger a webhook on netlify (see `.travis.yml`). 
+We host the site on netlify. On master branch builds (see `.travis.yml`), we push the built docs to the `docs`
+branch. Netlify automatically re-deploys the docs pages whenever there is a change to that branch.
 
 
 ## License


### PR DESCRIPTION
**Proposed changes**:
- netlify now configured to deploy any push to `docs` branch, so no need for this

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
