### PR TITLE
Update Facebook output channel with richer fbmessenger support

### DIFF
--- a/docs/user-guide/connectors/facebook-messenger.rst
+++ b/docs/user-guide/connectors/facebook-messenger.rst
@@ -82,12 +82,15 @@ In addition to typical text, image, button, and custom responses, the Facebook M
    utter_fb_buttons_example:
       - text: Hello World!
         buttons:
-          - title: Button Title
-            payload: /example_intent
-          - title: Button Title
-            payload: /example_intent
           - title: Button title over 20 characters # this will be truncated to: "Button title over..."
             payload: /example_intent
+          - title: Link in Messenger
+            type: web_url
+            url: https://youtu.be/dQw4w9WgXcQ
+          - title: Calls in Messenger
+            type: phone_number
+            payload: +15105551234
+
 
 .. warning::
 

--- a/docs/user-guide/connectors/facebook-messenger.rst
+++ b/docs/user-guide/connectors/facebook-messenger.rst
@@ -109,11 +109,7 @@ In addition to typical text, image, button, and custom responses, the Facebook M
           # the title and payload will be filled
           # with the user's information from their profile
           - content_type: user_email
-            title:
-            payload:
           - content_type: user_phone_number
-            title:
-            payload:
 
 .. note::
 

--- a/docs/user-guide/connectors/facebook-messenger.rst
+++ b/docs/user-guide/connectors/facebook-messenger.rst
@@ -73,14 +73,16 @@ you should add in the configuration of the webhook.
 Supported response attachments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In addition to typical text, image, button, and custom responses, the Facebook Messenger channel supports the following additional response template attachments:
+In addition to typical text, image, button, and custom responses, the Facebook
+Messenger channel supports the following additional response template attachments:
 
 * `Buttons <https://developers.facebook.com/docs/messenger-platform/send-messages/buttons>`_: sends a text message with up to three attached buttons
 
 .. code-block:: yaml
 
    utter_fb_buttons_example:
-      - text: Hello World!
+      - channel: facebook
+        text: Hello World!
         buttons:
           - title: Button title over 20 characters # this will be truncated to: "Button title over..."
             payload: /example_intent
@@ -94,14 +96,17 @@ In addition to typical text, image, button, and custom responses, the Facebook M
 
 .. warning::
 
-   Facebook API limits the amount of buttons you can sent in a message to 3.  If more than 3 buttons are provided in a message, Rasa will ignore all provided buttons.
+   Facebook API limits the amount of buttons you can sent in a message to 3.  If
+   more than 3 buttons are provided in a message, Rasa will ignore all provided
+   buttons.
 
-* `Quick Replies <https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies>`_: provide a way to present a set of up to 13 buttons in-conversation that contain a title and optional image, and appear prominently above the composer. You can also use quick replies to request a person's email address or phone number.
+* `Quick Replies <https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies>`_: provide a way to present a set of up to 13 buttons in-conversation that contain a title and optional image, and appear prominently above the composer. You can also use quick replies to request a person'semail address or phone number.
 
 .. code-block:: yaml
 
    utter_fb_quick_reply_example:
-      - text: Hello World!
+      - channel: facebook
+        text: Hello World!
         quick_replies:
           - title: Text quick reply
             payload: /example_intent
@@ -116,14 +121,16 @@ In addition to typical text, image, button, and custom responses, the Facebook M
 
 .. note::
 
-   Both Quick Reply and Button titles in Facebook Messenger have a character limit of 20.  Titles longer than 20 characters will be truncated.
+   Both Quick Reply and Button titles in Facebook Messenger have a character
+   limit of 20.  Titles longer than 20 characters will be truncated.
 
 * `Generic Template Elements <https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic>`_: provide a way to create a horizontally scrollable list up to 10 content elements that integrate buttons, images, and more alongside text a single message.
 
 .. code-block:: yaml
 
    utter_fb_element_example:
-      - text: Hello World!
+      - channel: facebook
+        text: Hello World!
         elements:
           - title: Element Title 1
             subtitle: Subtitles are supported

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -280,8 +280,8 @@ class MessengerBot(OutputChannel):
                 fb_buttons.append(
                     FBButton(
                         button["type"],
-                        title=button["title"],
-                        payload=button["payload"],
+                        title=button.get("title"),
+                        payload=button.get("payload"),
                         url=button.get("url"),
                         fallback_url=button.get("fallback_url"),
                         webview_height_ratio=button.get("webview_height_ratio"),


### PR DESCRIPTION
**Proposed changes**:
This is related to issue #5640 and a superset of documentation update PR #5693. Drafting the channel updates to see if this is something folks are interested in, in which case I'll update the docs with more button information and add some tests, then create the PR.
- Updated Facebook output channel to use `fbmessenger` provided template classes, except custom JSON payload messages
- improved out-of-the box support for [Facebook button templates](https://developers.facebook.com/docs/messenger-platform/send-messages/buttons), like URL buttons
- improved out-of-the box support for Facebook-provided [`user_email`](https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies#email) and [`user_phone_number`](https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies#phone) quick replies
    > With this, you would no longer need to add empty `title` and `payload` fields.  Previously, in order to use these, you'd have to send an empty `title` and `payload` keys in the quick reply for Rasa to accept as a valid quick reply, otherwise it would throw an error.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (pending further changes)
- [x] reformat files using `black`
