### PR TITLE
Keep clean_up_entities just for custom entity extractors

### DIFF
--- a/changelog/5755.bugfix.rst
+++ b/changelog/5755.bugfix.rst
@@ -1,0 +1,2 @@
+Remove ``clean_up_entities`` from extractors that extract pre-defined entities.
+Just keep the clean up method for entity extractors that extract custom entities.

--- a/rasa/nlu/extractors/duckling_http_extractor.py
+++ b/rasa/nlu/extractors/duckling_http_extractor.py
@@ -186,7 +186,6 @@ class DucklingHTTPExtractor(EntityExtractor):
             )
 
         extracted = self.add_extractor_name(extracted)
-        extracted = self.clean_up_entities(message, extracted)
         message.set(ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True)
 
     @classmethod

--- a/rasa/nlu/extractors/mitie_entity_extractor.py
+++ b/rasa/nlu/extractors/mitie_entity_extractor.py
@@ -141,7 +141,6 @@ class MitieEntityExtractor(EntityExtractor):
             mitie_feature_extractor,
         )
         extracted = self.add_extractor_name(ents)
-        extracted = self.clean_up_entities(message, extracted)
         message.set(ENTITIES, message.get(ENTITIES, []) + extracted, add_to_output=True)
 
     @classmethod

--- a/rasa/nlu/extractors/spacy_entity_extractor.py
+++ b/rasa/nlu/extractors/spacy_entity_extractor.py
@@ -32,7 +32,6 @@ class SpacyEntityExtractor(EntityExtractor):
         spacy_nlp = kwargs.get("spacy_nlp", None)
         doc = spacy_nlp(message.text)
         all_extracted = self.add_extractor_name(self.extract_entities(doc))
-        all_extracted = self.clean_up_entities(message, all_extracted)
         dimensions = self.component_config["dimensions"]
         extracted = SpacyEntityExtractor.filter_irrelevant_entities(
             all_extracted, dimensions


### PR DESCRIPTION
**Proposed changes**:
Fixes https://github.com/RasaHQ/rasa/issues/5755

Remove `clean_up_entities` from extractors that extract pre-defined entities. Just keep the clean up method for entity extractors that extract custom entities.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
