### PR TITLE
Get entity with specific role/group from tracker

### DIFF
--- a/changelog/3765.feature.rst
+++ b/changelog/3765.feature.rst
@@ -10,4 +10,4 @@ If you want to use a form, you can add the specific role/group label of interest
 
 .. note::
 
-    Composite entities are currently just supported by the ``DIETClassifier``.
+    Composite entities are currently just supported by the :ref:``diet-classifier``.

--- a/changelog/3765.feature.rst
+++ b/changelog/3765.feature.rst
@@ -1,0 +1,13 @@
+Add support for composite entities in Rasa NLU.
+
+Composite entities allow you to define a role and/or group label in addition to the entity type.
+For more details see :ref:`composite-entities`.
+
+To fill slots from entities with a specific role/group, you need to either use forms or use a custom action.
+We updated the tracker method ``get_latest_entity_values`` to take an optional role/group label.
+If you want to use a form, you can add the specific role/group label of interest to the slot mapping function
+``from_entity`` (see :ref:`forms``).
+
+.. note::
+
+    Composite entities are currently just supported by the ``DIETClassifier``.

--- a/changelog/3765.feature.rst
+++ b/changelog/3765.feature.rst
@@ -1,6 +1,11 @@
 Add support for composite entities in Rasa NLU.
 
 Composite entities allow you to define a role and/or group label in addition to the entity type.
+Use the role label if an entity can play different roles in your assistant.
+For example, a city can be a destination or a departure city.
+The group label can be use to group multiple entities together.
+For example, you could group different pizza orders together, so that you know what toppings goes with which pizza and
+what size which pizza has.
 For more details see :ref:`composite-entities`.
 
 To fill slots from entities with a specific role/group, you need to either use forms or use a custom action.

--- a/docs/core/forms.rst
+++ b/docs/core/forms.rst
@@ -142,10 +142,11 @@ Here's an example for the restaurant bot:
 
 The predefined functions work as follows:
 
-- ``self.from_entity(entity=entity_name, intent=intent_name)``
+- ``self.from_entity(entity=entity_name, intent=intent_name, role=role_name, group=group_name)``
   will look for an entity called ``entity_name`` to fill a slot
   ``slot_name`` regardless of user intent if ``intent_name`` is ``None``
-  else only if the users intent is ``intent_name``.
+  else only if the users intent is ``intent_name``. If ``role_name`` and/or ``group_name``
+  are/is provided, the role/group label of the entity also needs to match the given values.
 - ``self.from_intent(intent=intent_name, value=value)``
   will fill slot ``slot_name`` with ``value`` if user intent is ``intent_name``.
   To make a boolean slot, take a look at the definition of ``outdoor_seating``

--- a/docs/core/forms.rst
+++ b/docs/core/forms.rst
@@ -146,7 +146,7 @@ The predefined functions work as follows:
   will look for an entity called ``entity_name`` to fill a slot
   ``slot_name`` regardless of user intent if ``intent_name`` is ``None``
   else only if the users intent is ``intent_name``. If ``role_name`` and/or ``group_name``
-  are/is provided, the role/group label of the entity also needs to match the given values.
+  are provided, the role/group label of the entity also needs to match the given values.
 - ``self.from_intent(intent=intent_name, value=value)``
   will fill slot ``slot_name`` with ``value`` if user intent is ``intent_name``.
   To make a boolean slot, take a look at the definition of ``outdoor_seating``

--- a/docs/nlu/entity-extraction.rst
+++ b/docs/nlu/entity-extraction.rst
@@ -127,7 +127,7 @@ Composite entities allow you to assign a role and/or a group label in addition t
     - I want to fly from [Berlin]{"entity": "city", "role": "departure"} to [San Francisco]{"entity": "city", "role": "destination"}.
 
 The group label can, for example, be used to define different orders.
-In the following example we use the group label to reference what toppings goes with which pizze and
+In the following example we use the group label to reference what toppings goes with which pizza and
 what size which pizza has.
 
 .. code-block:: none

--- a/docs/nlu/entity-extraction.rst
+++ b/docs/nlu/entity-extraction.rst
@@ -166,7 +166,7 @@ The entity object returned by the extractor will include the detected role/group
 
 .. note::
 
-    Composite entities are currently only supported by the ``DIETClassifier``.
+    Composite entities are currently only supported by the :ref:``diet-classifier``.
 
 In order to properly train your model with composite entities, make sure to include enough training data examples
 for every combination of entity and role/group label.

--- a/rasa/core/trackers.py
+++ b/rasa/core/trackers.py
@@ -15,7 +15,7 @@ from typing import (
     Iterable,
 )
 
-from nlu.constants import (
+from rasa.nlu.constants import (
     ENTITY_ATTRIBUTE_VALUE,
     ENTITY_ATTRIBUTE_TYPE,
     ENTITY_ATTRIBUTE_ROLE,

--- a/rasa/core/trackers.py
+++ b/rasa/core/trackers.py
@@ -15,6 +15,12 @@ from typing import (
     Iterable,
 )
 
+from nlu.constants import (
+    ENTITY_ATTRIBUTE_VALUE,
+    ENTITY_ATTRIBUTE_TYPE,
+    ENTITY_ATTRIBUTE_ROLE,
+    ENTITY_ATTRIBUTE_GROUP,
+)
 from rasa.core import events  # pytype: disable=pyi-error
 from rasa.core.actions.action import ACTION_LISTEN_NAME  # pytype: disable=pyi-error
 from rasa.core.conversation import Dialogue  # pytype: disable=pyi-error
@@ -231,16 +237,73 @@ class DialogueStateTracker:
             return None
 
     def get_latest_entity_values(self, entity_type: Text) -> Iterator[Text]:
-        """Get entity values found for the passed entity name in latest msg.
+        """Get entity values found for the passed entity name in latest message.
 
         If you are only interested in the first entity of a given type use
         `next(tracker.get_latest_entity_values("my_entity_name"), None)`.
-        If no entity is found `None` is the default result."""
+        If no entity is found `None` is the default result.
+
+        Args:
+            entity_type: the entity type of interst
+
+        Returns:
+            List of entity values.
+        """
 
         return (
-            x.get("value")
+            x.get(ENTITY_ATTRIBUTE_VALUE)
             for x in self.latest_message.entities
-            if x.get("entity") == entity_type
+            if x.get(ENTITY_ATTRIBUTE_TYPE) == entity_type
+        )
+
+    def get_latest_entity_values_with_role(
+        self, entity_type: Text, entity_role: Text
+    ) -> Iterator[Text]:
+        """Get entity values found for the passed entity name and role in latest
+        message.
+
+        If you are only interested in the first entity of a given type and role use
+        `next(tracker.get_latest_entity_values("my_entity_name"), None)`.
+        If no entity is found `None` is the default result.
+
+        Args:
+            entity_type: the entity type of interest
+            entity_role:  the entity role of interest
+
+        Returns:
+            List of entity values.
+        """
+
+        return (
+            x.get(ENTITY_ATTRIBUTE_VALUE)
+            for x in self.latest_message.entities
+            if x.get(ENTITY_ATTRIBUTE_TYPE) == entity_type
+            and x.get(ENTITY_ATTRIBUTE_ROLE) == entity_role
+        )
+
+    def get_latest_entity_values_with_group(
+        self, entity_type: Text, entity_group: Text
+    ) -> Iterator[Text]:
+        """Get entity values found for the passed entity name and group in latest
+        message.
+
+        If you are only interested in the first entity of a given type and group use
+        `next(tracker.get_latest_entity_values("my_entity_name"), None)`.
+        If no entity is found `None` is the default result.
+
+        Args:
+            entity_type: the entity type of interest
+            entity_group:  the entity group of interest
+
+        Returns:
+            List of entity values.
+        """
+
+        return (
+            x.get(ENTITY_ATTRIBUTE_VALUE)
+            for x in self.latest_message.entities
+            if x.get(ENTITY_ATTRIBUTE_TYPE) == entity_type
+            and x.get(ENTITY_ATTRIBUTE_GROUP) == entity_group
         )
 
     def get_latest_input_channel(self) -> Optional[Text]:

--- a/rasa/core/trackers.py
+++ b/rasa/core/trackers.py
@@ -255,7 +255,7 @@ class DialogueStateTracker:
             entity_group: optional entity group of interest
 
         Returns:
-            List of entity values.
+            Entity values.
         """
 
         return (

--- a/rasa/core/trackers.py
+++ b/rasa/core/trackers.py
@@ -236,39 +236,23 @@ class DialogueStateTracker:
             logger.info(f"Tried to access non existent slot '{key}'")
             return None
 
-    def get_latest_entity_values(self, entity_type: Text) -> Iterator[Text]:
-        """Get entity values found for the passed entity name in latest message.
+    def get_latest_entity_values(
+        self,
+        entity_type: Text,
+        entity_role: Optional[Text] = None,
+        entity_group: Optional[Text] = None,
+    ) -> Iterator[Text]:
+        """Get entity values found for the passed entity type and optional role and
+        group in latest message.
 
         If you are only interested in the first entity of a given type use
         `next(tracker.get_latest_entity_values("my_entity_name"), None)`.
         If no entity is found `None` is the default result.
 
         Args:
-            entity_type: the entity type of interst
-
-        Returns:
-            List of entity values.
-        """
-
-        return (
-            x.get(ENTITY_ATTRIBUTE_VALUE)
-            for x in self.latest_message.entities
-            if x.get(ENTITY_ATTRIBUTE_TYPE) == entity_type
-        )
-
-    def get_latest_entity_values_with_role(
-        self, entity_type: Text, entity_role: Text
-    ) -> Iterator[Text]:
-        """Get entity values found for the passed entity name and role in latest
-        message.
-
-        If you are only interested in the first entity of a given type and role use
-        `next(tracker.get_latest_entity_values("my_entity_name"), None)`.
-        If no entity is found `None` is the default result.
-
-        Args:
             entity_type: the entity type of interest
-            entity_role:  the entity role of interest
+            entity_role: optional entity role of interest
+            entity_group: optional entity group of interest
 
         Returns:
             List of entity values.
@@ -278,32 +262,8 @@ class DialogueStateTracker:
             x.get(ENTITY_ATTRIBUTE_VALUE)
             for x in self.latest_message.entities
             if x.get(ENTITY_ATTRIBUTE_TYPE) == entity_type
-            and x.get(ENTITY_ATTRIBUTE_ROLE) == entity_role
-        )
-
-    def get_latest_entity_values_with_group(
-        self, entity_type: Text, entity_group: Text
-    ) -> Iterator[Text]:
-        """Get entity values found for the passed entity name and group in latest
-        message.
-
-        If you are only interested in the first entity of a given type and group use
-        `next(tracker.get_latest_entity_values("my_entity_name"), None)`.
-        If no entity is found `None` is the default result.
-
-        Args:
-            entity_type: the entity type of interest
-            entity_group:  the entity group of interest
-
-        Returns:
-            List of entity values.
-        """
-
-        return (
-            x.get(ENTITY_ATTRIBUTE_VALUE)
-            for x in self.latest_message.entities
-            if x.get(ENTITY_ATTRIBUTE_TYPE) == entity_type
-            and x.get(ENTITY_ATTRIBUTE_GROUP) == entity_group
+            and (entity_group is None or x.get(ENTITY_ATTRIBUTE_GROUP) == entity_group)
+            and (entity_role is None or x.get(ENTITY_ATTRIBUTE_ROLE) == entity_role)
         )
 
     def get_latest_input_channel(self) -> Optional[Text]:

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -209,76 +209,41 @@ async def test_bot_utterance_comes_after_action_event(default_agent):
 @pytest.mark.parametrize(
     "entities, expected_value",
     [
+        ([{"value": "greet", "entity": "entity_name"}], ["greet"]),
         (
             [
-                {
-                    "start": 1,
-                    "end": 5,
-                    "value": "greet",
-                    "entity": "entity_name",
-                    "extractor": "manual",
-                }
+                {"value": "greet", "entity": "entity_name"},
+                {"value": "bye", "entity": "other"},
             ],
             ["greet"],
         ),
         (
             [
-                {
-                    "start": 1,
-                    "end": 5,
-                    "value": "e1",
-                    "entity": "entity_name",
-                    "extractor": "manual",
-                },
-                {
-                    "start": 1,
-                    "end": 5,
-                    "value": "e2",
-                    "entity": "entity_name",
-                    "extractor": "manual",
-                },
+                {"value": "greet", "entity": "entity_name"},
+                {"value": "bye", "entity": "entity_name"},
             ],
-            ["e1", "e2"],
+            ["greet", "bye"],
         ),
         (
             [
-                {
-                    "start": 1,
-                    "end": 5,
-                    "value": "role-group",
-                    "entity": "entity_name",
-                    "role": "role",
-                    "group": "group",
-                    "extractor": "manual",
-                }
+                {"value": "greet", "entity": "entity_name", "role": "role"},
+                {"value": "bye", "entity": "entity_name"},
             ],
-            ["role-group"],
+            ["greet"],
         ),
         (
             [
-                {
-                    "start": 1,
-                    "end": 5,
-                    "value": "role",
-                    "entity": "entity_name",
-                    "role": "role",
-                    "extractor": "manual",
-                }
+                {"value": "greet", "entity": "entity_name", "group": "group"},
+                {"value": "bye", "entity": "entity_name"},
             ],
-            ["role"],
+            ["greet"],
         ),
         (
             [
-                {
-                    "start": 1,
-                    "end": 5,
-                    "value": "group",
-                    "entity": "entity_name",
-                    "role": "group",
-                    "extractor": "manual",
-                }
+                {"value": "greet", "entity": "entity_name"},
+                {"value": "bye", "entity": "entity_name", "group": "group"},
             ],
-            ["group"],
+            ["greet", "bye"],
         ),
     ],
 )
@@ -295,17 +260,14 @@ def test_tracker_entity_retrieval(entities, expected_value, default_domain: Doma
     intent = {"name": "greet", "confidence": 1.0}
     tracker.update(UserUttered("/greet", intent, entities))
 
-    assert list(tracker.get_latest_entity_values(entity_type)) == expected_value
-    if entity_role is not None:
-        assert (
-            list(tracker.get_latest_entity_values_with_role(entity_type, entity_role))
-            == expected_value
+    assert (
+        list(
+            tracker.get_latest_entity_values(
+                entity_type, entity_role=entity_role, entity_group=entity_group
+            )
         )
-    if entity_group is not None:
-        assert (
-            list(tracker.get_latest_entity_values_with_group(entity_type, entity_group))
-            == expected_value
-        )
+        == expected_value
+    )
     assert list(tracker.get_latest_entity_values("unknown")) == []
 
 

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import tempfile
-from typing import List
+from typing import List, Text, Dict, Any
 
 import fakeredis
 import pytest
@@ -207,7 +207,7 @@ async def test_bot_utterance_comes_after_action_event(default_agent):
 
 
 @pytest.mark.parametrize(
-    "entities, expected_value",
+    "entities, expected_values",
     [
         ([{"value": "greet", "entity": "entity_name"}], ["greet"]),
         (
@@ -247,7 +247,9 @@ async def test_bot_utterance_comes_after_action_event(default_agent):
         ),
     ],
 )
-def test_tracker_entity_retrieval(entities, expected_value, default_domain: Domain):
+def test_get_latest_entity_values(
+    entities: List[Dict[Text, Any]], expected_values: List[Text], default_domain: Domain
+):
     entity_type = entities[0].get("entity")
     entity_role = entities[0].get("role")
     entity_group = entities[0].get("group")
@@ -266,7 +268,7 @@ def test_tracker_entity_retrieval(entities, expected_value, default_domain: Doma
                 entity_type, entity_role=entity_role, entity_group=entity_group
             )
         )
-        == expected_value
+        == expected_values
     )
     assert list(tracker.get_latest_entity_values("unknown")) == []
 


### PR DESCRIPTION
**Proposed changes**:
Update the method `get_latest_entity_values` to take an optional role/group label. Needed to allow users to fill a slot that depends on a specific role/group in a custom action.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
