### PR TITLE
Fix issue with rasa.data.is_story_file where NLU training files were passing check

### DIFF
--- a/changelog/5992.bugfix.md
+++ b/changelog/5992.bugfix.md
@@ -1,0 +1,1 @@
+Fix `rasa.data.is_story_file` check whereby Markdown files in NLU training data format were passing this check. Now only story files will pass this check.

--- a/changelog/5992.bugfix.md
+++ b/changelog/5992.bugfix.md
@@ -1,1 +1,0 @@
-Fix `rasa.data.is_story_file` check whereby Markdown files in NLU training data format were passing this check. Now only story files will pass this check.

--- a/changelog/5992.bugfix.rst
+++ b/changelog/5992.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``rasa.data.is_story_file`` check whereby Markdown files in NLU training data format were passing this check. Now only story files will pass this check.

--- a/rasa/data.py
+++ b/rasa/data.py
@@ -168,7 +168,7 @@ def is_story_file(file_path: Text) -> bool:
 
 
 def _contains_story_pattern(text: Text) -> bool:
-    story_pattern = r".*##.+"
+    story_pattern = r".*##(?!.*(?:intent|synonym|regex|lookup):).+"
 
     return re.match(story_pattern, text) is not None
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -31,3 +31,16 @@ def test_story_file_with_minimal_story_is_story_file(tmpdir: Path):
 def test_default_story_files_are_story_files():
     for fn in glob.glob(os.path.join("data", "test_stories", "*")):
         assert is_story_file(fn)
+
+
+def test_nlu_file_is_not_story_file(tmpdir: Path):
+    nlu_path = tmpdir / "nlu.md"
+    nlu_data = """
+## intent: greet
+- hello
+- hi
+- hallo
+    """
+    write_text_file(nlu_data, nlu_path)
+
+    assert not is_story_file(str(nlu_path))


### PR DESCRIPTION
**Proposed changes**:
- Updates the `_contains_story_pattern` regex to be more specific and checks for NLU training data formats.

Fixes #5992.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
