### PR TITLE
[FEATURE] add dry-run tag to check if training is necessary

### DIFF
--- a/changelog/feature.rst
+++ b/changelog/feature.rst
@@ -1,0 +1,3 @@
+Added flag `--dry` for checking running `rasa train --dry` to check if the training is necessary.
+It is useful if we don't necessarily want to train new models. This feature helps with rasa CICD integration.
+Check data on one platform and then train on another.

--- a/rasa/cli/arguments/train.py
+++ b/rasa/cli/arguments/train.py
@@ -23,6 +23,7 @@ def set_train_arguments(parser: argparse.ArgumentParser):
     add_model_name_param(parser)
     add_persist_nlu_data_param(parser)
     add_force_param(parser)
+    add_dry_param(parser)
 
 
 def set_train_core_arguments(parser: argparse.ArgumentParser):
@@ -57,6 +58,12 @@ def add_force_param(parser: Union[argparse.ArgumentParser, argparse._ActionsCont
         "--force",
         action="store_true",
         help="Force a model training even if the data has not changed.",
+    )
+
+
+def add_dry_param(parser: Union[argparse.ArgumentParser, argparse._ActionsContainer]):
+    parser.add_argument(
+        "--dry", action="store_true", help="Check if models need to be retrained.",
     )
 
 

--- a/rasa/cli/interactive.py
+++ b/rasa/cli/interactive.py
@@ -82,6 +82,7 @@ def interactive(args: argparse.Namespace) -> None:
 def _set_not_required_args(args: argparse.Namespace) -> None:
     args.fixed_model_name = None
     args.store_uncompressed = False
+    args.dry = False
 
 
 def perform_interactive_learning(

--- a/rasa/cli/train.py
+++ b/rasa/cli/train.py
@@ -73,6 +73,7 @@ def train(args: argparse.Namespace) -> Optional[Text]:
         force_training=args.force,
         fixed_model_name=args.fixed_model_name,
         persist_nlu_training_data=args.persist_nlu_data,
+        dry=args.dry,
         additional_arguments=extract_additional_arguments(args),
     )
 

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -195,6 +195,20 @@ def test_train_force(run_in_default_project):
     assert len(files) == 2
 
 
+def test_train_dry(run_in_default_project):
+    temp_dir = os.getcwd()
+
+    assert os.path.exists(os.path.join(temp_dir, "models"))
+    files = io_utils.list_files(os.path.join(temp_dir, "models"))
+    assert len(files) == 1
+
+    run_in_default_project("train", "--dry")
+
+    assert os.path.exists(os.path.join(temp_dir, "models"))
+    files = io_utils.list_files(os.path.join(temp_dir, "models"))
+    assert len(files) == 1
+
+
 def test_train_with_only_nlu_data(run_in_default_project_without_models):
     temp_dir = os.getcwd()
 
@@ -327,7 +341,7 @@ def test_train_help(run):
                   [-c CONFIG] [-d DOMAIN] [--out OUT]
                   [--augmentation AUGMENTATION] [--debug-plots]
                   [--fixed-model-name FIXED_MODEL_NAME] [--persist-nlu-data]
-                  [--force]
+                  [--force] [--dry]
                   {core,nlu} ..."""
 
     lines = help_text.split("\n")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -129,3 +129,37 @@ def test_train_nlu_temp_files(
     )
 
     assert count_temp_rasa_files(tempfile.tempdir) == 0
+
+
+def test_train_files_dry(
+    tmp_path: Text,
+    monkeypatch: MonkeyPatch,
+    default_domain_path: Text,
+    default_stories_file: Text,
+    default_stack_config: Text,
+    default_nlu_data: Text,
+):
+    monkeypatch.setattr(tempfile, "tempdir", tmp_path)
+    output = "test_train_temp_files_models"
+
+    train(
+        default_domain_path,
+        default_stack_config,
+        [default_stories_file, default_nlu_data],
+        output=output,
+        dry=True,
+    )
+
+    assert count_temp_rasa_files(tempfile.tempdir) == 0
+
+    # After training the model, try to do it again. This shouldn't try to train
+    # a new model because nothing has been changed. It also shouldn't create
+    # any temp files.
+    train(
+        default_domain_path,
+        default_stack_config,
+        [default_stories_file, default_nlu_data],
+        output=output,
+    )
+
+    assert count_temp_rasa_files(tempfile.tempdir) == 0


### PR DESCRIPTION
**Proposed changes**:
- add tag `--dry` to the training `rasa train` which determines whether model training is necessary it does not train the model.
This is useful for  CICD pipeline integration. We can check with command `rasa train --dry` whether training is necessary and train on different machine.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
