### PR TITLE
Added "confused_with" & confusion matrix to response selector evaluation

### DIFF
--- a/changelog/5544.improvment.rst
+++ b/changelog/5544.improvment.rst
@@ -1,0 +1,3 @@
+Add confusion matrix and "confused_with" to response selection evaluation
+
+If you are using ResponseSelectors, they now produce similiar outputs during NLU evaluation. Misclassfied responses are listed in a "confused_with" attribute in the evaluation report. Similiarily, a confusion matrix of all responses is plotted.

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -377,19 +377,23 @@ def evaluate_response_selections(
             target_responses, predicted_responses, output_dict=True
         )
 
-        cnf_matrix = sklearn.metrics.confusion_matrix(target_responses, predicted_responses)
-        labels = sklearn.utils.multiclass.unique_labels(target_responses, predicted_responses)
+        cnf_matrix = sklearn.metrics.confusion_matrix(
+            target_responses, predicted_responses
+        )
+        labels = sklearn.utils.multiclass.unique_labels(
+            target_responses, predicted_responses
+        )
 
         report = _add_confused_intents_to_report(report, cnf_matrix, labels)
-        
+
         report_filename = os.path.join(report_folder, "response_selection_report.json")
         utils.write_json_to_file(report_filename, report)
         logger.info(f"Classification report saved to {report_filename}.")
 
         if not disable_plotting:
             _plot_confusion_matrix(
-                    report_folder, "response_selection_confmat.png", cnf_matrix, labels
-                )
+                report_folder, "response_selection_confmat.png", cnf_matrix, labels
+            )
 
     else:
         report, precision, f1, accuracy = get_evaluation_metrics(

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -494,6 +494,7 @@ def test_response_evaluation_report(tmpdir_factory):
         "recall": 1.0,
         "f1-score": 1.0,
         "support": 1,
+        "confused_with": {}
     }
 
     prediction = {

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -494,7 +494,7 @@ def test_response_evaluation_report(tmpdir_factory):
         "recall": 1.0,
         "f1-score": 1.0,
         "support": 1,
-        "confused_with": {}
+        "confused_with": {},
     }
 
     prediction = {


### PR DESCRIPTION
**Proposed changes**:
- Similar to the intent evaluation reports, I added the "confused_with" attribute to the `response_selection_report.json`
- Also similar to intent evaluation, I added a plot of the confusion matrix for response selection evaluation

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
