### PR TITLE
fix log_unseen_features warning for nlu-only models

### DIFF
--- a/changelog/6032.bugfix.rst
+++ b/changelog/6032.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``Interpreter parsed an intent ...`` warning when using the ``/model/parse`` 
+endpoint with an NLU-only model.

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -420,34 +420,40 @@ class MessageProcessor:
             logger.debug(f"Current slot values: \n{slot_values}")
 
     def _log_unseen_features(self, parse_data: Dict[Text, Any]) -> None:
-        """Check if the NLU interpreter picks up intents or entities that aren't
-        recognized."""
+        """Logs unrecognized features from the NLU parse data.
 
-        domain_is_not_empty = self.domain and not self.domain.is_empty()
+        Checks intents and entities picked up by the NLU interpreter
+        against the domain and warns the user of those that don't match.
+        Also considers a list of default intents that are valid but don't
+        need to be listed in the domain.
 
-        intent = parse_data["intent"]["name"]
-        if intent:
-            intent_is_recognized = (
-                domain_is_not_empty and intent in self.domain.intents
-            ) or intent in DEFAULT_INTENTS
-            if not intent_is_recognized:
-                raise_warning(
-                    f"Interpreter parsed an intent '{intent}' "
-                    f"which is not defined in the domain. "
-                    f"Please make sure all intents are listed in the domain.",
-                    docs=DOCS_URL_DOMAINS,
-                )
+        Args:
+            parse_data: NLUInterpreter parse data to check against the domain.
+        """
+        if self.domain and not self.domain.is_empty():
+            intent = parse_data["intent"]["name"]
+            if intent:
+                intent_is_recognized = (
+                    intent in self.domain.intents
+                ) or intent in DEFAULT_INTENTS
+                if not intent_is_recognized:
+                    raise_warning(
+                        f"Interpreter parsed an intent '{intent}' "
+                        f"which is not defined in the domain. "
+                        f"Please make sure all intents are listed in the domain.",
+                        docs=DOCS_URL_DOMAINS,
+                    )
 
-        entities = parse_data["entities"] or []
-        for element in entities:
-            entity = element["entity"]
-            if entity and domain_is_not_empty and entity not in self.domain.entities:
-                raise_warning(
-                    f"Interpreter parsed an entity '{entity}' "
-                    f"which is not defined in the domain. "
-                    f"Please make sure all entities are listed in the domain.",
-                    docs=DOCS_URL_DOMAINS,
-                )
+            entities = parse_data["entities"] or []
+            for element in entities:
+                entity = element["entity"]
+                if entity and entity not in self.domain.entities:
+                    raise_warning(
+                        f"Interpreter parsed an entity '{entity}' "
+                        f"which is not defined in the domain. "
+                        f"Please make sure all entities are listed in the domain.",
+                        docs=DOCS_URL_DOMAINS,
+                    )
 
     def _get_action(self, action_name) -> Optional[Action]:
         return self.domain.action_for_name(action_name, self.action_endpoint)

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -419,8 +419,8 @@ class MessageProcessor:
         if slot_values.strip():
             logger.debug(f"Current slot values: \n{slot_values}")
 
-    def _log_unseen_features(self, parse_data: Dict[Text, Any]) -> None:
-        """Logs unrecognized features from the NLU parse data.
+    def _check_for_unseen_features(self, parse_data: Dict[Text, Any]) -> None:
+        """Warns the user if the NLU parse data contains unrecognized features.
 
         Checks intents and entities picked up by the NLU interpreter
         against the domain and warns the user of those that don't match.
@@ -478,7 +478,7 @@ class MessageProcessor:
             )
         )
 
-        self._log_unseen_features(parse_data)
+        self._check_for_unseen_features(parse_data)
 
         return parse_data
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -430,30 +430,30 @@ class MessageProcessor:
         Args:
             parse_data: NLUInterpreter parse data to check against the domain.
         """
-        if self.domain and not self.domain.is_empty():
-            intent = parse_data["intent"]["name"]
-            if intent:
-                intent_is_recognized = (
-                    intent in self.domain.intents
-                ) or intent in DEFAULT_INTENTS
-                if not intent_is_recognized:
-                    raise_warning(
-                        f"Interpreter parsed an intent '{intent}' "
-                        f"which is not defined in the domain. "
-                        f"Please make sure all intents are listed in the domain.",
-                        docs=DOCS_URL_DOMAINS,
-                    )
+        if not self.domain or self.domain.is_empty():
+            return
 
-            entities = parse_data["entities"] or []
-            for element in entities:
-                entity = element["entity"]
-                if entity and entity not in self.domain.entities:
-                    raise_warning(
-                        f"Interpreter parsed an entity '{entity}' "
-                        f"which is not defined in the domain. "
-                        f"Please make sure all entities are listed in the domain.",
-                        docs=DOCS_URL_DOMAINS,
-                    )
+        intent = parse_data["intent"]["name"]
+        if intent:
+            known_intents = self.domain.intents + DEFAULT_INTENTS
+            if intent not in known_intents:
+                raise_warning(
+                    f"Interpreter parsed an intent '{intent}' "
+                    f"which is not defined in the domain. "
+                    f"Please make sure all intents are listed in the domain.",
+                    docs=DOCS_URL_DOMAINS,
+                )
+
+        entities = parse_data["entities"] or []
+        for element in entities:
+            entity = element["entity"]
+            if entity and entity not in self.domain.entities:
+                raise_warning(
+                    f"Interpreter parsed an entity '{entity}' "
+                    f"which is not defined in the domain. "
+                    f"Please make sure all entities are listed in the domain.",
+                    docs=DOCS_URL_DOMAINS,
+                )
 
     def _get_action(self, action_name) -> Optional[Action]:
         return self.domain.action_for_name(action_name, self.action_endpoint)

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -72,11 +72,11 @@ async def test_parsing(default_processor: MessageProcessor):
     assert parsed["entities"][0]["entity"] == "name"
 
 
-async def test_log_unseen_feature(default_processor: MessageProcessor):
+async def test_check_for_unseen_feature(default_processor: MessageProcessor):
     message = UserMessage('/dislike{"test_entity": "RASA"}')
     parsed = await default_processor._parse_message(message)
     with pytest.warns(UserWarning) as record:
-        default_processor._log_unseen_features(parsed)
+        default_processor._check_for_unseen_features(parsed)
     assert len(record) == 2
 
     assert (
@@ -96,7 +96,7 @@ async def test_default_intent_recognized(
     message = UserMessage(default_intent)
     parsed = await default_processor._parse_message(message)
     with pytest.warns(None) as record:
-        default_processor._log_unseen_features(parsed)
+        default_processor._check_for_unseen_features(parsed)
     assert len(record) == 0
 
 


### PR DESCRIPTION
**Proposed changes**:
- exit function early if no domain is provided (if you train with `rasa train nlu`), since the point is to check against the domain
- fix https://github.com/RasaHQ/rasa/issues/6032

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
