### PR TITLE
migrate all events with rasa export

### DIFF
--- a/changelog/5758.bugfix.rst
+++ b/changelog/5758.bugfix.rst
@@ -1,4 +1,4 @@
 Fixed a bug in
 `rasa export <https://rasa.com/docs/rasa-x/installation-and-setup/existing-deployment/#migrate-conversations>`_
-which caused Rasa Open Source to only migrate conversation events from the last
-:ref:`session_config`.
+ (:ref:`section_export`) which caused Rasa Open Source to only migrate conversation
+events from the last :ref:`session_config`.

--- a/changelog/5758.bugfix.rst
+++ b/changelog/5758.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug in
+`rasa export <https://rasa.com/docs/rasa-x/installation-and-setup/existing-deployment/#migrate-conversations>`_
+which caused Rasa Open Source to only migrate conversation events from the last
+:ref:`session_config`.

--- a/rasa/core/exporter.py
+++ b/rasa/core/exporter.py
@@ -49,6 +49,10 @@ class Exporter:
     ) -> None:
         self.endpoints_path = endpoints_path
         self.tracker_store = tracker_store
+        # The `TrackerStore` should return all events on `retrieve` and not just the
+        # ones from the last session.
+        self.tracker_store.load_events_from_previous_conversation_sessions = True
+
         self.event_broker = event_broker
         self.requested_conversation_ids = requested_conversation_ids
         self.minimum_timestamp = minimum_timestamp
@@ -142,7 +146,7 @@ class Exporter:
         )
 
     def _validate_all_requested_ids_exist(
-        self, conversation_ids_in_tracker_store: Set[Text],
+        self, conversation_ids_in_tracker_store: Set[Text]
     ) -> None:
         """Warn user if `self.requested_conversation_ids` contains IDs not found in
         `conversation_ids_in_tracker_store`

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -56,11 +56,28 @@ class TrackerStore:
     """Class to hold all of the TrackerStore classes"""
 
     def __init__(
-        self, domain: Optional[Domain], event_broker: Optional[EventBroker] = None
+        self,
+        domain: Optional[Domain],
+        event_broker: Optional[EventBroker] = None,
+        retrieve_events_from_previous_conversation_sessions: bool = False,
     ) -> None:
+        """Create a TrackerStore.
+
+        Args:
+            domain: The `Domain` to initialize the `DialogueStateTracker`.
+            event_broker: An event broker to publish any new events to another
+                destination.
+            retrieve_events_from_previous_conversation_sessions: If `True`, `retrieve`
+                will return all events (even if they are from a previous conversation
+                session). This setting only applies to `TrackerStore`s which usually
+                would only return events for the latest session.
+        """
         self.domain = domain
         self.event_broker = event_broker
         self.max_event_history = None
+        self.load_events_from_previous_conversation_sessions = (
+            retrieve_events_from_previous_conversation_sessions
+        )
 
     @staticmethod
     def create(
@@ -488,8 +505,9 @@ class MongoTrackerStore(TrackerStore):
         """
 
         stored = self.conversations.find_one({"sender_id": tracker.sender_id}) or {}
+        all_events = self._events_from_serialized_tracker(stored)
         number_events_since_last_session = len(
-            self._events_since_last_session_start(stored)
+            self._events_since_last_session_start(all_events)
         )
 
         return itertools.islice(
@@ -497,11 +515,15 @@ class MongoTrackerStore(TrackerStore):
         )
 
     @staticmethod
-    def _events_since_last_session_start(serialised_tracker: Dict) -> List[Dict]:
+    def _events_from_serialized_tracker(serialised: Dict) -> List[Dict]:
+        return serialised.get("events", [])
+
+    @staticmethod
+    def _events_since_last_session_start(events: List[Dict]) -> List[Dict]:
         """Retrieve events since and including the latest `SessionStart` event.
 
         Args:
-            serialised_tracker: Serialised tracker to inspect.
+            events: All events for a conversation ID.
 
         Returns:
             List of serialised events since and including the latest `SessionStarted`
@@ -509,15 +531,15 @@ class MongoTrackerStore(TrackerStore):
 
         """
 
-        events = []
-        for event in reversed(serialised_tracker.get("events", [])):
-            events.append(event)
+        events_after_session_start = []
+        for event in reversed(events):
+            events_after_session_start.append(event)
             if event["event"] == SessionStarted.type_name:
                 break
 
-        return list(reversed(events))
+        return list(reversed(events_after_session_start))
 
-    def retrieve(self, sender_id):
+    def retrieve(self, sender_id: Text) -> Optional[DialogueStateTracker]:
         """
         Args:
             sender_id: the message owner ID
@@ -529,7 +551,7 @@ class MongoTrackerStore(TrackerStore):
 
         # look for conversations which have used an `int` sender_id in the past
         # and update them.
-        if stored is None and sender_id.isdigit():
+        if not stored and sender_id.isdigit():
             from pymongo import ReturnDocument
 
             stored = self.conversations.find_one_and_update(
@@ -538,11 +560,14 @@ class MongoTrackerStore(TrackerStore):
                 return_document=ReturnDocument.AFTER,
             )
 
-        if stored is not None:
-            events = self._events_since_last_session_start(stored)
-            return DialogueStateTracker.from_dict(sender_id, events, self.domain.slots)
-        else:
-            return None
+        if not stored:
+            return
+
+        events = self._events_from_serialized_tracker(stored)
+        if not self.load_events_from_previous_conversation_sessions:
+            events = self._events_since_last_session_start(events)
+
+        return DialogueStateTracker.from_dict(sender_id, events, self.domain.slots)
 
     def keys(self) -> Iterable[Text]:
         """Returns sender_ids of the Mongo Tracker Store"""
@@ -688,7 +713,7 @@ class SQLTrackerStore(TrackerStore):
         while True:
             try:
                 self.engine = sa.engine.create_engine(
-                    engine_url, **create_engine_kwargs(engine_url),
+                    engine_url, **create_engine_kwargs(engine_url)
                 )
                 # if `login_db` has been provided, use current channel with
                 # that database to create working database `db`
@@ -869,19 +894,20 @@ class SQLTrackerStore(TrackerStore):
             .subquery()
         )
 
-        return (
-            session.query(self.SQLEvent)
-            .filter(
-                self.SQLEvent.sender_id == sender_id,
+        event_query = session.query(self.SQLEvent).filter(
+            self.SQLEvent.sender_id == sender_id
+        )
+        if not self.load_events_from_previous_conversation_sessions:
+            event_query = event_query.filter(
                 # Find events after the latest `SessionStarted` event or return all
                 # events
                 sa.or_(
                     self.SQLEvent.timestamp >= session_start_sub_query.c.session_start,
                     session_start_sub_query.c.session_start.is_(None),
-                ),
+                )
             )
-            .order_by(self.SQLEvent.timestamp)
-        )
+
+        return event_query.order_by(self.SQLEvent.timestamp)
 
     def save(self, tracker: DialogueStateTracker) -> None:
         """Update database with events from the current conversation."""

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -18,10 +18,7 @@ from typing import Tuple, Text, Type, Dict, List, Union, Optional, ContextManage
 from unittest.mock import Mock
 
 import rasa.core.tracker_store
-from rasa.core.actions.action import (
-    ACTION_LISTEN_NAME,
-    ACTION_SESSION_START_NAME,
-)
+from rasa.core.actions.action import ACTION_LISTEN_NAME, ACTION_SESSION_START_NAME
 from rasa.core.channels.channel import UserMessage
 from rasa.core.constants import POSTGRESQL_SCHEMA
 from rasa.core.domain import Domain
@@ -612,6 +609,38 @@ def test_tracker_store_retrieve_without_session_started_events(
     assert all(event == tracker.events[i] for i, event in enumerate(events))
 
 
+@pytest.mark.parametrize(
+    "tracker_store_type,tracker_store_kwargs",
+    [
+        (MockedMongoTrackerStore, {}),
+        (SQLTrackerStore, {"host": "sqlite:///"}),
+        (InMemoryTrackerStore, {}),
+    ],
+)
+def test_tracker_store_retrieve_with_events_from_previous_sessions(
+    tracker_store_type: Type[TrackerStore], tracker_store_kwargs: Dict
+):
+    tracker_store = tracker_store_type(Domain.empty(), **tracker_store_kwargs)
+    tracker_store.load_events_from_previous_conversation_sessions = True
+
+    conversation_id = uuid.uuid4().hex
+    tracker = DialogueStateTracker.from_events(
+        conversation_id,
+        [
+            ActionExecuted(ACTION_SESSION_START_NAME),
+            SessionStarted(),
+            UserUttered("hi"),
+            ActionExecuted(ACTION_SESSION_START_NAME),
+            SessionStarted(),
+        ],
+    )
+    tracker_store.save(tracker)
+
+    actual = tracker_store.retrieve(conversation_id)
+
+    assert len(actual.events) == len(tracker.events)
+
+
 def test_session_scope_error(
     monkeypatch: MonkeyPatch, capsys: CaptureFixture, default_domain: Domain
 ):
@@ -623,7 +652,7 @@ def test_session_scope_error(
     # `ensure_schema_exists()` raises `ValueError`
     mocked_ensure_schema_exists = Mock(side_effect=ValueError(requested_schema))
     monkeypatch.setattr(
-        rasa.core.tracker_store, "ensure_schema_exists", mocked_ensure_schema_exists,
+        rasa.core.tracker_store, "ensure_schema_exists", mocked_ensure_schema_exists
     )
 
     # `SystemExit` is triggered by failing `ensure_schema_exists()`


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/5787
- add a variable `load_events_from_previous_conversation_sessions` to each `TrackerStore`. The `Exporter` can use this to explicitly disable session queries for `TrackerStore`s

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
