### PR TITLE
Fix urlsplit python3.7.6

### DIFF
--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -30,6 +30,8 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+SQLITE_SCHEME = "sqlite"
+
 
 class TrackerStore:
     """Class to hold all of the TrackerStore classes"""
@@ -644,12 +646,15 @@ class SQLTrackerStore(TrackerStore):
 
         # Users might specify a url in the host
         parsed = parse.urlsplit(host or "")
-        if parsed.scheme and parsed.hostname:
+        # We have to check `scheme` and `hostname` because Python 3.7.6 parses strings
+        # like `localhost:1234` as a URL with scheme `localhost`. However, `sqlite:///`
+        # a special case because it doesn't require a hostname.
+        if parsed.scheme and (parsed.hostname or parsed.scheme == SQLITE_SCHEME):
             return host
 
         if host:
             # add fake scheme to properly parse components
-            parsed = parse.urlsplit("schema://" + host)
+            parsed = parse.urlsplit(f"scheme://{host}")
 
             # users might include the port in the url
             port = parsed.port or port

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -639,17 +639,17 @@ class SQLTrackerStore(TrackerStore):
             URL ready to be used with an SQLAlchemy `Engine` object.
 
         """
-        from urllib.parse import urlsplit
+        from urllib import parse
         from sqlalchemy.engine.url import URL
 
         # Users might specify a url in the host
-        parsed = urlsplit(host or "")
+        parsed = parse.urlsplit(host or "")
         if parsed.scheme and parsed.hostname:
             return host
 
         if host:
             # add fake scheme to properly parse components
-            parsed = urlsplit("schema://" + host)
+            parsed = parse.urlsplit("schema://" + host)
 
             # users might include the port in the url
             port = parsed.port or port

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -644,7 +644,7 @@ class SQLTrackerStore(TrackerStore):
 
         # Users might specify a url in the host
         parsed = urlsplit(host or "")
-        if parsed.scheme:
+        if parsed.scheme and parsed.hostname:
             return host
 
         if host:

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -260,6 +260,7 @@ def test_deprecated_pickle_deserialisation(caplog: LogCaptureFixture):
         "postgresql://localhost",
         "postgresql://localhost:5432",
         "postgresql://user:secret@localhost",
+        "sqlite:///"
     ],
 )
 def test_get_db_url_with_fully_specified_url(full_url: Text):
@@ -276,6 +277,14 @@ def test_get_db_url_with_port_in_host():
     assert (
         str(SQLTrackerStore.get_db_url(dialect="postgresql", host=host, db=db))
         == expected
+    )
+
+
+def test_db_get_url_with_sqlite():
+    expected = "sqlite:///rasa.db"
+    assert (
+            str(SQLTrackerStore.get_db_url(dialect="sqlite", db="rasa.db"))
+            == expected
     )
 
 

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -260,7 +260,7 @@ def test_deprecated_pickle_deserialisation(caplog: LogCaptureFixture):
         "postgresql://localhost",
         "postgresql://localhost:5432",
         "postgresql://user:secret@localhost",
-        "sqlite:///"
+        "sqlite:///",
     ],
 )
 def test_get_db_url_with_fully_specified_url(full_url: Text):
@@ -282,10 +282,7 @@ def test_get_db_url_with_port_in_host():
 
 def test_db_get_url_with_sqlite():
     expected = "sqlite:///rasa.db"
-    assert (
-            str(SQLTrackerStore.get_db_url(dialect="sqlite", db="rasa.db"))
-            == expected
-    )
+    assert str(SQLTrackerStore.get_db_url(dialect="sqlite", db="rasa.db")) == expected
 
 
 def test_get_db_url_with_correct_host():


### PR DESCRIPTION
**Proposed changes**:
- fix behavior of Python 3.7.6 where `urlsplit("localhost:1234")` returns `ParseResult(scheme='localhost', netloc='', path='1234', params='', query='', fragment='')` 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality (already covered, failed on @ChristinaKoss machine)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
