### PR TITLE
Fix button link on Watson docs page

### DIFF
--- a/docs/migrate-from/ibm-watson-to-rasa.rst
+++ b/docs/migrate-from/ibm-watson-to-rasa.rst
@@ -27,5 +27,5 @@ At Rasa, we hear a few different reasons why developers switch from cloud-based 
 
 
 .. button::
-     :link: ../../user-guide/rasa-tutorial.html
+     :link: https://rasa.com/docs/getting-started/
      :text: Learn more about Rasa

--- a/docs/migrate-from/ibm-watson-to-rasa.rst
+++ b/docs/migrate-from/ibm-watson-to-rasa.rst
@@ -27,5 +27,5 @@ At Rasa, we hear a few different reasons why developers switch from cloud-based 
 
 
 .. button::
-     :link: ../get_started_step1/
+     :link: ../rasa-tutorial/
      :text: Learn more about Rasa

--- a/docs/migrate-from/ibm-watson-to-rasa.rst
+++ b/docs/migrate-from/ibm-watson-to-rasa.rst
@@ -27,5 +27,5 @@ At Rasa, we hear a few different reasons why developers switch from cloud-based 
 
 
 .. button::
-     :link: ../rasa-tutorial/
+     :link: ../../user-guide/rasa-tutorial.html
      :text: Learn more about Rasa


### PR DESCRIPTION
**Proposed changes**:
- Fix the button link on the IBM Watson migration page to point to the rasa tutorial

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
