### PR TITLE
Fixed a bug with duplicated SessionStarted event

### DIFF
--- a/changelog/5964.bugfix.rst
+++ b/changelog/5964.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug when custom metadata passed with the utterance always restarted the session.

--- a/docs/api/rasa-sdk.rst
+++ b/docs/api/rasa-sdk.rst
@@ -158,7 +158,7 @@ slots, but only a user's name and their phone number. To do that, you'd override
       ) -> List[EventType]:
 
           # the session should begin with a `session_started` event
-          events = [SessionStarted()]
+          _events = [SessionStarted(metadata=self.metadata)]
 
           # any slots that should be carried over should come after the
           # `session_started` event

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -352,6 +352,9 @@ class ActionSessionStart(Action):
     session.
     """
 
+    # Optional arbitrary metadata that can be passed to the SessionStarted event.
+    metadata: Optional[Dict[Text, Any]] = None
+
     def name(self) -> Text:
         return ACTION_SESSION_START_NAME
 
@@ -378,7 +381,7 @@ class ActionSessionStart(Action):
     ) -> List[Event]:
         from rasa.core.events import SessionStarted
 
-        _events = [SessionStarted()]
+        _events = [SessionStarted(metadata=self.metadata)]
 
         if domain.session_config.carry_over_slots:
             _events.extend(self._slot_set_events_from_tracker(tracker))

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -172,14 +172,12 @@ class MessageProcessor:
                 f"Starting a new session for conversation ID '{tracker.sender_id}'."
             )
 
-            if metadata:
-                tracker.events.append(SessionStarted(metadata=metadata))
-
             await self._run_action(
                 action=self._get_action(ACTION_SESSION_START_NAME),
                 tracker=tracker,
                 output_channel=output_channel,
                 nlg=self.nlg,
+                metadata=metadata,
             )
 
     async def get_tracker_with_session_start(
@@ -636,11 +634,22 @@ class MessageProcessor:
                         scheduler.remove_job(scheduled_job.id)
 
     async def _run_action(
-        self, action, tracker, output_channel, nlg, policy=None, confidence=None
+        self,
+        action,
+        tracker,
+        output_channel,
+        nlg,
+        policy=None,
+        confidence=None,
+        metadata: Optional[Dict[Text, Any]] = None,
     ) -> bool:
         # events and return values are used to update
         # the tracker state after an action has been taken
         try:
+            # Here we set optional metadata to the ActionSessionStart, which will then
+            # be passed to the SessionStart event. Otherwise the metadata will be lost.
+            if action.name() == ACTION_SESSION_START_NAME:
+                action.metadata = metadata
             events = await action.run(output_channel, nlg, tracker, self.domain)
         except ActionExecutionRejection:
             events = [ActionExecutionRejected(action.name(), policy, confidence)]

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -505,12 +505,15 @@ async def test_update_tracker_session_with_metadata(
     # the save is not called in _update_tracker_session()
     default_processor._save_tracker(tracker)
 
-    # inspect tracker events and make sure SessionStarted event is present and has metadata.
+    # inspect tracker events and make sure SessionStarted event is present
+    # and has metadata.
     tracker = default_processor.tracker_store.retrieve(sender_id)
-    session_event_idx = tracker.events.index(SessionStarted())
-    session_event_metadata = tracker.events[session_event_idx].metadata
+    assert tracker.events.count(SessionStarted()) == 1
 
-    assert session_event_metadata == metadata
+    session_started_event_idx = tracker.events.index(SessionStarted())
+    session_started_event_metadata = tracker.events[session_started_event_idx].metadata
+
+    assert session_started_event_metadata == metadata
 
 
 # noinspection PyProtectedMember


### PR DESCRIPTION
Fixes #5964 

**Proposed changes**:

- Custom metadata was restarting the session
- Not the situation is handled properly

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
