### PR TITLE
Add cache_dir config for save HFTransformersNLP pre-trained model data.

### DIFF
--- a/changelog/5389.feature.rst
+++ b/changelog/5389.feature.rst
@@ -1,1 +1,1 @@
-Add an optional path to a specific directory to download and cache the pre-trained model weights for HFTransformersNLP.
+Add an optional path to a specific directory to download and cache the pre-trained model weights for :ref:`HFTransformersNLP`.

--- a/changelog/5389.feature.rst
+++ b/changelog/5389.feature.rst
@@ -1,0 +1,1 @@
+Add an optional path to a specific directory to download and cache the pre-trained model weights for HFTransformersNLP.

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -119,6 +119,10 @@ HFTransformersNLP
             # can be found at https://huggingface.co/transformers/pretrained_models.html . If left empty, it uses the
             # default model architecture that original transformers library loads
             model_weights: "bert-base-uncased"
+            
+            # An optional path to a specific directory to download and cache the pre-trained model weights.
+            # default cache_dir is the same as https://huggingface.co/transformers/serialization.html#cache-directory .
+            cache_dir: "~/.cache/torch/"
 
         #    +----------------+--------------+-------------------------+
         #    | Language Model | Parameter    | Default value for       |

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -122,7 +122,7 @@ HFTransformersNLP
             
             # An optional path to a specific directory to download and cache the pre-trained model weights.
             # default cache_dir is the same as https://huggingface.co/transformers/serialization.html#cache-directory .
-            cache_dir: "~/.cache/torch/"
+            cache_dir: null
 
         #    +----------------+--------------+-------------------------+
         #    | Language Model | Parameter    | Default value for       |

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -121,7 +121,7 @@ HFTransformersNLP
             model_weights: "bert-base-uncased"
             
             # An optional path to a specific directory to download and cache the pre-trained model weights.
-            # default cache_dir is the same as https://huggingface.co/transformers/serialization.html#cache-directory .
+            # The `default` cache_dir is the same as https://huggingface.co/transformers/serialization.html#cache-directory .
             cache_dir: null
 
         #    +----------------+--------------+-------------------------+

--- a/rasa/nlu/utils/hugging_face/hf_transformers.py
+++ b/rasa/nlu/utils/hugging_face/hf_transformers.py
@@ -78,12 +78,10 @@ class HFTransformersNLP(Component):
         logger.debug(f"Loading Tokenizer and Model for {self.model_name}")
 
         self.tokenizer = model_tokenizer_dict[self.model_name].from_pretrained(
-            self.model_weights,
-            cache_dir=self.cache_dir
+            self.model_weights, cache_dir=self.cache_dir
         )
         self.model = model_class_dict[self.model_name].from_pretrained(
-            self.model_weights,
-            cache_dir=self.cache_dir
+            self.model_weights, cache_dir=self.cache_dir
         )
 
         # Use a universal pad token since all transformer architectures do not have a

--- a/rasa/nlu/utils/hugging_face/hf_transformers.py
+++ b/rasa/nlu/utils/hugging_face/hf_transformers.py
@@ -36,6 +36,9 @@ class HFTransformersNLP(Component):
         "model_name": "bert",
         # Pre-Trained weights to be loaded(string)
         "model_weights": None,
+        # an optional path to a specific directory to download
+        # and cache the pre-trained model weights.
+        "cache_dir": None,
     }
 
     def __init__(self, component_config: Optional[Dict[Text, Any]] = None) -> None:
@@ -63,6 +66,7 @@ class HFTransformersNLP(Component):
             )
 
         self.model_weights = self.component_config["model_weights"]
+        self.cache_dir = self.component_config["cache_dir"]
 
         if not self.model_weights:
             logger.info(
@@ -74,10 +78,12 @@ class HFTransformersNLP(Component):
         logger.debug(f"Loading Tokenizer and Model for {self.model_name}")
 
         self.tokenizer = model_tokenizer_dict[self.model_name].from_pretrained(
-            self.model_weights
+            self.model_weights,
+            cache_dir=self.cache_dir
         )
         self.model = model_class_dict[self.model_name].from_pretrained(
-            self.model_weights
+            self.model_weights,
+            cache_dir=self.cache_dir
         )
 
         # Use a universal pad token since all transformer architectures do not have a


### PR DESCRIPTION
**Proposed changes**:
-  Add `cache_dir` for save HFTransformersNLP pre-trained model data

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
