### PR TITLE
Update docs config and enable canonical meta tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ html_theme_options = {
     "fixed_sidebar": True,
     "product": "Rasa",
     "base_url": "https://rasa.com/docs/rasa/",
+    "canonical_url": "https://rasa.com/docs/rasa/"
 }
 # html_theme_options = {}
 


### PR DESCRIPTION
**Proposed changes**:
- Add `canonical_url` option to sphinx config
