### PR TITLE
Fix type annotation error in train function

### DIFF
--- a/rasa/train.py
+++ b/rasa/train.py
@@ -21,7 +21,7 @@ from rasa.constants import DEFAULT_MODELS_PATH, DEFAULT_CORE_SUBDIRECTORY_NAME
 
 
 def train(
-    domain: Text,
+    domain: Union[Domain, Text],
     config: Text,
     training_files: Union[Text, List[Text]],
     output: Text = DEFAULT_MODELS_PATH,


### PR DESCRIPTION

**Proposed changes**:

The `train` expect `domain` type to be `Text`, but then passes that to `train_async` which permits `Domain` type. I need to pass in `Domain.empty()` for nlu training without a domain, but this is restricting me from passing that object to `train` function.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
