### PR TITLE
Change account user to root who is going to start rasa on docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,6 @@ VOLUME /tmp
 # Make sure the default group has the same permissions as the owner
 RUN chgrp -R 0 . && chmod -R g=u .
 
-# Don't run as root
-USER 1001
-
 EXPOSE 5005
 
 ENTRYPOINT ["rasa"]


### PR DESCRIPTION
**Proposed changes**:
- We are facing a permission error when ``rasa init`` on docker image. [issue-4797](https://github.com/RasaHQ/rasa/issues/4797)
- It can be fixed by changing ``Dockerfile``.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
