### PR TITLE
Remove 'clean_up_entities' from DIETClassifier and CRFEntityExtractor

### DIFF
--- a/changelog/5972.bugfix.rst
+++ b/changelog/5972.bugfix.rst
@@ -1,0 +1,2 @@
+Remove the ``clean_up_entities`` method from the ``DIETClassifier`` and ``CRFEntityExtractor`` as it let to incorrect
+entity predictions.

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -803,7 +803,6 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
         )
 
         entities = self.add_extractor_name(entities)
-        entities = self.clean_up_entities(message, entities)
         entities = message.get(ENTITIES, []) + entities
 
         return entities

--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -195,7 +195,6 @@ class CRFEntityExtractor(EntityExtractor):
     def process(self, message: Message, **kwargs: Any) -> None:
         entities = self.extract_entities(message)
         entities = self.add_extractor_name(entities)
-        entities = self.clean_up_entities(message, entities)
         message.set(ENTITIES, message.get(ENTITIES, []) + entities, add_to_output=True)
 
     def extract_entities(self, message: Message) -> List[Dict[Text, Any]]:


### PR DESCRIPTION
**Proposed changes**:
- fixes https://github.com/RasaHQ/rasa/issues/5972

Remove `clean_up_entities` from the `DIETClassifier` and the `CRFEntityExtractor` as the method let to incorrect entity predictions.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
