### PR TITLE
Fix bug in sparse featurizers

### DIFF
--- a/changelog/5171.bugfix.rst
+++ b/changelog/5171.bugfix.rst
@@ -1,0 +1,4 @@
+Fix bug ``ValueError: Cannot concatenate sparse features as sequence dimension does not match``.
+
+When training a Rasa model that contains responses for just some of the intents, training was failing.
+Fixed the featurizers to return a consistent feature vector in case no response was given for a specific message.

--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -269,7 +269,7 @@ class CountVectorsFeaturizer(Featurizer):
         """Get processed text of attribute of a message"""
 
         if message.get(attribute) is None:
-            # return empty string since sklearn countvectorizer does not like None
+            # return empty list since sklearn countvectorizer does not like None
             # object while training and predicting
             return []
 
@@ -415,6 +415,11 @@ class CountVectorsFeaturizer(Featurizer):
             tokens_without_cls = tokens
             if attribute in [TEXT_ATTRIBUTE, RESPONSE_ATTRIBUTE]:
                 tokens_without_cls = tokens[:-1]
+
+            if not tokens_without_cls:
+                # attribute is not set (e.g. response not present)
+                X.append(None)
+                continue
 
             seq_vec = self.vectorizers[attribute].transform(tokens_without_cls)
             seq_vec.sort_indices()

--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -271,7 +271,7 @@ class CountVectorsFeaturizer(Featurizer):
         if message.get(attribute) is None:
             # return empty string since sklearn countvectorizer does not like None
             # object while training and predicting
-            return [""]
+            return []
 
         tokens = self._get_message_tokens_by_attribute(message, attribute)
         tokens = self._process_tokens(tokens, attribute)
@@ -420,7 +420,9 @@ class CountVectorsFeaturizer(Featurizer):
             seq_vec.sort_indices()
 
             if attribute in [TEXT_ATTRIBUTE, RESPONSE_ATTRIBUTE]:
-                tokens_text = [" ".join(tokens_without_cls)]
+                tokens_text = (
+                    [" ".join(tokens_without_cls)] if tokens_without_cls else []
+                )
                 cls_vec = self.vectorizers[attribute].transform(tokens_text)
                 cls_vec.sort_indices()
 
@@ -489,7 +491,6 @@ class CountVectorsFeaturizer(Featurizer):
 
         # transform for all attributes
         for attribute in self._attributes:
-
             attribute_features = self._get_featurized_attribute(
                 attribute, processed_attribute_tokens[attribute]
             )

--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -425,9 +425,7 @@ class CountVectorsFeaturizer(Featurizer):
             seq_vec.sort_indices()
 
             if attribute in [TEXT_ATTRIBUTE, RESPONSE_ATTRIBUTE]:
-                tokens_text = (
-                    [" ".join(tokens_without_cls)] if tokens_without_cls else []
-                )
+                tokens_text = [" ".join(tokens_without_cls)]
                 cls_vec = self.vectorizers[attribute].transform(tokens_text)
                 cls_vec.sort_indices()
 

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -81,13 +81,18 @@ class RegexFeaturizer(Featurizer):
 
     def _features_for_patterns(
         self, message: Message, attribute: Text
-    ) -> scipy.sparse.coo_matrix:
+    ) -> Optional[scipy.sparse.coo_matrix]:
         """Checks which known patterns match the message.
 
         Given a sentence, returns a vector of {1,0} values indicating which
         regexes did match. Furthermore, if the
         message is tokenized, the function will mark all tokens with a dict
         relating the name of the regex to whether it was matched."""
+
+        # Attribute not set (e.g. response not present)
+        if not message.get(attribute):
+            return None
+
         tokens = message.get(TOKENS_NAMES[attribute], [])
         seq_length = len(tokens)
 

--- a/tests/nlu/featurizers/test_count_vectors_featurizer.py
+++ b/tests/nlu/featurizers/test_count_vectors_featurizer.py
@@ -67,6 +67,8 @@ def test_count_vector_featurizer_response_attribute_featurization(
     train_message.set(INTENT_ATTRIBUTE, intent)
     train_message.set(RESPONSE_ATTRIBUTE, response)
 
+    # add a second example that has some response, so that the vocabulary for
+    # response exists
     second_message = Message("hello")
     second_message.set(RESPONSE_ATTRIBUTE, "hi")
     second_message.set(INTENT_ATTRIBUTE, "greet")
@@ -90,10 +92,7 @@ def test_count_vector_featurizer_response_attribute_featurization(
             == response_features
         )
     else:
-        assert train_message.get(SPARSE_FEATURE_NAMES[RESPONSE_ATTRIBUTE]).shape == (
-            0,
-            1,
-        )
+        assert train_message.get(SPARSE_FEATURE_NAMES[RESPONSE_ATTRIBUTE]) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Proposed changes**:
When training a Rasa model that contains responses for just some of the intents, training was failing.
Fixed `CountVectorsFeaturizer` to return a consistent feature vector in case no response was given for a specific message.

closes https://github.com/RasaHQ/rasa/issues/5171

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
