### PR TITLE
Fixed ambiguous logging in DIETClassifier

### DIFF
--- a/changelog/5441.bugfix.rst
+++ b/changelog/5441.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ambiguous logging in `DIETClassifier` by adding the name of the calling class to the log message.

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -81,7 +81,6 @@ from rasa.utils.tensorflow.constants import (
     TENSORBOARD_LOG_LEVEL,
 )
 
-
 logger = logging.getLogger(__name__)
 
 TEXT_FEATURES = f"{TEXT}_features"
@@ -658,7 +657,7 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
     def _predict(self, message: Message) -> Optional[Dict[Text, tf.Tensor]]:
         if self.model is None:
             logger.debug(
-                "There is no trained model: component is either not trained or "
+                f"There is no trained model for {self.__class__.name} : component is either not trained or "
                 "didn't receive enough training data."
             )
             return


### PR DESCRIPTION
**Proposed changes**:
- Improved logging as it was unclear whether a log message comes from `DIETClassifier` or a subclass.

**Changes made**:
- added class name of caller to log message

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
