### PR TITLE
fix RabbitMQ 'queue' argument usage

### DIFF
--- a/changelog/5492.bugfix.rst
+++ b/changelog/5492.bugfix.rst
@@ -1,0 +1,4 @@
+Fix an issue where the deprecated ``queue`` parameter for the :ref:`event-brokers-pika`
+was ignored and Rasa Open Source published the events to the ``rasa_core_events``
+queue instead. Note that this does not change the fact that the ``queue`` argument
+is deprecated in favor of the ``queues`` argument.

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -328,8 +328,9 @@ class PikaEventBroker(EventBroker):
             return queue_arg  # pytype: disable=bad-return-type
 
         raise_warning(
-            f"No `queues` argument provided. It is suggested to explicitly "
-            f"specify a queue as described in {DOCS_URL_PIKA_EVENT_BROKER}."
+            f"No `queues` or `queue` argument provided. It is suggested to "
+            f"explicitly specify a queue as described in "
+            f"{DOCS_URL_PIKA_EVENT_BROKER}. "
             f"Using the default queue '{DEFAULT_QUEUE_NAME}' for now."
         )
 


### PR DESCRIPTION
**Proposed changes**:
- since there was a default value for the `queues` argument and a `queues` argument takes precedence over a potentially specified `queue` argument, the `queue` argument was always ignored
- long story short: Rasa sent events to the wrong queue when using the old `queue` argument

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
