### PR TITLE
fix typo in type def, plus remove redundant comment

### DIFF
--- a/docs/user-guide/building-assistants.rst
+++ b/docs/user-guide/building-assistants.rst
@@ -636,8 +636,7 @@ use the ``from_text`` method to extract the users whole message:
 
 .. code-block:: python
 
-    def slot_mappings(self) -> Dict[Text: Union[Dict, List[Dict]]]:
-        # type: () -> Dict[Text: Union[Dict, List[Dict]]]
+    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict]]]:
         """A dictionary to map required slots to
         - an extracted entity
         - intent: value pairs

--- a/docs/user-guide/building-assistants.rst
+++ b/docs/user-guide/building-assistants.rst
@@ -636,7 +636,7 @@ use the ``from_text`` method to extract the users whole message:
 
 .. code-block:: python
 
-    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict]]]:
+    def slot_mappings(self) -> Dict[Text, Union[Dict, List[Dict[Text, Any]]]]:
         """A dictionary to map required slots to
         - an extracted entity
         - intent: value pairs


### PR DESCRIPTION
**Proposed changes**:
- fixes typo

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
