### PR TITLE
Update class Message to properly set attribute text

### DIFF
--- a/rasa/nlu/training_data/message.py
+++ b/rasa/nlu/training_data/message.py
@@ -25,9 +25,12 @@ class Message:
             self.output_properties = set()
 
     def set(self, prop, info, add_to_output=False) -> None:
-        self.data[prop] = info
-        if add_to_output:
-            self.output_properties.add(prop)
+        if prop == TEXT:
+            self.text = info
+        else:
+            self.data[prop] = info
+            if add_to_output:
+                self.output_properties.add(prop)
 
     def get(self, prop, default=None) -> Any:
         if prop == TEXT:


### PR DESCRIPTION
Method `set` of class `Message` does not properly set attribute `text`. I know that it can be set as in `message.text = "foo"`, but method `set` should work as a unified API with method `get` for an intuitive API. Setting attribute `text` might be required for noisy text normalizers as a custom component, and calling `message.set('text', 'bar')` would not work just as in my case. I had to read the source code to make it work for me.

**Proposed changes**:
- Update method `set` to set `self.text` if `prop == TEXT`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
