### PR TITLE
retry on PermissionError during data export

### DIFF
--- a/changelog/5921.bugfix.md
+++ b/changelog/5921.bugfix.md
@@ -1,0 +1,1 @@
+Allow user to retry failed file exports in interactive training.

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -606,9 +606,9 @@ async def _write_data_to_file(conversation_id: Text, endpoint: EndpointConfig):
     serialised_domain = await retrieve_domain(endpoint)
     domain = Domain.from_dict(serialised_domain)
 
-    await _retry_on_error(_write_stories_to_file, story_path, events, domain)
-    await _retry_on_error(_write_nlu_to_file, nlu_path, events)
-    await _retry_on_error(_write_domain_to_file, domain_path, events, domain)
+    _retry_on_error(_write_stories_to_file, story_path, events, domain)
+    _retry_on_error(_write_nlu_to_file, nlu_path, events)
+    _retry_on_error(_write_domain_to_file, domain_path, events, domain)
 
     logger.info("Successfully wrote stories and NLU data")
 

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -580,6 +580,21 @@ def _slot_history(tracker_dump: Dict[Text, Any]) -> List[Text]:
     return slot_strings
 
 
+async def _retry_on_error(
+    func: Callable, export_path: Text, *args: Any, **kwargs: Any
+) -> None:
+    while True:
+        try:
+            return func(export_path, *args, **kwargs)
+        except OSError as e:
+            answer = questionary.confirm(
+                f"Failed to export '{export_path}': {e}. Please make sure 'rasa' "
+                f"has read and write access to this file. Would you like to retry?"
+            ).ask()
+            if not answer:
+                raise e
+
+
 async def _write_data_to_file(conversation_id: Text, endpoint: EndpointConfig):
     """Write stories and nlu data to file."""
 
@@ -591,9 +606,9 @@ async def _write_data_to_file(conversation_id: Text, endpoint: EndpointConfig):
     serialised_domain = await retrieve_domain(endpoint)
     domain = Domain.from_dict(serialised_domain)
 
-    _write_stories_to_file(story_path, events, domain)
-    _write_nlu_to_file(nlu_path, events)
-    _write_domain_to_file(domain_path, events, domain)
+    await _retry_on_error(_write_stories_to_file, story_path, events, domain)
+    await _retry_on_error(_write_nlu_to_file, nlu_path, events)
+    await _retry_on_error(_write_domain_to_file, domain_path, events, domain)
 
     logger.info("Successfully wrote stories and NLU data")
 

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -580,7 +580,7 @@ def _slot_history(tracker_dump: Dict[Text, Any]) -> List[Text]:
     return slot_strings
 
 
-async def _retry_on_error(
+def _retry_on_error(
     func: Callable, export_path: Text, *args: Any, **kwargs: Any
 ) -> None:
     while True:

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -644,7 +644,7 @@ def test_retry_on_error(monkeypatch: MonkeyPatch):
     monkeypatch.setattr(interactive.questionary, "confirm", QuestionaryConfirmMock(3))
 
     m = Mock(return_value=None)
-    await interactive._retry_on_error(m, "export_path", 1, a=2)
+    interactive._retry_on_error(m, "export_path", 1, a=2)
     m.assert_called_once_with("export_path", 1, a=2)
 
     m = Mock(side_effect=PermissionError())

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -626,7 +626,7 @@ async def test_not_getting_trackers_when_skipping_visualization(
     get_trackers.assert_not_called()
 
 
-async def test_retry_on_error(monkeypatch: MonkeyPatch):
+def test_retry_on_error(monkeypatch: MonkeyPatch):
     class QuestionaryConfirmMock:
         def __init__(self, tries: int) -> None:
             self.tries = tries


### PR DESCRIPTION
**Proposed changes**:
- handle PermissionError on file export during interactive training and allow the user the retry
- addresses https://github.com/RasaHQ/rasa/issues/5921

I did not catch the error at the higher level, because then the individual files could not be retried and inconsistent data (like double appends) would be unavoidable.

This is my first pull request for this project. It would be great to have some feedback.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
