### PR TITLE
Fix usage of empty spaCy model

### DIFF
--- a/changelog/5638.bugfix.rst
+++ b/changelog/5638.bugfix.rst
@@ -1,0 +1,1 @@
+Fix: DIET breaks with empty spaCy model

--- a/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
@@ -69,7 +69,7 @@ class SpacyFeaturizer(DenseFeaturizer):
             return
 
         # in case an empty spaCy model was used, no vectors are present
-        if doc.vocab.vectors.name is None:
+        if doc.vocab.vectors_length == 0:
             logger.debug("No features present. You are using an empty spaCy model.")
             return
 

--- a/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
@@ -72,7 +72,7 @@ class SpacyFeaturizer(DenseFeaturizer):
             features = self._features_for_doc(message_attribute_doc)
 
             # in case an empty spaCy model was used, features are empty
-            if not features:
+            if not features.any():
                 logger.debug("No features present. You are using an empty spaCy model.")
                 return
 

--- a/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
@@ -67,6 +67,10 @@ class SpacyFeaturizer(DenseFeaturizer):
         if message_attribute_doc is not None:
             features = self._features_for_doc(message_attribute_doc)
 
+            # in case an empty spaCy model was used, features are empty
+            if not features:
+                return
+
             cls_token_vec = self._calculate_cls_vector(features, self.pooling_operation)
             features = np.concatenate([features, cls_token_vec])
 

--- a/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
+++ b/rasa/nlu/featurizers/dense_featurizer/spacy_featurizer.py
@@ -1,5 +1,6 @@
 import numpy as np
 import typing
+import logging
 from typing import Any, Optional, Text, Dict, List, Type
 
 from rasa.nlu.config import RasaNLUModelConfig
@@ -18,6 +19,9 @@ from rasa.utils.tensorflow.constants import POOLING, MEAN_POOLING
 
 if typing.TYPE_CHECKING:
     from spacy.tokens import Doc
+
+
+logger = logging.getLogger(__name__)
 
 
 class SpacyFeaturizer(DenseFeaturizer):
@@ -69,6 +73,7 @@ class SpacyFeaturizer(DenseFeaturizer):
 
             # in case an empty spaCy model was used, features are empty
             if not features:
+                logger.debug("No features present. You are using an empty spaCy model.")
                 return
 
             cls_token_vec = self._calculate_cls_vector(features, self.pooling_operation)

--- a/tests/nlu/featurizers/test_spacy_featurizer.py
+++ b/tests/nlu/featurizers/test_spacy_featurizer.py
@@ -165,3 +165,24 @@ def test_spacy_featurizer_train(spacy_nlp):
     vecs = message.get(DENSE_FEATURE_NAMES[INTENT])
 
     assert vecs is None
+
+
+def test_spacy_featurizer_using_empty_model():
+    from rasa.nlu.featurizers.dense_featurizer.spacy_featurizer import SpacyFeaturizer
+    import spacy
+
+    sentence = "This test is using an empty spaCy model"
+
+    model = spacy.blank("en")
+    doc = model(sentence)
+
+    ftr = SpacyFeaturizer.create({}, RasaNLUModelConfig())
+
+    message = Message(sentence)
+    message.set("text_spacy_doc", doc)
+
+    ftr._set_spacy_features(message)
+
+    vecs = message.get("text_dense_features")
+
+    assert vecs is None

--- a/tests/nlu/featurizers/test_spacy_featurizer.py
+++ b/tests/nlu/featurizers/test_spacy_featurizer.py
@@ -99,11 +99,11 @@ def test_spacy_featurizer_sequence(sentence, expected, spacy_nlp):
     greet = {"intent": "greet", "text_features": [0.5]}
 
     message = Message(sentence, greet)
-    message.set("text_spacy_doc", doc)
+    message.set(SPACY_DOCS[TEXT], doc)
 
     ftr._set_spacy_features(message)
 
-    vecs = message.get("text_dense_features")[0][:5]
+    vecs = message.get(DENSE_FEATURE_NAMES[TEXT])[0][:5]
 
     assert np.allclose(token_vectors[0][:5], vecs, atol=1e-4)
     assert np.allclose(vecs, expected, atol=1e-4)
@@ -179,10 +179,10 @@ def test_spacy_featurizer_using_empty_model():
     ftr = SpacyFeaturizer.create({}, RasaNLUModelConfig())
 
     message = Message(sentence)
-    message.set("text_spacy_doc", doc)
+    message.set(SPACY_DOCS[TEXT], doc)
 
     ftr._set_spacy_features(message)
 
-    vecs = message.get("text_dense_features")
+    vecs = message.get(SPACY_DOCS[TEXT])
 
     assert vecs is None

--- a/tests/nlu/featurizers/test_spacy_featurizer.py
+++ b/tests/nlu/featurizers/test_spacy_featurizer.py
@@ -183,6 +183,6 @@ def test_spacy_featurizer_using_empty_model():
 
     ftr._set_spacy_features(message)
 
-    vecs = message.get(SPACY_DOCS[TEXT])
+    vecs = message.get(DENSE_FEATURE_NAMES[TEXT])
 
     assert vecs is None


### PR DESCRIPTION
**Proposed changes**:
Skip featurizer via `SpacyFeaturizer` if an empty SpaCy model is used.

closes https://github.com/RasaHQ/rasa/issues/5638

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
