### PR TITLE
use concat_url to add "/parse" to duckling url safely

### DIFF
--- a/changelog/5792.bugfix.rst
+++ b/changelog/5792.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed issue where the ``DucklingHTTPExtractor`` component would
+not work if its `url` contained a trailing slash.

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -115,13 +115,14 @@ class DucklingHTTPExtractor(EntityExtractor):
     def _duckling_parse(self, text: Text, reference_time: int) -> List[Dict[Text, Any]]:
         """Sends the request to the duckling server and parses the result."""
 
+        parse_url = self._url() + "/parse"
         try:
             payload = self._payload(text, reference_time)
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
             }
             response = requests.post(
-                self._url() + "/parse",
+                parse_url,
                 data=payload,
                 headers=headers,
                 timeout=self.component_config.get("timeout"),
@@ -130,9 +131,8 @@ class DucklingHTTPExtractor(EntityExtractor):
                 return response.json()
             else:
                 logger.error(
-                    "Failed to get a proper response from remote "
-                    "duckling. Status Code: {}. Response: {}"
-                    "".format(response.status_code, response.text)
+                    f"Failed to get a proper response from remote "
+                    f"duckling at '{parse_url}. Status Code: {response.status_code}. Response: {response.text}"
                 )
                 return []
         except (

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -5,6 +5,7 @@ import os
 import requests
 from typing import Any, List, Optional, Text, Dict
 
+import rasa.utils.endpoints as endpoints_utils
 from rasa.constants import DOCS_URL_COMPONENTS
 from rasa.nlu.constants import ENTITIES
 from rasa.nlu.config import RasaNLUModelConfig
@@ -12,7 +13,6 @@ from rasa.nlu.extractors.extractor import EntityExtractor
 from rasa.nlu.model import Metadata
 from rasa.nlu.training_data import Message
 from rasa.utils.common import raise_warning
-from rasa.utils.endpoints import concat_url
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class DucklingHTTPExtractor(EntityExtractor):
         Returns:
             JSON response from duckling server with parse data.
         """
-        parse_url = concat_url(self._url(), "/parse")
+        parse_url = endpoints_utils.concat_url(self._url(), "/parse")
         try:
             payload = self._payload(text, reference_time)
             headers = {

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -12,6 +12,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
 from rasa.nlu.model import Metadata
 from rasa.nlu.training_data import Message
 from rasa.utils.common import raise_warning
+from rasa.utils.endpoints import concat_url
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +114,16 @@ class DucklingHTTPExtractor(EntityExtractor):
         }
 
     def _duckling_parse(self, text: Text, reference_time: int) -> List[Dict[Text, Any]]:
-        """Sends the request to the duckling server and parses the result."""
+        """Sends the request to the duckling server and parses the result.
 
-        parse_url = self._url() + "/parse"
+        Args:
+            text: Text for duckling server to parse.
+            reference_time: Reference time in milliseconds.
+
+        Returns:
+            JSON response from duckling server with parse data.
+        """
+        parse_url = concat_url(self._url(), "/parse")
         try:
             payload = self._payload(text, reference_time)
             headers = {

--- a/rasa/utils/endpoints.py
+++ b/rasa/utils/endpoints.py
@@ -1,11 +1,9 @@
+import aiohttp
 import logging
 import os
-
-import aiohttp
 from aiohttp.client_exceptions import ContentTypeError
-from typing import Any, Optional, Text, Dict
-
 from sanic.request import Request
+from typing import Any, Optional, Text, Dict
 
 import rasa.utils.io
 from rasa.constants import DEFAULT_REQUEST_TIMEOUT
@@ -44,14 +42,20 @@ def concat_url(base: Text, subpath: Optional[Text]) -> Text:
     Strips leading slashes from the subpath if necessary. This behaves
     differently than `urlparse.urljoin` and will not treat the subpath
     as a base url if it starts with `/` but will always append it to the
-    `base`."""
+    `base`.
 
+    Args:
+        base: Base URL.
+        subpath: Optional path to append to the base URL.
+
+    Returns:
+        Concatenated URL with base and subpath.
+    """
     if not subpath:
         if base.endswith("/"):
             logger.debug(
-                "The URL '{}' has a trailing slash. Please make sure the "
-                "target server supports trailing slashes for this "
-                "endpoint.".format(base)
+                f"The URL '{base}' has a trailing slash. Please make sure the "
+                f"target server supports trailing slashes for this endpoint."
             )
         return base
 

--- a/tests/utils/test_endpoints.py
+++ b/tests/utils/test_endpoints.py
@@ -15,6 +15,16 @@ import rasa.utils.endpoints as endpoint_utils
         ("https://example.com/", None, "https://example.com/"),
         ("https://example.com/", "test", "https://example.com/test"),
         ("https://example.com/", "test/", "https://example.com/test/"),
+        (
+            "http://duckling.rasa.com:8000",
+            "/parse",
+            "http://duckling.rasa.com:8000/parse",
+        ),
+        (
+            "http://duckling.rasa.com:8000/",
+            "/parse",
+            "http://duckling.rasa.com:8000/parse",
+        ),
     ],
 )
 def test_concat_url(base, subpath, expected_result):


### PR DESCRIPTION
**Proposed changes**:
- use concat_url instead of basic string concatenation to handle trailing slashes on the URL
- fix #5792

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
