### PR TITLE
Fix docs: Don't overwrite footer

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,6 +1,7 @@
 {% extends "!page.html" %}
 
 {% block footer %}
+{{ super() }}
  <script type="text/javascript">
     $(document).ready(function() {
         $(".toggle > *").hide();


### PR DESCRIPTION
**Proposed changes**:
We were overwriting the footer block that triggered Sara. 

Solution:
If you override a block, call {{ super() }} somewhere to render the block’s original content in the extended template – unless you don’t want that content to show up.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
