### PR TITLE
Update log messages that include return_sequence

### DIFF
--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -602,9 +602,7 @@ class CRFEntityExtractor(EntityExtractor):
             raise_warning(
                 f"Number of features ({len(features)}) for attribute "
                 f"'{DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE]}' "
-                f"does not match number of tokens ({len(tokens)}). Set "
-                f"'return_sequence' to true in the corresponding featurizer in order "
-                f"to make use of the features in 'CRFEntityExtractor'.",
+                f"does not match number of tokens ({len(tokens)}).",
                 docs=DOCS_URL_COMPONENTS + "#crfentityextractor",
             )
             return None

--- a/rasa/nlu/featurizers/featurizer.py
+++ b/rasa/nlu/featurizers/featurizer.py
@@ -37,9 +37,7 @@ class Featurizer(Component):
                 raise ValueError(
                     f"Cannot concatenate dense features as sequence dimension does not "
                     f"match: {len(message.get(feature_name))} != "
-                    f"{len(additional_features)}. "
-                    f"Make sure to set 'return_sequence' to the same value for all your "
-                    f"featurizers."
+                    f"{len(additional_features)}. Message: '{message.text}'."
                 )
 
             return np.concatenate(
@@ -61,9 +59,7 @@ class Featurizer(Component):
                 raise ValueError(
                     f"Cannot concatenate sparse features as sequence dimension does not "
                     f"match: {message.get(feature_name).shape[0]} != "
-                    f"{additional_features.shape[0]}. "
-                    f"Make sure to set 'return_sequence' to the same value for all your "
-                    f"featurizers."
+                    f"{additional_features.shape[0]}. Message: '{message.text}'."
                 )
             return hstack([message.get(feature_name), additional_features])
         else:

--- a/tests/nlu/featurizers/test_featurizer.py
+++ b/tests/nlu/featurizers/test_featurizer.py
@@ -9,7 +9,7 @@ from rasa.nlu.training_data import Message
 
 def test_combine_with_existing_dense_features():
 
-    featurizer = Featurizer({"return_sequence": False})
+    featurizer = Featurizer()
     attribute = DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE]
 
     existing_features = [[1, 0, 2, 3], [2, 0, 0, 1]]
@@ -27,7 +27,7 @@ def test_combine_with_existing_dense_features():
 
 
 def test_combine_with_existing_dense_features_shape_mismatch():
-    featurizer = Featurizer({"return_sequence": False})
+    featurizer = Featurizer()
     attribute = DENSE_FEATURE_NAMES[TEXT_ATTRIBUTE]
 
     existing_features = [[1, 0, 2, 3], [2, 0, 0, 1]]
@@ -44,7 +44,7 @@ def test_combine_with_existing_dense_features_shape_mismatch():
 
 def test_combine_with_existing_sparse_features():
 
-    featurizer = Featurizer({"return_sequence": False})
+    featurizer = Featurizer()
     attribute = SPARSE_FEATURE_NAMES[TEXT_ATTRIBUTE]
 
     existing_features = scipy.sparse.csr_matrix([[1, 0, 2, 3], [2, 0, 0, 1]])
@@ -64,7 +64,7 @@ def test_combine_with_existing_sparse_features():
 
 def test_combine_with_existing_sparse_features_shape_mismatch():
 
-    featurizer = Featurizer({"return_sequence": False})
+    featurizer = Featurizer()
     attribute = SPARSE_FEATURE_NAMES[TEXT_ATTRIBUTE]
 
     existing_features = scipy.sparse.csr_matrix([[1, 0, 2, 3], [2, 0, 0, 1]])


### PR DESCRIPTION
**Proposed changes**:
- We removed the option `return_sequence` in Rasa 1.7.0. Update log messages that still point to this option.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
