### PR TITLE
Suppress unnecessary tensorflow logs

### DIFF
--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -105,18 +105,14 @@ def update_tensorflow_log_level() -> None:
     """Set the log level of Tensorflow to the log level specified in the environment
     variable 'LOG_LEVEL_LIBRARIES'."""
 
-    modules_to_disable = [
-        "tensorflow.stream_executor.platform.default",
-        "tensorflow/compiler/tf2tensorrt/utils",
-    ]
-    for module in modules_to_disable:
-        logging.getLogger(module).setLevel(logging.ERROR)
+    os.environ[
+        "TF_CPP_MIN_LOG_LEVEL"
+    ] = "2"  # Disables libvinfer, tensorRT, cuda, AVX2 and FMA warnings (CPU support)
 
     import tensorflow as tf
 
     log_level = os.environ.get(ENV_LOG_LEVEL_LIBRARIES, DEFAULT_LOG_LEVEL_LIBRARIES)
 
-    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # disables AVX2 FMA warnings (CPU support)
     if log_level == "DEBUG":
         tf_log_level = tf.compat.v1.logging.DEBUG
     elif log_level == "INFO":

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -104,6 +104,14 @@ def update_socketio_log_level() -> None:
 def update_tensorflow_log_level() -> None:
     """Set the log level of Tensorflow to the log level specified in the environment
     variable 'LOG_LEVEL_LIBRARIES'."""
+
+    modules_to_disable = [
+        "tensorflow.stream_executor.platform.default",
+        "tensorflow/compiler/tf2tensorrt/utils",
+    ]
+    for module in modules_to_disable:
+        logging.getLogger(module).setLevel(logging.ERROR)
+
     import tensorflow as tf
 
     log_level = os.environ.get(ENV_LOG_LEVEL_LIBRARIES, DEFAULT_LOG_LEVEL_LIBRARIES)


### PR DESCRIPTION
**Proposed changes**:
- Partly fixes https://github.com/RasaHQ/rasa/issues/5369
- Suppresses the first set of warnings sourced at `tensorflow/stream_executor/platform/default/dso_loader.cc` and `tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:30`. These warnings were raised at the first import of tensorflow
- `E tensorflow/stream_executor/cuda/cuda_driver.cc:351]` is set at a log level `ERROR` which is an implementation bug from tensorflow's side since they merged CPU and GPU packages in a single package. We can neither suppress all `ERROR` logs from tensorflow, nor suppress all logs from  `tensorflow/stream_executor/cuda/cuda_driver.cc:351` since the same module does log useful information when a GPU is used. Many issues have been raised on TF repo regarding the same, for e.g. - https://github.com/tensorflow/tensorflow/issues/37689

**Status (please check what you already did)**:
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
