### PR TITLE
fix cloudpickle version

### DIFF
--- a/changelog/5216.bugfix.rst
+++ b/changelog/5216.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve version conflicts: Pin version of cloudpickle to ~=1.2.0.

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,8 @@ terminaltables==3.1.0
 sanic==19.9.0
 sanic-cors==0.9.9.post1
 sanic-jwt==1.3.2
+# needed because of https://github.com/RasaHQ/rasa/issues/5216
+cloudpickle==1.2.2
 # https://github.com/RasaHQ/rasa/pull/5064
 sanic-plugins-framework==0.8.2
 # needed because of https://github.com/huge-success/sanic/issues/1729

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ sanic==19.9.0
 sanic-cors==0.9.9.post1
 sanic-jwt==1.3.2
 # needed because of https://github.com/RasaHQ/rasa/issues/5216
-cloudpickle==1.2.2
+cloudpickle~=1.2.0
 # https://github.com/RasaHQ/rasa/pull/5064
 sanic-plugins-framework==0.8.2
 # needed because of https://github.com/huge-success/sanic/issues/1729

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ install_requires = [
     "sanic-cors==0.9.9.post1",
     "sanic-jwt~=1.3",
     # needed because of https://github.com/RasaHQ/rasa/issues/5216
-    "cloudpickle==1.2.2",
+    "cloudpickle~=1.2.0",
     # needed because of https://github.com/huge-success/sanic/issues/1729
     "multidict==4.6.1",
     "aiohttp~=3.5",

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,8 @@ install_requires = [
     "sanic~=19.9.0",
     "sanic-cors==0.9.9.post1",
     "sanic-jwt~=1.3",
+    # needed because of https://github.com/RasaHQ/rasa/issues/5216
+    "cloudpickle==1.2.2",
     # needed because of https://github.com/huge-success/sanic/issues/1729
     "multidict==4.6.1",
     "aiohttp~=3.5",


### PR DESCRIPTION
**Proposed changes**:
Fix cloudpickle version

`tensor2tensor` requires `gym`, which requires `cloudpickle`. We cannot increase the version of `tensor2tensor`. Also the latest version of `gym` (0.16.0) has requirement `cloudpickle~=1.2.0`. So, we need to pin `cloudpickle`.

fixes https://github.com/RasaHQ/rasa/issues/5216

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
