### PR TITLE
fix golden inputs in case mask loss is on in diet

### DIFF
--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1236,14 +1236,15 @@ class DIET(RasaModel):
         inputs = self._tf_layers[f"ffnn.{name}"](inputs, self._training)
 
         if masked_lm_loss:
-            inputs, lm_mask_bool = self._tf_layers[f"{name}_input_mask"](
+            transformer_inputs, lm_mask_bool = self._tf_layers[f"{name}_input_mask"](
                 inputs, mask, self._training
             )
         else:
+            transformer_inputs = inputs
             lm_mask_bool = None
 
         outputs = self._tf_layers[f"{name}_transformer"](
-            inputs, 1 - mask, self._training
+            transformer_inputs, 1 - mask, self._training
         )
 
         if self.config[NUM_TRANSFORMER_LAYERS] > 0:


### PR DESCRIPTION
**Proposed changes**:
- output inputs before masking, for them to be used as golden tokens

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
