### PR TITLE
type_name should be nullable=True

### DIFF
--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -567,7 +567,7 @@ class SQLTrackerStore(TrackerStore):
         # don't autoincrement Integer primary keys (e.g. Oracle)
         id = Column(Integer, _create_sequence(__tablename__), primary_key=True)
         sender_id = Column(String(255), nullable=False, index=True)
-        type_name = Column(String(255), nullable=False)
+        type_name = Column(String(255))
         timestamp = Column(Float)
         intent_name = Column(String(255))
         action_name = Column(String(255))


### PR DESCRIPTION
type_name should be nullable=True because it is not inserted by the tracker. The tracker is inserting only sender_id and data. 
Postgresql tracker is not usable without this change.

**Proposed changes**:
- set type_name as nullable=true or fix postgresql tracker inserts and also table structure. It is quite a mess. :) 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
