### PR TITLE
Don't set roles/groups to 'O'

### DIFF
--- a/changelog/5788.misc.rst
+++ b/changelog/5788.misc.rst
@@ -1,0 +1,1 @@
+Don't set roles and groups to ``O`` (nothing found) when constructing entities from model predictions.

--- a/rasa/nlu/extractors/extractor.py
+++ b/rasa/nlu/extractors/extractor.py
@@ -507,13 +507,13 @@ class EntityExtractor(Component):
                 ENTITY_ATTRIBUTE_TYPE
             ][idx]
 
-        if ENTITY_ATTRIBUTE_ROLE in tag_names:
+        if ENTITY_ATTRIBUTE_ROLE in tag_names and role_tag != NO_ENTITY_TAG:
             entity[ENTITY_ATTRIBUTE_ROLE] = role_tag
             if confidences is not None:
                 entity[ENTITY_ATTRIBUTE_CONFIDENCE_ROLE] = confidences[
                     ENTITY_ATTRIBUTE_ROLE
                 ][idx]
-        if ENTITY_ATTRIBUTE_GROUP in tag_names:
+        if ENTITY_ATTRIBUTE_GROUP in tag_names and group_tag != NO_ENTITY_TAG:
             entity[ENTITY_ATTRIBUTE_GROUP] = group_tag
             if confidences is not None:
                 entity[ENTITY_ATTRIBUTE_CONFIDENCE_GROUP] = confidences[

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -308,6 +308,12 @@ def test_clean_up_entities(
                 },
             ],
         ),
+        (
+            "Amsterdam",
+            {"entity": ["city"], "role": ["O"], "group": ["O"]},
+            None,
+            [{"entity": "city", "start": 0, "end": 9, "value": "Amsterdam"}],
+        ),
     ],
 )
 def test_convert_tags_to_entities(


### PR DESCRIPTION
**Proposed changes**:
Fixes https://github.com/RasaHQ/rasa/issues/5788

Don't set roles and groups to `O` (nothing found) when constructing entities from model predictions.


**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
