### PR TITLE
explain no-root user for SDK image

### DIFF
--- a/changelog/5404.doc.rst
+++ b/changelog/5404.doc.rst
@@ -1,0 +1,5 @@
+Explain how to run commands as ``root`` user in Rasa SDK Docker images since version
+``1.8.0``. Since version ``1.8.0`` the Rasa SDK Docker images does not longer run as
+``root`` user by default. For commands which require ``root`` user usage, you have to
+switch back to the ``root`` user in your Docker image as described in
+:ref:`deploying-your-rasa-assistant_custom-dependencies`.

--- a/docs/user-guide/how-to-deploy.rst
+++ b/docs/user-guide/how-to-deploy.rst
@@ -396,12 +396,19 @@ image and add your custom dependencies. For example:
     # Extend the official Rasa SDK image
     FROM rasa/rasa-sdk:latest
 
+    # The Rasa SDK image runs as non-root user by default. Hence, you have to switch
+    # back to the `root` user if you want to install additional dependencies.
+    USER root
+
     # Add a custom system library (e.g. git)
     RUN apt-get update && \
         apt-get install -y git
 
     # Add a custom python library (e.g. jupyter)
     RUN pip install --no-cache-dir jupyter
+
+   # Switch back to a non-root user
+   USER 1001
 
 You can then build the image via the following command, and use it in your
 ``docker-compose.yml`` instead of the ``rasa/rasa-sdk`` image.

--- a/docs/user-guide/how-to-deploy.rst
+++ b/docs/user-guide/how-to-deploy.rst
@@ -332,7 +332,7 @@ Then build a custom action using the Rasa SDK, e.g.:
     def name(self):
       return "action_joke"
 
-    def run(self, dispatcher, tracker, domain):
+    async def run(self, dispatcher, tracker, domain):
       request = requests.get('http://api.icndb.com/jokes/random').json()  # make an api call
       joke = request['value']['joke']  # extract a joke from returned json response
       dispatcher.utter_message(text=joke)  # send the message back to the user

--- a/docs/user-guide/how-to-deploy.rst
+++ b/docs/user-guide/how-to-deploy.rst
@@ -382,6 +382,8 @@ Add this to your ``endpoints.yml`` (if it does not exist, create it):
 Run ``docker-compose up`` to start the action server together
 with Rasa.
 
+.. _deploying-your-rasa-assistant_custom-dependencies:
+
 Adding Custom Dependencies
 **************************
 


### PR DESCRIPTION
**Proposed changes**:
- the Rasa SDK image doesn't run as root user anymore since version 1.8.0. This needs to be clarified in the docs to avoid misunderstandings as in https://github.com/RasaHQ/rasa-sdk/issues/157

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
