### PR TITLE
docs : import knowledgebase before using it

### DIFF
--- a/docs/core/knowledge-bases.rst
+++ b/docs/core/knowledge-bases.rst
@@ -209,6 +209,9 @@ base to the constructor of ``ActionQueryKnowledgeBase``.
 
 .. code-block:: python
 
+    from rasa_sdk.knowledge_base.storage import InMemoryKnowledgeBase
+    from rasa_sdk.knowledge_base.actions import ActionQueryKnowledgeBase
+
     class MyKnowledgeBaseAction(ActionQueryKnowledgeBase):
         def __init__(self):
             knowledge_base = InMemoryKnowledgeBase("data.json")


### PR DESCRIPTION
In the documentation there's an object being created without showing how to import it's base-classes. Added two import statements to the knowledge-base docs. 