### PR TITLE
Minor docs fix for Action Selection

### DIFF
--- a/docs/core/policies.rst
+++ b/docs/core/policies.rst
@@ -148,7 +148,7 @@ expected outcome in the case of a tie. They look like this, where higher numbers
     | 4. ``FallbackPolicy`` and ``TwoStageFallbackPolicy``
     | 3. ``MemoizationPolicy`` and ``AugmentedMemoizationPolicy``
     | 2. ``MappingPolicy``
-    | 1. ``TEDPolicy`` and ``KerasPolicy``
+    | 1. ``TEDPolicy``, ``EmbeddingPolicy`` and ``KerasPolicy``
 
 This priority hierarchy ensures that, for example, if there is an intent with a mapped action, but the NLU confidence is not
 above the ``nlu_threshold``, the bot will still fall back. In general, it is not recommended to have more

--- a/docs/core/policies.rst
+++ b/docs/core/policies.rst
@@ -148,7 +148,7 @@ expected outcome in the case of a tie. They look like this, where higher numbers
     | 4. ``FallbackPolicy`` and ``TwoStageFallbackPolicy``
     | 3. ``MemoizationPolicy`` and ``AugmentedMemoizationPolicy``
     | 2. ``MappingPolicy``
-    | 1. ``TEDPolicy``, ``EmbeddingPolicy``, ``KerasPolicy``, and ``SklearnPolicy``
+    | 1. ``TEDPolicy`` and ``KerasPolicy``
 
 This priority hierarchy ensures that, for example, if there is an intent with a mapped action, but the NLU confidence is not
 above the ``nlu_threshold``, the bot will still fall back. In general, it is not recommended to have more


### PR DESCRIPTION
I've made a small change to the docs [here](https://rasa.com/docs/rasa/core/policies/#action-selection). 

![image](https://user-images.githubusercontent.com/1019791/82197021-bdb19800-98fa-11ea-9d98-3281aad7a5b1.png)

My impression is that the `SklearnPolicy` is not really supported and it is also not documented so it should not be listed. 

I've also removed `EmbeddingPolicy` because we now favor TED. 