### PR TITLE
Log roles and groups in training data stats

### DIFF
--- a/data/test/demo-rasa-composite-entities.md
+++ b/data/test/demo-rasa-composite-entities.md
@@ -2,11 +2,11 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-  - [intent:affirm](#intentaffirm)
-  - [intent:goodbye](#intentgoodbye)
-  - [intent:greet](#intentgreet)
-  - [intent:chitchat](#intentchitchat)
-  - [intent:restaurant_search](#intentrestaurant_search)
+- [intent:affirm](#intentaffirm)
+- [intent:goodbye](#intentgoodbye)
+- [intent:greet](#intentgreet)
+- [intent:chitchat](#intentchitchat)
+- [intent:restaurant_search](#intentrestaurant_search)
 - [intent:order_pizza](#intentorder_pizza)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -67,7 +67,7 @@
 - I am looking for [mexican indian fusion](cuisine)
 - [central](location) [indian]{"entity": "cuisine", "role": "asian"} restaurant
 
-# intent:order_pizza
+## intent:order_pizza
 - i want a [large]{"entity": "size", "group": "1"} pizza with [tomato]{"entity": "topping", "group": "1"} and a [small]{"entity": "size", "group": "2"} pizza with [bacon]{"entity": "topping", "group": "2"}
 - one [large]{"entity": "size", "group": "1"} with [pepperoni]{"entity": "topping", "group": "1"} and a [medium]{"entity": "size", "group": "2"} with [mushrooms]{"entity": "topping", "group": "2"}
 - I would like a [medium]{"entity": "size", "group": "1"} standard pizza and a [medium]{"entity": "size", "group": "2"} pizza with [extra cheese]{"entity": "topping", "group": "2"}

--- a/data/test/demo-rasa-composite-entities.md
+++ b/data/test/demo-rasa-composite-entities.md
@@ -71,5 +71,5 @@
 - i want a [large]{"entity": "size", "group": "1"} pizza with [tomato]{"entity": "topping", "group": "1"} and a [small]{"entity": "size", "group": "2"} pizza with [bacon]{"entity": "topping", "group": "2"}
 - one [large]{"entity": "size", "group": "1"} with [pepperoni]{"entity": "topping", "group": "1"} and a [medium]{"entity": "size", "group": "2"} with [mushrooms]{"entity": "topping", "group": "2"}
 - I would like a [medium]{"entity": "size", "group": "1"} standard pizza and a [medium]{"entity": "size", "group": "2"} pizza with [extra cheese]{"entity": "topping", "group": "2"}
-- [large]{"entity": "size", "group": "1"} with [onions]{"entity": "topping", "group": "1"} and [small]{"entity": "size", "group": "1"} with [olives]{"entity": "topping", "group": "1"}
+- [large]{"entity": "size", "group": "1"} with [onions]{"entity": "topping", "group": "1"} and [small]{"entity": "size", "group": "2"} with [olives]{"entity": "topping", "group": "2"}
 - a pizza with [onions]{"entity": "topping", "group": "1"} in [medium]{"entity": "size", "group": "1"} and one with [mushrooms]{"entity": "topping", "group": "2"} in [small]{"entity": "size", "group": "2"} please

--- a/rasa/nlu/training_data/training_data.py
+++ b/rasa/nlu/training_data/training_data.py
@@ -109,7 +109,9 @@ class TrainingData:
     def sanitize_examples(examples: List[Message]) -> List[Message]:
         """Makes sure the training data is clean.
 
-        Remove trailing whitespaces from intent and response annotations and drop duplicate examples."""
+        Remove trailing whitespaces from intent and response annotations and drop
+        duplicate examples.
+        """
 
         for ex in examples:
             if ex.get("intent"):
@@ -194,16 +196,16 @@ class TrainingData:
 
         entities = []
 
-        def _append_entity(attribute: Text) -> None:
+        def _append_entity(entity: Dict[Text, Any], attribute: Text) -> None:
             if attribute in entity:
                 _value = entity.get(attribute)
                 if _value is not None and _value != NO_ENTITY_TAG:
                     entities.append(f"{attribute} '{_value}'")
 
         for entity in self.sorted_entities():
-            _append_entity(ENTITY_ATTRIBUTE_TYPE)
-            _append_entity(ENTITY_ATTRIBUTE_ROLE)
-            _append_entity(ENTITY_ATTRIBUTE_GROUP)
+            _append_entity(entity, ENTITY_ATTRIBUTE_TYPE)
+            _append_entity(entity, ENTITY_ATTRIBUTE_ROLE)
+            _append_entity(entity, ENTITY_ATTRIBUTE_GROUP)
 
         return dict(Counter(entities))
 
@@ -217,8 +219,8 @@ class TrainingData:
         """Set response phrase for all examples by looking up NLG stories"""
         for example in self.training_examples:
             response_key = example.get(RESPONSE_KEY_ATTRIBUTE)
-            # if response_key is None, that means the corresponding intent is not a retrieval intent
-            # and hence no response text needs to be fetched.
+            # if response_key is None, that means the corresponding intent is not a
+            # retrieval intent and hence no response text needs to be fetched.
             # If response_key is set, fetch the corresponding response text
             if response_key:
                 # look for corresponding bot utterance

--- a/tests/nlu/training_data/test_training_data.py
+++ b/tests/nlu/training_data/test_training_data.py
@@ -385,7 +385,7 @@ def cmp_dict_list(firsts, seconds):
                 del seconds[idx]
                 break
         else:
-            others = ", ".join([e.text for e in seconds])
+            others = ", ".join(e.text for e in seconds)
             assert False, f"Failed to find message {a.text} in {others}"
     return not seconds
 

--- a/tests/nlu/training_data/test_training_data.py
+++ b/tests/nlu/training_data/test_training_data.py
@@ -93,6 +93,26 @@ def test_lookup_table_md():
     ]
 
 
+def test_composite_entities_data():
+    td = training_data.load_data("data/test/demo-rasa-composite-entities.md")
+    assert not td.is_empty()
+    assert len(td.entity_examples) == 16
+    assert len(td.intent_examples) == 51
+    assert len(td.training_examples) == 51
+    assert td.entity_synonyms == {"chines": "chinese"}
+    assert td.intents == {
+        "order_pizza",
+        "restaurant_search",
+        "chitchat",
+        "greet",
+        "goodbye",
+        "affirm",
+    }
+    assert td.entities == {"location", "cuisine", "topping", "size"}
+    assert td.entity_groups == {"1", "2"}
+    assert td.entity_roles == {"european", "asian", "latin america"}
+
+
 @pytest.mark.parametrize(
     "files",
     [

--- a/tests/nlu/training_data/test_training_data.py
+++ b/tests/nlu/training_data/test_training_data.py
@@ -112,6 +112,10 @@ def test_composite_entities_data():
     assert td.entity_groups == {"1", "2"}
     assert td.entity_roles == {"european", "asian", "latin america"}
 
+    assert td.examples_per_entity["entity 'location'"] == 7
+    assert td.examples_per_entity["group '1'"] == 9
+    assert td.examples_per_entity["role 'european'"] == 1
+
 
 @pytest.mark.parametrize(
     "files",


### PR DESCRIPTION
**Proposed changes**:
Part of https://github.com/RasaHQ/research/issues/69

Update the training data statistics to include roles and groups.
Log warning if just one training example with a role/group is given.

Merged into `composite-entities`

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
