### PR TITLE
set default value for weight_sparsity in response selector to 0

### DIFF
--- a/changelog/5505.bugfix.rst
+++ b/changelog/5505.bugfix.rst
@@ -1,0 +1,1 @@
+Set default value for ``weight_sparsity`` in ``ResponseSelector`` to ``0``.

--- a/rasa/nlu/selectors/response_selector.py
+++ b/rasa/nlu/selectors/response_selector.py
@@ -171,7 +171,7 @@ class ResponseSelector(DIETClassifier):
         # The scale of regularization
         REGULARIZATION_CONSTANT: 0.002,
         # Sparsity of the weights in dense layers
-        WEIGHT_SPARSITY: 0.8,
+        WEIGHT_SPARSITY: 0.0,
         # The scale of how important is to minimize the maximum similarity
         # between embeddings of different labels.
         NEGATIVE_MARGIN_SCALE: 0.8,


### PR DESCRIPTION
**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
