### PR TITLE
make timeout for rasa shell configurable

### DIFF
--- a/changelog/4606.improvement.rst
+++ b/changelog/4606.improvement.rst
@@ -1,0 +1,4 @@
+The stream reading timeout for ``rasa shell` is now configurable by using the
+environment variable ``RASA_SHELL_STREAM_READING_TIMEOUT_IN_SECONDS``.
+This can help to fix problems when using ``rasa shell`` with custom actions which run
+10 seconds or longer.

--- a/rasa/core/channels/console.py
+++ b/rasa/core/channels/console.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import asyncio
+import os
 from typing import Text, Optional, Dict, List
 
 import aiohttp
@@ -19,6 +20,7 @@ from typing import Any, Coroutine
 
 logger = logging.getLogger(__name__)
 
+STREAM_READING_TIMEOUT_ENV = "RASA_SHELL_STREAM_READING_TIMEOUT_IN_SECONDS"
 DEFAULT_STREAM_READING_TIMEOUT_IN_SECONDS = 10
 
 
@@ -97,7 +99,7 @@ async def send_message_receive_stream(
     url = f"{server_url}/webhooks/rest/webhook?stream=true&token={auth_token}"
 
     # Define timeout to not keep reading in case the server crashed in between
-    timeout = ClientTimeout(DEFAULT_STREAM_READING_TIMEOUT_IN_SECONDS)
+    timeout = _get_stream_reading_timeout()
 
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.post(url, json=payload, raise_for_status=True) as resp:
@@ -105,6 +107,16 @@ async def send_message_receive_stream(
             async for line in resp.content:
                 if line:
                     yield json.loads(line.decode(DEFAULT_ENCODING))
+
+
+def _get_stream_reading_timeout() -> ClientTimeout:
+    timeout_in_seconds = int(
+        os.environ.get(
+            STREAM_READING_TIMEOUT_ENV, DEFAULT_STREAM_READING_TIMEOUT_IN_SECONDS
+        )
+    )
+
+    return ClientTimeout(timeout_in_seconds)
 
 
 async def record_messages(

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -1,16 +1,17 @@
 import json
 import logging
-import urllib.parse
 from typing import Dict
 from unittest.mock import patch, MagicMock, Mock
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from aiohttp import ClientTimeout
 from aioresponses import aioresponses
 from sanic import Sanic
 
 import rasa.core.run
 from rasa.core import utils
-from rasa.core.channels import RasaChatInput
+from rasa.core.channels import RasaChatInput, console
 from rasa.core.channels.channel import UserMessage
 from rasa.core.channels.rasa_chat import (
     JWT_USERNAME_KEY,
@@ -548,7 +549,7 @@ def test_slack_metadata_missing_keys():
             "channel": channel,
             "event_ts": "1579802617.000800",
             "channel_type": "im",
-        },
+        }
     }
 
     input_channel = SlackInput(
@@ -1032,3 +1033,10 @@ def test_has_user_permission_to_send_messages_to_conversation_without_permission
     assert not RasaChatInput._has_user_permission_to_send_messages_to_conversation(
         jwt, message
     )
+
+
+def test_set_console_stream_reading_timeout(monkeypatch: MonkeyPatch):
+    expected = 100
+    monkeypatch.setenv(console.STREAM_READING_TIMEOUT_ENV, str(100))
+
+    assert console._get_stream_reading_timeout() == ClientTimeout(expected)


### PR DESCRIPTION
**Proposed changes**:
- make timeout for `rasa shell` configurable through env variable `RASA_SHELL_STREAM_READING_TIMEOUT_IN_SECONDS`
- fix https://github.com/RasaHQ/rasa/issues/4606

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
