### PR TITLE
Start a server with your NLU model with "rasa run"

### DIFF
--- a/docs/migrate-from/google-dialogflow-to-rasa.rst
+++ b/docs/migrate-from/google-dialogflow-to-rasa.rst
@@ -97,7 +97,7 @@ To start a server with your NLU model, run:
 
 .. code-block:: bash
 
-   rasa run nlu
+   rasa run
 
 This will start a server listening on port 5005.
 


### PR DESCRIPTION
**Proposed changes**: Documentation update

```bash
rasa run nlu
```
throw
```
rasa run: error: invalid choice: 'nlu' (choose from 'actions')
```

so i suggested
```bash
rasa run
```

Which works