### PR TITLE
Improved ValueError string

### DIFF
--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -144,7 +144,7 @@ class RegexFeaturizer(Featurizer):
             except OSError:
                 raise ValueError(
                     "Could not load lookup table {}"
-                    "Make sure you've provided the correct path".format(lookup_elements)
+                    " Make sure you've provided the correct path".format(lookup_elements)
                 )
 
             with f:

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -143,7 +143,7 @@ class RegexFeaturizer(Featurizer):
                 f = open(lookup_elements, "r", encoding=rasa.utils.io.DEFAULT_ENCODING)
             except OSError:
                 raise ValueError(
-                    f"Could not load lookup table {lookup_elements}."
+                    f"Could not load lookup table {lookup_elements}. "
                     f"Please make sure you've provided the correct path."
                 )
 

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -143,7 +143,7 @@ class RegexFeaturizer(Featurizer):
                 f = open(lookup_elements, "r", encoding=rasa.utils.io.DEFAULT_ENCODING)
             except OSError:
                 raise ValueError(
-                    "Could not load lookup table {}"
+                    f"Could not load lookup table {lookup_elements}."
                     f"Please make sure you've provided the correct path."
                 )
 

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -144,7 +144,7 @@ class RegexFeaturizer(Featurizer):
             except OSError:
                 raise ValueError(
                     "Could not load lookup table {}"
-                    " Make sure you've provided the correct path".format(lookup_elements)
+                    f"Please make sure you've provided the correct path."
                 )
 
             with f:


### PR DESCRIPTION
This is a small readability fix. When the path to a lookup table is incorrect, the ValueError raised has the string ```Could not load lookup table /some/incorrect/pathMake sure you've provided the correct path```, fixed this to add a whitespace ```Could not load lookup table /some/incorrect/path Make sure you've provided the correct path```

**Proposed changes**:
- small readability fix

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
