### PR TITLE
Fix shell skips button messages

### DIFF
--- a/changelog/5135.bugfix.rst
+++ b/changelog/5135.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Rasa shell skipping button messages if buttons are attached to a message previous to the latest.

--- a/rasa/core/channels/console.py
+++ b/rasa/core/channels/console.py
@@ -70,7 +70,7 @@ def print_bot_output(
         cli_utils.print_color(json.dumps(message.get("custom"), indent=2), color=color)
 
 
-def get_user_input(previous_response: Dict[str, Any]) -> Optional[Text]:
+def get_user_input(previous_response: Optional[Dict[str, Any]]) -> Optional[Text]:
     button_response = None
     if previous_response is not None:
         button_response = print_bot_output(previous_response, is_last=True)

--- a/rasa/core/channels/console.py
+++ b/rasa/core/channels/console.py
@@ -1,14 +1,15 @@
 # this builtin is needed so we can overwrite in test
+import asyncio
 import json
 import logging
-import asyncio
 import os
-from typing import Text, Optional, Dict, List
 
 import aiohttp
 import questionary
 from aiohttp import ClientTimeout
 from prompt_toolkit.styles import Style
+from typing import Any
+from typing import Text, Optional, Dict, List
 
 from rasa.cli import utils as cli_utils
 from rasa.core import utils
@@ -16,7 +17,6 @@ from rasa.core.channels.channel import RestInput
 from rasa.core.constants import DEFAULT_SERVER_URL
 from rasa.core.interpreter import INTENT_MESSAGE_PREFIX
 from rasa.utils.io import DEFAULT_ENCODING
-from typing import Any, Coroutine
 
 logger = logging.getLogger(__name__)
 
@@ -25,18 +25,9 @@ DEFAULT_STREAM_READING_TIMEOUT_IN_SECONDS = 10
 
 
 def print_bot_output(
-    message: Dict[Text, Any], color=cli_utils.bcolors.OKBLUE
+    message: Dict[Text, Any], is_last=False, color=cli_utils.bcolors.OKBLUE
 ) -> Optional[questionary.Question]:
-    if ("text" in message) and not ("buttons" in message):
-        cli_utils.print_color(message.get("text"), color=color)
-
-    if "image" in message:
-        cli_utils.print_color("Image: " + message.get("image"), color=color)
-
-    if "attachment" in message:
-        cli_utils.print_color("Attachment: " + message.get("attachment"), color=color)
-
-    if "buttons" in message:
+    if "buttons" in message and is_last:
         choices = cli_utils.button_choices_from_message_data(
             message, allow_free_text_input=True
         )
@@ -47,6 +38,20 @@ def print_bot_output(
             style=Style([("qmark", "#6d91d3"), ("", "#6d91d3"), ("answer", "#b373d6")]),
         )
         return question
+
+    if "text" in message:
+        cli_utils.print_color(message.get("text"), color=color)
+
+    if "image" in message:
+        cli_utils.print_color("Image: " + message.get("image"), color=color)
+
+    if "attachment" in message:
+        cli_utils.print_color("Attachment: " + message.get("attachment"), color=color)
+
+    if "buttons" in message:
+        cli_utils.print_color("Buttons:", color=color)
+        for idx, button in enumerate(message.get("buttons")):
+            cli_utils.print_color(cli_utils.button_to_string(button, idx), color=color)
 
     if "elements" in message:
         cli_utils.print_color("Elements:", color=color)
@@ -65,12 +70,16 @@ def print_bot_output(
         cli_utils.print_color(json.dumps(message.get("custom"), indent=2), color=color)
 
 
-def get_user_input(button_question: questionary.Question) -> Optional[Text]:
-    if button_question is not None:
-        response = cli_utils.payload_from_button_question(button_question)
+def get_user_input(previous_response: Dict[str, Any]) -> Optional[Text]:
+    button_response = None
+    if previous_response is not None:
+        button_response = print_bot_output(previous_response, is_last=True)
+
+    if button_response is not None:
+        response = cli_utils.payload_from_button_question(button_response)
         if response == cli_utils.FREE_TEXT_INPUT_PROMPT:
             # Re-prompt user with a free text input
-            response = get_user_input(None)
+            response = get_user_input({})
     else:
         response = questionary.text(
             "",
@@ -136,10 +145,10 @@ async def record_messages(
     )
 
     num_messages = 0
-    button_question = None
+    previous_response = None
     await asyncio.sleep(0.5)  # Wait for server to start
     while not utils.is_limit_reached(num_messages, max_message_limit):
-        text = get_user_input(button_question)
+        text = get_user_input(previous_response)
 
         if text == exit_text or text is None:
             break
@@ -148,14 +157,20 @@ async def record_messages(
             bot_responses = send_message_receive_stream(
                 server_url, auth_token, sender_id, text
             )
+            previous_response = None
             async for response in bot_responses:
-                button_question = print_bot_output(response)
+                if previous_response is not None:
+                    print_bot_output(previous_response)
+                previous_response = response
         else:
             bot_responses = await send_message_receive_block(
                 server_url, auth_token, sender_id, text
             )
+            previous_response = None
             for response in bot_responses:
-                button_question = print_bot_output(response)
+                if previous_response is not None:
+                    print_bot_output(response)
+                previous_response = response
 
         num_messages += 1
         await asyncio.sleep(0)  # Yield event loop for others coroutines

--- a/tests/core/channels/test_cmdline.py
+++ b/tests/core/channels/test_cmdline.py
@@ -1,0 +1,111 @@
+from typing import List, Text
+
+from _pytest.capture import CaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
+from prompt_toolkit import PromptSession, Application
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+from rasa.core.channels.console import record_messages
+
+from aioresponses import aioresponses
+
+ENTER = "\x0a"
+
+
+def mock_stdin(input_from_stdin: List[Text]):
+    inp = create_pipe_input()
+
+    text = ""
+    for line in input_from_stdin:
+        text += line + ENTER + "\r"
+
+    inp.send_text(text)
+
+    prompt_session_init = PromptSession.__init__
+
+    def prompt_session_init_fake(self, *k, **kw):
+        prompt_session_init(self, input=inp, output=DummyOutput(), *k, **kw)
+
+    PromptSession.__init__ = prompt_session_init_fake
+
+    application_init = Application.__init__
+
+    def application_init_fake(self, *k, **kw):
+        kw.pop("input", None)
+        kw.pop("output", None)
+        application_init(self, input=inp, output=DummyOutput(), *k, **kw)
+
+    Application.__init__ = application_init_fake
+
+    return inp
+
+
+async def test_record_messages(monkeypatch: MonkeyPatch, capsys: CaptureFixture):
+    input_output = [
+        {
+            "in": "Give me a question!",
+            "out": [
+                {
+                    "buttons": [
+                        {
+                            "title": "button 1 title",
+                            "payload": "button 1 payload",
+                            "details": "button 1 details",
+                        }
+                    ],
+                    "text": "This is a button 1",
+                },
+                {
+                    "buttons": [
+                        {
+                            "title": "button 2 title",
+                            "payload": "button 2 payload",
+                            "details": "button 2 details",
+                        }
+                    ],
+                    "text": "This is a button 2",
+                },
+                {
+                    "buttons": [
+                        {
+                            "title": "button 3 title",
+                            "payload": "button 3 payload",
+                            "details": "button 3 details",
+                        }
+                    ],
+                    "text": "This is a button 3",
+                },
+            ],
+        },
+        {"in": ENTER, "out": [{"text": "You've pressed the button"}]},
+        {"in": "Dummy message", "out": [{"text": "Dummy response"}]},
+    ]
+
+    inp = mock_stdin([m["in"] for m in input_output])
+
+    server_url = "http://example.com"
+    endpoint = f"{server_url}/webhooks/rest/webhook"
+
+    with aioresponses() as mocked:
+
+        for output in [m["out"] for m in input_output]:
+            if output:
+                mocked.post(
+                    url=endpoint, payload=output,
+                )
+
+        num_of_messages = await record_messages(
+            "123",
+            server_url=server_url,
+            max_message_limit=len(input_output),
+            use_response_stream=False,
+        )
+
+        assert num_of_messages == len(input_output)
+
+    captured = capsys.readouterr()
+
+    assert "button 1 payload" in captured.out
+    assert "button 2 payload" in captured.out
+
+    inp.close()


### PR DESCRIPTION
Closes #3856

**Proposed changes**:
- `rasa shell` now prints buttons-message in the console channel even if they were immediately followed by other buttons

Originally community change: #5135 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
