### PR TITLE
Fixed ambiguous logging in DIETClassifier

### DIFF
--- a/changelog/5547.bugfix.rst
+++ b/changelog/5547.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ambiguous logging in ``DIETClassifier`` by adding the name of the calling class to the log message.

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -659,8 +659,9 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
     def _predict(self, message: Message) -> Optional[Dict[Text, tf.Tensor]]:
         if self.model is None:
             logger.debug(
-                "There is no trained model: component is either not trained or "
-                "didn't receive enough training data."
+                f"There is no trained model for '{self.__class__.__name__}': The "
+                f"component is either not trained or didn't receive enough training "
+                f"data."
             )
             return
 
@@ -838,8 +839,9 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
 
         if not model_dir or not meta.get("file"):
             logger.debug(
-                f"Failed to load model. "
-                f"Maybe the path '{os.path.abspath(model_dir)}' doesn't exist?"
+                f"Failed to load model for '{cls.__name__}'. "
+                f"Maybe you did not provide enough training data and no model was "
+                f"trained or the path '{os.path.abspath(model_dir)}' doesn't exist?"
             )
             return cls(component_config=meta)
 


### PR DESCRIPTION
**Proposed changes**:
Fixed ambiguous logging in ``DIETClassifier`` by adding the name of the calling class to the log message.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
