### PR TITLE
Move warning for retrieval intent left empty

### DIFF
--- a/rasa/nlu/selectors/response_selector.py
+++ b/rasa/nlu/selectors/response_selector.py
@@ -217,13 +217,6 @@ class ResponseSelector(DIETClassifier):
 
     def _load_selector_params(self, config: Dict[Text, Any]) -> None:
         self.retrieval_intent = config[RETRIEVAL_INTENT]
-        if not self.retrieval_intent:
-            # retrieval intent was left to its default value
-            logger.info(
-                "Retrieval intent parameter was left to its default value. This "
-                "response selector will be trained on training examples combining "
-                "all retrieval intents."
-            )
 
     def _check_config_parameters(self) -> None:
         super()._check_config_parameters()
@@ -249,6 +242,13 @@ class ResponseSelector(DIETClassifier):
 
         if self.retrieval_intent:
             training_data = training_data.filter_by_intent(self.retrieval_intent)
+        else:
+            # retrieval intent was left to its default value
+            logger.info(
+                "Retrieval intent parameter was left to its default value. This "
+                "response selector will be trained on training examples combining "
+                "all retrieval intents."
+            )
 
         label_id_index_mapping = self._label_id_index_mapping(
             training_data, attribute=RESPONSE


### PR DESCRIPTION
**Proposed changes**:
- move warning for `retrieval intent` left empty to a function which is called only during training.

**Status (please check what you already did)**:
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
