### PR TITLE
only run coveralls if secret is available

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -139,7 +139,11 @@ jobs:
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_SERVICE_NAME: github-ci
-      run: coveralls
+      run: |
+        # Community PRs don't have access to secrets
+        if [[ ${COVERALLS_REPO_TOKEN} != "" ]]; then
+          coveralls
+        fi
 
   deploy:
     name: Deploy to PyPI


### PR DESCRIPTION
**Proposed changes**:
- only run coveralls if secret is available (which it isn't for fork prs)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
