### PR TITLE
suppress pika logs during startup

### DIFF
--- a/changelog/2224.improvement.rst
+++ b/changelog/2224.improvement.rst
@@ -1,0 +1,8 @@
+Suppressed ``pika`` logs when establishing the connection. These log messages
+mostly happened when Rasa X and RabbitMQ were started at the same time. Since RabbitMQ
+can take a few seconds to initialize, Rasa X has to re-try until the connection is
+established.
+In case you suspect a different problem (such as failing authentication) you can
+re-enable the ``pika`` logs by setting the log level to ``DEBUG``. To run Rasa Open
+Source in debug mode, use the ``--debug`` flag. To run Rasa X in debug mode, set the
+environment variable ``DEBUG_MODE`` to ``true``.

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -4,8 +4,20 @@ import os
 import time
 import typing
 from collections import deque
+from contextlib import contextmanager
 from threading import Thread
-from typing import Callable, Deque, Dict, Optional, Text, Union, Any, List, Tuple
+from typing import (
+    Callable,
+    Deque,
+    Dict,
+    Optional,
+    Text,
+    Union,
+    Any,
+    List,
+    Tuple,
+    Generator,
+)
 
 from rasa.constants import (
     DEFAULT_LOG_LEVEL_LIBRARIES,
@@ -53,10 +65,35 @@ def initialise_pika_connection(
     """
     import pika
 
-    parameters = _get_pika_parameters(
-        host, username, password, port, connection_attempts, retry_delay_in_seconds
-    )
-    return pika.BlockingConnection(parameters)
+    with _pika_log_level(logging.CRITICAL):
+        parameters = _get_pika_parameters(
+            host, username, password, port, connection_attempts, retry_delay_in_seconds
+        )
+        return pika.BlockingConnection(parameters)
+
+
+@contextmanager
+def _pika_log_level(temporary_log_level: int) -> Generator[None, None, None]:
+    """Change the log level of the `pika` library.
+
+    The log level will remain unchanged if the current log level is 10 (`DEBUG`) or
+    lower.
+
+    Args:
+        temporary_log_level: Temporary log level for pika. Will be revert to previous
+            log level when context manager exits.
+    """
+
+    pika_logger = logging.getLogger("pika")
+    old_log_level = pika_logger.level
+    is_debug_mode = logging.root.level <= logging.DEBUG
+
+    if not is_debug_mode:
+        pika_logger.setLevel(temporary_log_level)
+
+    yield
+
+    pika_logger.setLevel(old_log_level)
 
 
 def _get_pika_parameters(

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -80,10 +80,9 @@ def _pika_log_level(temporary_log_level: int) -> Generator[None, None, None]:
     lower.
 
     Args:
-        temporary_log_level: Temporary log level for pika. Will be revert to previous
-            log level when context manager exits.
+        temporary_log_level: Temporary log level for pika. Will be reverted to
+        previous log level when context manager exits.
     """
-
     pika_logger = logging.getLogger("pika")
     old_log_level = pika_logger.level
     is_debug_mode = logging.root.level <= logging.DEBUG


### PR DESCRIPTION
**Proposed changes**:
- suppress `pika` logs during startup
   - this happens only during startup, the behavior after the startup stays the same
   - the logs are not suppressed when a log level <= `DEBUG` (10) is used
- fix https://github.com/RasaHQ/rasa-x/issues/2224

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
