### PR TITLE
Pass entity tags as features to second level CRFs in DIETClassifier

### DIFF
--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -355,7 +355,7 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
                 )
             else:
                 tag_id_index_mapping = self._tag_id_index_mapping_for(
-                    tag_name, training_data.entity_examples
+                    tag_name, training_data
                 )
 
             if tag_id_index_mapping:
@@ -372,18 +372,17 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
 
     @staticmethod
     def _tag_id_index_mapping_for(
-        tag_name: Text, entity_examples: List[Message]
+        tag_name: Text, training_data: TrainingData
     ) -> Optional[Dict[Text, int]]:
         """Create mapping from tag name to id."""
-        distinct_tags = (
-            {
-                entity.get(tag_name)
-                for example in entity_examples
-                for entity in example.get(ENTITIES)
-            }
-            - {None}
-            - {NO_ENTITY_TAG}
-        )
+        if tag_name == ENTITY_ATTRIBUTE_ROLE:
+            distinct_tags = training_data.entity_roles
+        elif tag_name == ENTITY_ATTRIBUTE_GROUP:
+            distinct_tags = training_data.entity_groups
+        else:
+            distinct_tags = training_data.entities
+
+        distinct_tags = distinct_tags - {NO_ENTITY_TAG} - {None}
 
         if not distinct_tags:
             return None

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1513,8 +1513,8 @@ class DIET(RasaModel):
         tag_ids = tf.cast(tag_ids[:, :, 0], tf.int32)
 
         if entity_tags is not None:
-            entity_tags = self._tf_layers[f"embed.{tag_name}.tags"](entity_tags)
-            inputs = tf.concat([inputs, entity_tags], axis=-1)
+            _tags = self._tf_layers[f"embed.{tag_name}.tags"](entity_tags)
+            inputs = tf.concat([inputs, _tags], axis=-1)
 
         logits = self._tf_layers[f"embed.{tag_name}.logits"](inputs)
 
@@ -1691,8 +1691,8 @@ class DIET(RasaModel):
             _input = text_transformed
 
             if entity_tags is not None:
-                entity_tags = self._tf_layers[f"embed.{name}.tags"](entity_tags)
-                _input = tf.concat([_input, entity_tags], axis=-1)
+                _tags = self._tf_layers[f"embed.{name}.tags"](entity_tags)
+                _input = tf.concat([_input, _tags], axis=-1)
 
             _logits = self._tf_layers[f"embed.{name}.logits"](_input)
             pred_ids = self._tf_layers[f"crf.{name}"](_logits, sequence_lengths - 1)

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1332,7 +1332,6 @@ class DIET(RasaModel):
         self._prepare_dot_product_loss(LABEL, self.config[SCALE_LOSS])
 
     def _prepare_entity_recognition_layers(self) -> None:
-        num_entity_tags = 0
         for tag_spec in self._entity_tag_specs:
             name = tag_spec.tag_name
             num_tags = tag_spec.num_tags
@@ -1342,14 +1341,11 @@ class DIET(RasaModel):
             self._tf_layers[f"crf.{name}"] = layers.CRF(
                 num_tags, self.config[REGULARIZATION_CONSTANT], self.config[SCALE_LOSS]
             )
-            if name == ENTITY_ATTRIBUTE_TYPE:
-                num_entity_tags = num_tags
-            else:
-                self._tf_layers[f"embed.{name}.tags"] = layers.Embed(
-                    num_entity_tags,
-                    self.config[REGULARIZATION_CONSTANT],
-                    f"tags.{name}",
-                )
+            self._tf_layers[f"embed.{name}.tags"] = layers.Embed(
+                self.config[EMBEDDING_DIMENSION],
+                self.config[REGULARIZATION_CONSTANT],
+                f"tags.{name}",
+            )
 
     @staticmethod
     def _get_sequence_lengths(mask: tf.Tensor) -> tf.Tensor:

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -99,7 +99,7 @@ class RasaModel(tf.keras.models.Model):
         evaluate_every_num_epochs: int,
         batch_strategy: Text,
         silent: bool = False,
-        eager: bool = True,
+        eager: bool = False,
     ) -> None:
         """Fit model data"""
 
@@ -194,7 +194,7 @@ class RasaModel(tf.keras.models.Model):
         self.optimizer.apply_gradients(zip(gradients, self.trainable_variables))
 
     def build_for_predict(
-        self, predict_data: RasaModelData, eager: bool = True
+        self, predict_data: RasaModelData, eager: bool = False
     ) -> None:
         self._training = False  # needed for tf graph mode
         self._predict_function = self._get_tf_call_model_function(

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -99,7 +99,7 @@ class RasaModel(tf.keras.models.Model):
         evaluate_every_num_epochs: int,
         batch_strategy: Text,
         silent: bool = False,
-        eager: bool = False,
+        eager: bool = True,
     ) -> None:
         """Fit model data"""
 
@@ -194,7 +194,7 @@ class RasaModel(tf.keras.models.Model):
         self.optimizer.apply_gradients(zip(gradients, self.trainable_variables))
 
     def build_for_predict(
-        self, predict_data: RasaModelData, eager: bool = False
+        self, predict_data: RasaModelData, eager: bool = True
     ) -> None:
         self._training = False  # needed for tf graph mode
         self._predict_function = self._get_tf_call_model_function(


### PR DESCRIPTION
**Proposed changes**:
Pass entity tags instead of logits as features to second level CRFs in DIETClassifier.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
