### PR TITLE
make sure Domain.fromDict(domain) doesn't change its input domain

### DIFF
--- a/changelog/5794.improvement.rst
+++ b/changelog/5794.improvement.rst
@@ -1,0 +1,3 @@
+Creating a ``Domain`` using ``Domain.fromDict`` can no longer alter the input dictionary.
+Previously, there could be problems when the input dictionary was re-used for other
+things after creating the ``Domain`` from it.

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -259,6 +259,8 @@ class Domain:
         # it is super important to sort the slots here!!!
         # otherwise state ordering is not consistent
         slots = []
+        # make a copy to not alter the input dictionary
+        slot_dict = copy.deepcopy(slot_dict)
         for slot_name in sorted(slot_dict):
             slot_class = Slot.resolve_by_type(slot_dict[slot_name].get("type"))
             if "type" in slot_dict[slot_name]:
@@ -332,6 +334,8 @@ class Domain:
         Returns:
             The intent properties to be stored in the domain.
         """
+        # make a copy to not alter the input argument
+        intents = copy.deepcopy(intents)
         intent_properties = {}
         duplicates = set()
         for intent in intents:

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -134,6 +134,7 @@ class Domain:
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Domain":
+        data = copy.deepcopy(data)
         utter_templates = cls.collect_templates(data.get("responses", {}))
         if "templates" in data:
             raise_warning(

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -134,7 +134,6 @@ class Domain:
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Domain":
-        data = copy.deepcopy(data)
         utter_templates = cls.collect_templates(data.get("responses", {}))
         if "templates" in data:
             raise_warning(

--- a/tests/core/test_domain.py
+++ b/tests/core/test_domain.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from pathlib import Path
 
@@ -802,3 +803,12 @@ slots: {}"""
     old_domain = Domain.from_yaml(old_yaml)
     new_domain = Domain.from_yaml(new_yaml)
     assert hash(old_domain) == hash(new_domain)
+
+
+def test_domain_from_dict_does_not_change_input():
+    path = DEFAULT_DOMAIN_PATH_WITH_SLOTS
+    input_before = io_utils.read_yaml(io_utils.read_file(path))
+    input_after = copy.deepcopy(input_before)
+
+    Domain.from_dict(input_after)
+    assert input_after == input_before

--- a/tests/core/test_domain.py
+++ b/tests/core/test_domain.py
@@ -681,8 +681,6 @@ def test_clean_domain_deprecated_templates():
 
 
 def test_add_knowledge_base_slots(default_domain):
-    import copy
-
     # don't modify default domain as it is used in other tests
     test_domain = copy.deepcopy(default_domain)
 
@@ -806,9 +804,26 @@ slots: {}"""
 
 
 def test_domain_from_dict_does_not_change_input():
-    path = DEFAULT_DOMAIN_PATH_WITH_SLOTS
-    input_before = io_utils.read_yaml(io_utils.read_file(path))
-    input_after = copy.deepcopy(input_before)
+    input_before = {
+        "intents": [
+            {"greet": {USE_ENTITIES_KEY: ["name"]}},
+            {"default": {IGNORE_ENTITIES_KEY: ["unrelated_recognized_entity"]}},
+            {"goodbye": {USE_ENTITIES_KEY: None}},
+            {"thank": {USE_ENTITIES_KEY: False}},
+            {"ask": {USE_ENTITIES_KEY: True}},
+            {"why": {USE_ENTITIES_KEY: []}},
+            "pure_intent",
+        ],
+        "entities": ["name", "unrelated_recognized_entity", "other"],
+        "slots": {"name": {"type": "text"}},
+        "responses": {
+            "utter_greet": [{"text": "hey there {name}!"}],
+            "utter_goodbye": [{"text": "goodbye 😢"}, {"text": "bye bye 😢"}],
+            "utter_default": [{"text": "default message"}],
+        },
+    }
 
+    input_after = copy.deepcopy(input_before)
     Domain.from_dict(input_after)
+
     assert input_after == input_before


### PR DESCRIPTION
**Proposed changes**:
Previously, in `rasa.core.domain.` `Domain.fromDict` and `Domain.__init__` could alter their inputs because of the way `Domain.collect_slots` and `Domain.collect_intent_properties` were implemented.
This PR makes sure these `collect` functions don't alter their inputs.

This is related to https://github.com/RasaHQ/rasa-x/pull/2669, which fixes an issue in Rasa X that was caused by such a domain dictionary alteration.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
