### PR TITLE
pip install poetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ clean:
 	rm -rf docs/_build
 
 install:
+	python -m pip install poetry
 	poetry run python -m pip install -U 'pip<20'
 	poetry install
 


### PR DESCRIPTION
Added a line to the `Makefile`. 

If you want to install using poetry, you probably want to make sure it is installed. So poetry is installed now with `pip` which should be in the standardlib as of python > 3.5. 

Minor change, but saves an extra command when getting started. 