### PR TITLE
Entity applies to complete word not just parts of it

### DIFF
--- a/changelog/5509.bugfix.rst
+++ b/changelog/5509.bugfix.rst
@@ -1,0 +1,5 @@
+An entity label should always cover a complete word.
+
+If you are using, for example, ``ConveRTTokenizer`` words can be split into multiple tokens.
+Our entity extractors assign entity labels per token. So, it might happen, that just a part of a word has
+an entity label. This is now fixed. An entity label always covers a complete word.

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -745,8 +745,9 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
 
         return entities
 
+    @staticmethod
     def _convert_tags_to_entities(
-        self, text: Text, tokens: List[Token], tags: List[Text]
+        text: Text, tokens: List[Token], tags: List[Text]
     ) -> List[Dict[Text, Any]]:
         entities = []
         last_tag = NO_ENTITY_TAG

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -739,8 +739,9 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
             message.text, message.get(TOKENS_NAMES[TEXT], []), tags
         )
 
-        extracted = self.add_extractor_name(entities)
-        entities = message.get(ENTITIES, []) + extracted
+        entities = self.add_extractor_name(entities)
+        entities = self.clean_up_entities(message, entities)
+        entities = message.get(ENTITIES, []) + entities
 
         return entities
 
@@ -773,7 +774,7 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
         for entity in entities:
             entity["value"] = text[entity["start"] : entity["end"]]
 
-        return self.clean_up_entities(entities)
+        return entities
 
     def process(self, message: Message, **kwargs: Any) -> None:
         """Return the most likely label and its similarity to the input."""

--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -156,8 +156,9 @@ class CRFEntityExtractor(EntityExtractor):
         return dataset
 
     def process(self, message: Message, **kwargs: Any) -> None:
-        extracted = self.add_extractor_name(self.extract_entities(message))
-        message.set(ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True)
+        entities = self.add_extractor_name(self.extract_entities(message))
+        entities = self.clean_up_entities(message, entities)
+        message.set(ENTITIES, message.get(ENTITIES, []) + entities, add_to_output=True)
 
     def extract_entities(self, message: Message) -> List[Dict[Text, Any]]:
         """Take a sentence and return entities in json format"""
@@ -166,8 +167,7 @@ class CRFEntityExtractor(EntityExtractor):
             text_data = self._from_text_to_crf(message)
             features = self._sentence_to_features(text_data)
             entities = self.ent_tagger.predict_marginals_single(features)
-            entities = self._from_crf_to_json(message, entities)
-            return self.clean_up_entities(entities)
+            return self._from_crf_to_json(message, entities)
         else:
             return []
 

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -186,9 +186,8 @@ class DucklingHTTPExtractor(EntityExtractor):
             )
 
         extracted = self.add_extractor_name(extracted)
-        message.set(
-            ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True,
-        )
+        extracted = self.clean_up_entities(message, extracted)
+        message.set(ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True)
 
     @classmethod
     def load(

--- a/rasa/nlu/extractors/extractor.py
+++ b/rasa/nlu/extractors/extractor.py
@@ -100,6 +100,8 @@ class EntityExtractor(Component):
             of the final entity in the text and entity indices that are part of this
             misalignment
         """
+        if not tokens:
+            return []
 
         # group tokens: one token cluster corresponds to one word
         token_clusters = self._token_clusters(tokens)

--- a/rasa/nlu/extractors/extractor.py
+++ b/rasa/nlu/extractors/extractor.py
@@ -218,7 +218,8 @@ class EntityExtractor(Component):
             if tokens[token_idx].start == tokens[previous_token_idx].end:
                 # a word was split into multiple tokens
                 token_cluster_already_exists = (
-                    token_index_clusters[-1][-1] == previous_token_idx
+                    token_index_clusters
+                    and token_index_clusters[-1][-1] == previous_token_idx
                 )
                 if token_cluster_already_exists:
                     token_index_clusters[-1].append(token_idx)

--- a/rasa/nlu/extractors/extractor.py
+++ b/rasa/nlu/extractors/extractor.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Text, Tuple, Optional
 
-from nlu.tokenizers.tokenizer import Token
+from rasa.nlu.tokenizers.tokenizer import Token
 from rasa.nlu.components import Component
 from rasa.nlu.constants import EXTRACTOR, ENTITIES, TOKENS_NAMES, TEXT
 from rasa.nlu.training_data import Message
@@ -23,7 +23,7 @@ class EntityExtractor(Component):
         return entity
 
     def clean_up_entities(
-        self, message: Message, entities: List[Dict[Text, Any]], keep: bool = True
+        self, message: Message, entities: List[Dict[Text, Any]], keep: bool = False
     ) -> List[Dict[Text, Any]]:
         """
         Checks if multiple entity labels are assigned to one word or if an entity label

--- a/rasa/nlu/extractors/mitie_entity_extractor.py
+++ b/rasa/nlu/extractors/mitie_entity_extractor.py
@@ -142,9 +142,8 @@ class MitieEntityExtractor(EntityExtractor):
             message.text, self._tokens_without_cls(message), mitie_feature_extractor
         )
         extracted = self.add_extractor_name(ents)
-        message.set(
-            ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True,
-        )
+        extracted = self.clean_up_entities(message, extracted)
+        message.set(ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True)
 
     @classmethod
     def load(

--- a/rasa/nlu/extractors/spacy_entity_extractor.py
+++ b/rasa/nlu/extractors/spacy_entity_extractor.py
@@ -32,13 +32,12 @@ class SpacyEntityExtractor(EntityExtractor):
         spacy_nlp = kwargs.get("spacy_nlp", None)
         doc = spacy_nlp(message.text)
         all_extracted = self.add_extractor_name(self.extract_entities(doc))
+        all_extracted = self.clean_up_entities(message, all_extracted)
         dimensions = self.component_config["dimensions"]
         extracted = SpacyEntityExtractor.filter_irrelevant_entities(
             all_extracted, dimensions
         )
-        message.set(
-            ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True,
-        )
+        message.set(ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True)
 
     @staticmethod
     def extract_entities(doc: "Doc") -> List[Dict[Text, Any]]:

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -99,7 +99,7 @@ class RasaModel(tf.keras.models.Model):
         evaluate_every_num_epochs: int,
         batch_strategy: Text,
         silent: bool = False,
-        eager: bool = False,
+        eager: bool = True,
     ) -> None:
         """Fit model data"""
 

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -99,7 +99,7 @@ class RasaModel(tf.keras.models.Model):
         evaluate_every_num_epochs: int,
         batch_strategy: Text,
         silent: bool = False,
-        eager: bool = True,
+        eager: bool = False,
     ) -> None:
         """Fit model data"""
 

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -2,8 +2,8 @@ from typing import Any, Text, Dict, List
 
 import pytest
 
-from nlu.tokenizers.tokenizer import Token
-from nlu.training_data import Message
+from rasa.nlu.tokenizers.tokenizer import Token
+from rasa.nlu.training_data import Message
 from rasa.nlu.extractors.extractor import EntityExtractor
 
 

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -230,7 +230,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
         ),
     ],
 )
-def test_convert_tags_to_entities(
+def test_clean_up_entities(
     text: Text,
     tokens: List[Token],
     entities: List[Dict[Text, Any]],

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -2,21 +2,32 @@ from typing import Any, Text, Dict, List
 
 import pytest
 
+from nlu.tokenizers.tokenizer import Token
+from nlu.training_data import Message
 from rasa.nlu.extractors.extractor import EntityExtractor
 
 
 @pytest.mark.parametrize(
-    "entities, keep, expected_entities",
+    "tokens, entities, keep, expected_entities",
     [
         (
             [
+                Token("Aar", 0, 3),
+                Token("hus", 3, 6),
+                Token("is", 7, 9),
+                Token("a", 10, 11),
+                Token("city", 12, 16),
+            ],
+            [
                 {"entity": "iata", "start": 0, "end": 3, "value": "Aar"},
                 {"entity": "city", "start": 3, "end": 6, "value": "hus"},
+                {"entity": "location", "start": 12, "end": 16, "value": "city"},
             ],
             False,
-            [],
+            [{"entity": "location", "start": 12, "end": 16, "value": "city"}],
         ),
         (
+            [Token("Aar", 0, 3), Token("hus", 3, 6)],
             [
                 {"entity": "iata", "start": 0, "end": 3, "value": "Aar"},
                 {"entity": "city", "start": 3, "end": 6, "value": "hus"},
@@ -25,17 +36,25 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             [],
         ),
         (
+            [Token("Aarhus", 0, 6), Token("city", 7, 11)],
             [
-                {"entity": "city", "start": 0, "end": 3, "value": "Aarhus"},
-                {"entity": "type", "start": 4, "end": 9, "value": "city"},
+                {"entity": "city", "start": 0, "end": 6, "value": "Aarhus"},
+                {"entity": "type", "start": 7, "end": 11, "value": "city"},
             ],
             False,
             [
-                {"entity": "city", "start": 0, "end": 3, "value": "Aarhus"},
-                {"entity": "type", "start": 4, "end": 9, "value": "city"},
+                {"entity": "city", "start": 0, "end": 6, "value": "Aarhus"},
+                {"entity": "type", "start": 7, "end": 11, "value": "city"},
             ],
         ),
         (
+            [
+                Token("Aar", 0, 3),
+                Token("hus", 3, 6),
+                Token("is", 7, 9),
+                Token("a", 10, 11),
+                Token("city", 12, 16),
+            ],
             [
                 {
                     "entity": "city",
@@ -51,6 +70,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
                     "confidence": 0.43,
                     "value": "hus",
                 },
+                {"entity": "location", "start": 12, "end": 16, "value": "city"},
             ],
             True,
             [
@@ -60,10 +80,12 @@ from rasa.nlu.extractors.extractor import EntityExtractor
                     "end": 6,
                     "confidence": 0.87,
                     "value": "Aarhus",
-                }
+                },
+                {"entity": "location", "start": 12, "end": 16, "value": "city"},
             ],
         ),
         (
+            [Token("Aa", 0, 2), Token("r", 2, 3), Token("hu", 3, 5), Token("s", 5, 6)],
             [
                 {
                     "entity": "iata",
@@ -105,15 +127,55 @@ from rasa.nlu.extractors.extractor import EntityExtractor
                 }
             ],
         ),
+        (
+            [Token("Aa", 0, 2), Token("r", 2, 3), Token("hu", 3, 5), Token("s", 5, 6)],
+            [
+                {
+                    "entity": "city",
+                    "start": 0,
+                    "end": 2,
+                    "confidence": 0.32,
+                    "value": "Aa",
+                }
+            ],
+            True,
+            [
+                {
+                    "entity": "city",
+                    "start": 0,
+                    "end": 6,
+                    "confidence": 0.32,
+                    "value": "Aarhus",
+                }
+            ],
+        ),
+        (
+            [Token("Aa", 0, 2), Token("r", 2, 3), Token("hu", 3, 5), Token("s", 5, 6)],
+            [
+                {
+                    "entity": "city",
+                    "start": 0,
+                    "end": 2,
+                    "confidence": 0.32,
+                    "value": "Aa",
+                }
+            ],
+            False,
+            [],
+        ),
     ],
 )
 def test_convert_tags_to_entities(
+    tokens: List[Token],
     entities: List[Dict[Text, Any]],
     keep: bool,
     expected_entities: List[Dict[Text, Any]],
 ):
     extractor = EntityExtractor()
 
-    updated_entities = extractor.clean_up_entities(entities, keep)
+    message = Message("test")
+    message.set("tokens", tokens)
+
+    updated_entities = extractor.clean_up_entities(message, entities, keep)
 
     assert updated_entities == expected_entities

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -8,9 +8,10 @@ from rasa.nlu.extractors.extractor import EntityExtractor
 
 
 @pytest.mark.parametrize(
-    "tokens, entities, keep, expected_entities",
+    "text, tokens, entities, keep, expected_entities",
     [
         (
+            "Aarhus is a city",
             [
                 Token("Aar", 0, 3),
                 Token("hus", 3, 6),
@@ -27,6 +28,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             [{"entity": "location", "start": 12, "end": 16, "value": "city"}],
         ),
         (
+            "Aarhus",
             [Token("Aar", 0, 3), Token("hus", 3, 6)],
             [
                 {"entity": "iata", "start": 0, "end": 3, "value": "Aar"},
@@ -36,6 +38,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             [],
         ),
         (
+            "Aarhus city",
             [Token("Aarhus", 0, 6), Token("city", 7, 11)],
             [
                 {"entity": "city", "start": 0, "end": 6, "value": "Aarhus"},
@@ -48,6 +51,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             ],
         ),
         (
+            "Aarhus is a city",
             [
                 Token("Aar", 0, 3),
                 Token("hus", 3, 6),
@@ -85,6 +89,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             ],
         ),
         (
+            "Aarhus",
             [Token("Aa", 0, 2), Token("r", 2, 3), Token("hu", 3, 5), Token("s", 5, 6)],
             [
                 {
@@ -128,6 +133,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             ],
         ),
         (
+            "Aarhus",
             [Token("Aa", 0, 2), Token("r", 2, 3), Token("hu", 3, 5), Token("s", 5, 6)],
             [
                 {
@@ -150,6 +156,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             ],
         ),
         (
+            "Aarhus",
             [Token("Aa", 0, 2), Token("r", 2, 3), Token("hu", 3, 5), Token("s", 5, 6)],
             [
                 {
@@ -163,9 +170,68 @@ from rasa.nlu.extractors.extractor import EntityExtractor
             False,
             [],
         ),
+        (
+            "Buenos Aires is a city",
+            [
+                Token("Buenos", 0, 6),
+                Token("Ai", 7, 9),
+                Token("res", 9, 12),
+                Token("is", 13, 15),
+                Token("a", 16, 17),
+                Token("city", 18, 22),
+            ],
+            [
+                {"entity": "city", "start": 0, "end": 9, "value": "Buenos Ai"},
+                {"entity": "location", "start": 18, "end": 22, "value": "city"},
+            ],
+            False,
+            [{"entity": "location", "start": 18, "end": 22, "value": "city"}],
+        ),
+        (
+            "Buenos Aires is a city",
+            [
+                Token("Buenos", 0, 6),
+                Token("Ai", 7, 9),
+                Token("res", 9, 12),
+                Token("is", 13, 15),
+                Token("a", 16, 17),
+                Token("city", 18, 22),
+            ],
+            [
+                {"entity": "city", "start": 0, "end": 9, "value": "Buenos Ai"},
+                {"entity": "location", "start": 18, "end": 22, "value": "city"},
+            ],
+            True,
+            [
+                {"entity": "city", "start": 0, "end": 12, "value": "Buenos Aires"},
+                {"entity": "location", "start": 18, "end": 22, "value": "city"},
+            ],
+        ),
+        (
+            "Buenos Aires is a city",
+            [
+                Token("Buen", 0, 4),
+                Token("os", 4, 6),
+                Token("Ai", 7, 9),
+                Token("res", 9, 12),
+                Token("is", 13, 15),
+                Token("a", 16, 17),
+                Token("city", 18, 22),
+            ],
+            [
+                {"entity": "city", "start": 4, "end": 9, "value": "os Ai"},
+                {"entity": "location", "start": 18, "end": 22, "value": "city"},
+            ],
+            True,
+            [
+                {"entity": "city", "start": 0, "end": 12, "value": "Buenos Aires"},
+                {"entity": "location", "start": 18, "end": 22, "value": "city"},
+            ],
+        ),
     ],
 )
 def test_convert_tags_to_entities(
+    text: Text,
     tokens: List[Token],
     entities: List[Dict[Text, Any]],
     keep: bool,
@@ -173,7 +239,7 @@ def test_convert_tags_to_entities(
 ):
     extractor = EntityExtractor()
 
-    message = Message("test")
+    message = Message(text)
     message.set("tokens", tokens)
 
     updated_entities = extractor.clean_up_entities(message, entities, keep)


### PR DESCRIPTION
**Proposed changes**:
- fix #5509 

An entity now always covers a complete word, not just parts of it.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
