### PR TITLE
Fix Cert_URI Bug to string for Hangouts Channel

### DIFF
--- a/changelog/5808.bugfix.rst
+++ b/changelog/5808.bugfix.rst
@@ -1,0 +1,1 @@
+Changed to variable CERT_URI in hangouts.py to a string type

--- a/rasa/core/channels/hangouts.py
+++ b/rasa/core/channels/hangouts.py
@@ -14,9 +14,7 @@ from rasa.core.channels.channel import InputChannel, OutputChannel, UserMessage
 logger = logging.getLogger(__name__)
 
 CHANNEL_NAME = "hangouts"
-CERT_URI = (
-    "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com",
-)
+CERT_URI = "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com"
 
 
 class HangoutsOutput(OutputChannel):


### PR DESCRIPTION
**Proposed changes**:
-  Changed the CERT_URI in hangouts.py to a string.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [**Fixed this error** traceback (most recent call last):
```
  File "/home/ec2-user/.local/lib/python3.6/site-packages/sanic/app.py", line 976, in handle_request
    response = await response
  File "/home/ec2-user/.local/lib/python3.6/site-packages/rasa/core/channels/hangouts.py", line 280, in receive
    self._check_token(token)
  File "/home/ec2-user/.local/lib/python3.6/site-packages/rasa/core/channels/hangouts.py", line 257, in _check_token
    bot_token, self.project_id, cert_uri=CERT_URI,
  File "/home/ec2-user/.local/lib/python3.6/site-packages/oauth2client/_helpers.py", line 133, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/home/ec2-user/.local/lib/python3.6/site-packages/oauth2client/client.py", line 1556, in verify_id_token
    resp, content = transport.request(http, cert_uri)
  File "/home/ec2-user/.local/lib/python3.6/site-packages/oauth2client/transport.py", line 282, in request
    connection_type=connection_type)
  File "/home/ec2-user/.local/lib/python3.6/site-packages/httplib2/__init__.py", line 1794, in request
    (scheme, authority, request_uri, defrag_uri) = urlnorm(uri)
  File "/home/ec2-user/.local/lib/python3.6/site-packages/httplib2/__init__.py", line 241, in urlnorm
    (scheme, authority, path, query, fragment) = parse_uri(uri)
  File "/home/ec2-user/.local/lib/python3.6/site-packages/httplib2/__init__.py", line 236, in parse_uri
    groups = URI.match(uri).groups()
TypeError: expected string or bytes-like object ] 
```
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
