### PR TITLE
add up and ready server log

### DIFF
--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -190,8 +190,7 @@ def serve_application(
     protocol = "https" if ssl_context else "http"
 
     logger.info(
-        "Starting Rasa server on "
-        "{}".format(constants.DEFAULT_SERVER_FORMAT.format(protocol, port))
+        f"Starting Rasa server on {constants.DEFAULT_SERVER_FORMAT.format(protocol, port)}"
     )
 
     app.register_listener(

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -272,6 +272,7 @@ async def load_agent_on_start(
             remote_storage=remote_storage,
         )
 
+    logger.info("Rasa server is up and running.")
     return app.agent
 
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -23,7 +23,8 @@ from rasa.constants import (
     DOCS_BASE_URL,
     MINIMUM_COMPATIBLE_VERSION,
 )
-from rasa.core.agent import Agent, load_agent
+from rasa.core import agent
+from rasa.core.agent import Agent
 from rasa.core.brokers.broker import EventBroker
 from rasa.core.channels.channel import (
     CollectingOutputChannel,
@@ -333,7 +334,7 @@ async def _load_agent(
             if not lock_store:
                 lock_store = LockStore.create(endpoints.lock_store)
 
-        loaded_agent = await load_agent(
+        loaded_agent = await agent.load_agent(
             model_path,
             model_server,
             remote_storage,


### PR DESCRIPTION
**Proposed changes**:
- add a log that tells the user when the server is up and ready. This is helpful because sometimes the loading of the model takes a while, and one can't tell when the server is ready to accept HTTP requests. These were part of rasa and rasa-sdk before we moved to sanic: https://github.com/RasaHQ/rasa_core/blob/0.14.0/rasa_core/run.py#L120

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
