### PR TITLE
Set regularization constant in `EmbeddingIntentClassifier` to 0.001

### DIFF
--- a/changelog/5631.misc.rst
+++ b/changelog/5631.misc.rst
@@ -1,0 +1,1 @@
+Set regularization constant in ``EmbeddingIntentClassifier`` to 0.001.

--- a/rasa/nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa/nlu/classifiers/embedding_intent_classifier.py
@@ -117,7 +117,7 @@ class EmbeddingIntentClassifier(DIETClassifier):
         SCALE_LOSS: True,
         # ## Regularization parameters
         # The scale of regularization
-        REGULARIZATION_CONSTANT: 0.002,
+        REGULARIZATION_CONSTANT: 0.001,
         # The scale of how important is to minimize the maximum similarity
         # between embeddings of different labels.
         NEGATIVE_MARGIN_SCALE: 0.8,


### PR DESCRIPTION
**Proposed changes**:
Set regularization constant in `EmbeddingIntentClassifier` to 0.001.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
