### PR TITLE
Fix sed command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,7 +66,7 @@ Features
 
   The markdown format ``[LA](location:Los Angeles)`` is deprecated. To update your training data file just
   execute the following command on the terminal of your choice:
-  ``sed -i -E 's/\[([^]]*)\]\(([^:]*):([^)]*)\)/\[\1\]\{"entity": "\2", "value": "\3"\}/g' nlu.md``
+  ``sed -i -E 's/\[([^)]+)\]\(([^)]+):([^)]+)\)/[\1]{"entity": "\2", "value": "\3"}/g' nlu.md``
 
   For more information about the new data format see :ref:`training-data-format`.
 

--- a/docs/nlu/training-data-format.rst
+++ b/docs/nlu/training-data-format.rst
@@ -85,7 +85,7 @@ case-insensitive regex patterns that are added to the regex features.
     new format ``[savings account]{"entity": "source_account", "value": "savings"}``.
 
     To update your training data file execute the following command on the terminal of your choice:
-    ``sed -i -E 's/\[([^]]*)\]\(([^:]*):([^)]*)\)/\[\1\]\{"entity": "\2", "value": "\3"\}/g' <nlu training data file>``
+    ``sed -i -E 's/\[([^)]+)\]\(([^)]+):([^)]+)\)/[\1]{"entity": "\2", "value": "\3"}/g' <nlu training data file>``
     Your NLU training data file will contain the new training data format after you executed the above command.
     Depending on your OS you might need to update the syntax of the sed command.
 

--- a/rasa/nlu/training_data/formats/markdown.py
+++ b/rasa/nlu/training_data/formats/markdown.py
@@ -110,7 +110,7 @@ class MarkdownReader(TrainingDataReader):
                 '"<entity-synonym>"}.'
                 "\nYou can use the following command to update your training data file:"
                 "\nsed -i -E 's/\\[([^)]+)\\]\\(([^)]+):([^)]+)\\)/[\\1]{"
-                'entity": "\\2", "value": "\\3"}/g\' nlu.md',
+                '"entity": "\\2", "value": "\\3"}/g\' nlu.md',
                 category=FutureWarning,
                 docs=DOCS_URL_TRAINING_DATA_NLU,
             )

--- a/rasa/nlu/training_data/formats/markdown.py
+++ b/rasa/nlu/training_data/formats/markdown.py
@@ -109,8 +109,8 @@ class MarkdownReader(TrainingDataReader):
                 '[<entity-text>]{"entity": "<entity-type>", "value": '
                 '"<entity-synonym>"}.'
                 "\nYou can use the following command to update your training data file:"
-                "\nsed -i -E 's/\\[([^]]*)\\]\\(([^:]*):([^)]*)\\)/\\[\\1\\]\\{"
-                'entity": "\\2", "value": "\\3"\\}/g\' nlu.md',
+                "\nsed -i -E 's/\\[([^)]+)\\]\\(([^)]+):([^)]+)\\)/[\\1]{"
+                'entity": "\\2", "value": "\\3"}/g\' nlu.md',
                 category=FutureWarning,
                 docs=DOCS_URL_TRAINING_DATA_NLU,
             )


### PR DESCRIPTION
**Proposed changes**:
I've been trying the `sed` command for the new entities format on the following test file:
```markdown
Order something
Order [pizza](food) please
Order [pizza](food) in [Berlin](city) please
Order [döner](food:döner kebab) in [Berlin](city) please
Order [döner](food) in [Berlin](city:brn) please
Order [döner](food:döner kebab) in [Berlin](city:brn) please
```

The output is:
```bash
$ sed -E 's/\[([^]]*)\]\(([^:]*):([^)]*)\)/\[\1\]\{"entity": "\2", "value": "\3"\}/g' test.md 
Order something
Order [pizza](food) please
Order [pizza](food) in [Berlin](city) please
Order [döner]{"entity": "food", "value": "döner kebab"} in [Berlin](city) please
Order [döner]{"entity": "food) in [Berlin](city", "value": "brn"} please
Order [döner]{"entity": "food", "value": "döner kebab"} in [Berlin]{"entity": "city", "value": "brn"} please
```

Notice that the 5th line has the wrong format. I then updated the sed command to:
```bash
$ sed -E 's/\[([^)]+)\]\(([^)]+):([^)]+)\)/[\1]{"entity": "\2", "value": "\3"}/g' test.md 
Order something
Order [pizza](food) please
Order [pizza](food) in [Berlin](city) please
Order [döner]{"entity": "food", "value": "döner kebab"} in [Berlin](city) please
Order [döner](food) in [Berlin]{"entity": "city", "value": "brn"} please
Order [döner]{"entity": "food", "value": "döner kebab"} in [Berlin]{"entity": "city", "value": "brn"} please
```

So, the changes were:
- Remove escapes `\` from the substitution string as they're not needed on that side.
- Use `[^)]` instead of `[^:]` and `[^]]`.
- Use `+` instead of `*`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
