### PR TITLE
DIETClassifier adds a confidence value to entity predictions

### DIFF
--- a/changelog/5481.improvement.rst
+++ b/changelog/5481.improvement.rst
@@ -1,0 +1,1 @@
+``DIETClassifier`` now also assigns a confidence value to entity predictions.

--- a/docs/nlu/entity-extraction.rst
+++ b/docs/nlu/entity-extraction.rst
@@ -60,9 +60,9 @@ exactly. Instead it will return the trained synonym.
 
 .. note::
 
-    The ``confidence`` will be set by the ``CRFEntityExtractor`` component. The
+    The ``confidence`` will be set by the ``CRFEntityExtractor`` and the ``DIETClassifier`` component. The
     ``DucklingHTTPExtractor`` will always return ``1``. The ``SpacyEntityExtractor`` extractor
-    and ``DIETClassifier`` do not provide this information and return ``null``.
+    does not provide this information and returns ``null``.
 
 
 Some extractors, like ``duckling``, may include additional information. For example:

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 # performs entity extraction but those two classifiers don't
 ENTITY_PROCESSORS = {"EntitySynonymMapper", "ResponseSelector"}
 
-EXTRACTORS_WITH_CONFIDENCES = {"CRFEntityExtractor"}
+EXTRACTORS_WITH_CONFIDENCES = {"CRFEntityExtractor", "DIETClassifier"}
 
 CVEvaluationResult = namedtuple("Results", "train test")
 

--- a/rasa/utils/tensorflow/crf.py
+++ b/rasa/utils/tensorflow/crf.py
@@ -51,8 +51,7 @@ class CrfDecodeForwardRnnCell(tf.keras.layers.AbstractRNNCell):
         new_state = inputs + tf.reduce_max(transition_scores, [1])
         backpointers = tf.argmax(transition_scores, 1)
         backpointers = tf.cast(backpointers, tf.float32)
-        scores = tf.reduce_max(transition_scores, [1])
-        return tf.concat([backpointers, scores], axis=1), new_state
+        return tf.concat([backpointers, new_state], axis=1), new_state
 
 
 def crf_decode_forward(

--- a/rasa/utils/tensorflow/crf.py
+++ b/rasa/utils/tensorflow/crf.py
@@ -154,9 +154,7 @@ def crf_decode(
     # argmax tag and the max activation.
     def _single_seq_fn():
         decode_tags = tf.cast(tf.argmax(potentials, axis=2), dtype=tf.int32)
-        decode_scores = tf.reshape(
-            tf.reduce_max(tf.nn.softmax(potentials, axis=2), axis=2), shape=[-1]
-        )
+        decode_scores = tf.reduce_max(tf.nn.softmax(potentials, axis=2), axis=2)
         best_score = tf.reshape(tf.reduce_max(potentials, axis=2), shape=[-1])
         return decode_tags, decode_scores, best_score
 

--- a/rasa/utils/tensorflow/crf.py
+++ b/rasa/utils/tensorflow/crf.py
@@ -5,6 +5,11 @@ from typeguard import typechecked
 from typing import Tuple
 
 
+# original code taken from
+# https://github.com/tensorflow/addons/blob/master/tensorflow_addons/text/crf.py
+# (modified to our neeeds)
+
+
 class CrfDecodeForwardRnnCell(tf.keras.layers.AbstractRNNCell):
     """Computes the forward decoding in a linear-chain CRF."""
 

--- a/rasa/utils/tensorflow/crf.py
+++ b/rasa/utils/tensorflow/crf.py
@@ -211,9 +211,7 @@ def crf_decode(
         # the appropriate code path
         if potentials.shape[1] == 1:
             return _single_seq_fn()
-        else:
-            return _multi_seq_fn()
-    else:
-        return tf.cond(
-            tf.equal(tf.shape(potentials)[1], 1), _single_seq_fn, _multi_seq_fn
-        )
+
+        return _multi_seq_fn()
+
+    return tf.cond(tf.equal(tf.shape(potentials)[1], 1), _single_seq_fn, _multi_seq_fn)

--- a/rasa/utils/tensorflow/crf.py
+++ b/rasa/utils/tensorflow/crf.py
@@ -1,0 +1,181 @@
+import numpy as np
+import tensorflow as tf
+
+from tensorflow_addons.utils.types import TensorLike
+from typeguard import typechecked
+from typing import Optional
+
+
+class CrfDecodeForwardRnnCell(tf.keras.layers.AbstractRNNCell):
+    """Computes the forward decoding in a linear-chain CRF."""
+
+    @typechecked
+    def __init__(self, transition_params: TensorLike, **kwargs):
+        """Initialize the CrfDecodeForwardRnnCell.
+
+        Args:
+          transition_params: A [num_tags, num_tags] matrix of binary
+            potentials. This matrix is expanded into a
+            [1, num_tags, num_tags] in preparation for the broadcast
+            summation occurring within the cell.
+        """
+        super().__init__(**kwargs)
+        self._transition_params = tf.expand_dims(transition_params, 0)
+        self._num_tags = transition_params.shape[0]
+
+    @property
+    def state_size(self):
+        return self._num_tags
+
+    @property
+    def output_size(self):
+        return self._num_tags
+
+    def build(self, input_shape):
+        super().build(input_shape)
+
+    def call(self, inputs, state):
+        """Build the CrfDecodeForwardRnnCell.
+
+        Args:
+          inputs: A [batch_size, num_tags] matrix of unary potentials.
+          state: A [batch_size, num_tags] matrix containing the previous step's
+                score values.
+
+        Returns:
+          backpointers: A [batch_size, num_tags] matrix of backpointers.
+          new_state: A [batch_size, num_tags] matrix of new score values.
+        """
+        state = tf.expand_dims(state[0], 2)
+        transition_scores = state + self._transition_params
+        new_state = inputs + tf.reduce_max(transition_scores, [1])
+        backpointers = tf.argmax(transition_scores, 1)
+        backpointers = tf.cast(backpointers, tf.float32)
+        scores = tf.reduce_max(transition_scores, [1])
+        return tf.concat([backpointers, scores], axis=1), new_state
+
+
+def crf_decode_forward(
+    inputs: TensorLike,
+    state: TensorLike,
+    transition_params: TensorLike,
+    sequence_lengths: TensorLike,
+) -> tf.Tensor:
+    """Computes forward decoding in a linear-chain CRF.
+
+    Args:
+      inputs: A [batch_size, num_tags] matrix of unary potentials.
+      state: A [batch_size, num_tags] matrix containing the previous step's
+            score values.
+      transition_params: A [num_tags, num_tags] matrix of binary potentials.
+      sequence_lengths: A [batch_size] vector of true sequence lengths.
+
+    Returns:
+      backpointers: A [batch_size, num_tags] matrix of backpointers.
+      new_state: A [batch_size, num_tags] matrix of new score values.
+    """
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+    mask = tf.sequence_mask(sequence_lengths, tf.shape(inputs)[1])
+    crf_fwd_cell = CrfDecodeForwardRnnCell(transition_params)
+    crf_fwd_layer = tf.keras.layers.RNN(
+        crf_fwd_cell, return_sequences=True, return_state=True
+    )
+    return crf_fwd_layer(inputs, state, mask=mask)
+
+
+def crf_decode_backward(inputs: TensorLike, state: TensorLike) -> tf.Tensor:
+    """Computes backward decoding in a linear-chain CRF.
+
+    Args:
+      inputs: A [batch_size, num_tags] matrix of
+            backpointer of next step (in time order).
+      state: A [batch_size, 1] matrix of tag index of next step.
+
+    Returns:
+      new_tags: A [batch_size, num_tags]
+        tensor containing the new tag indices.
+    """
+    inputs = tf.transpose(inputs, [1, 0, 2])
+
+    def _scan_fn(state, inputs):
+        state = tf.squeeze(state, axis=[1])
+        idxs = tf.stack([tf.range(tf.shape(inputs)[0]), state], axis=1)
+        new_tags = tf.expand_dims(tf.gather_nd(inputs, idxs), axis=-1)
+        return new_tags
+
+    return tf.transpose(tf.scan(_scan_fn, inputs, state), [1, 0, 2])
+
+
+def crf_decode(
+    potentials: TensorLike, transition_params: TensorLike, sequence_length: TensorLike
+) -> tf.Tensor:
+    """Decode the highest scoring sequence of tags.
+
+    Args:
+      potentials: A [batch_size, max_seq_len, num_tags] tensor of
+                unary potentials.
+      transition_params: A [num_tags, num_tags] matrix of
+                binary potentials.
+      sequence_length: A [batch_size] vector of true sequence lengths.
+
+    Returns:
+      decode_tags: A [batch_size, max_seq_len] matrix, with dtype `tf.int32`.
+                  Contains the highest scoring tag indices.
+      scores: A [batch_size, max_seq_len] vector, containing the score of `decode_tags`.
+    """
+    sequence_length = tf.cast(sequence_length, dtype=tf.int32)
+
+    # If max_seq_len is 1, we skip the algorithm and simply return the
+    # argmax tag and the max activation.
+    def _single_seq_fn():
+        decode_tags = tf.cast(tf.argmax(potentials, axis=2), dtype=tf.int32)
+        best_score = tf.reshape(tf.reduce_max(potentials, axis=2), shape=[-1])
+        return decode_tags, best_score
+
+    def _multi_seq_fn():
+        # Computes forward decoding. Get last score and backpointers.
+        initial_state = tf.slice(potentials, [0, 0, 0], [-1, 1, -1])
+        initial_state = tf.squeeze(initial_state, axis=[1])
+        inputs = tf.slice(potentials, [0, 1, 0], [-1, -1, -1])
+
+        sequence_length_less_one = tf.maximum(
+            tf.constant(0, dtype=tf.int32), sequence_length - 1
+        )
+
+        backpointers, last_score = crf_decode_forward(
+            inputs, initial_state, transition_params, sequence_length_less_one
+        )
+
+        backpointers, scores = tf.split(backpointers, 2, axis=2)
+
+        scores = tf.reduce_max(scores, axis=[2])
+        initial_score = tf.reduce_max(last_score, axis=[1])
+        initial_score = tf.expand_dims(initial_score, axis=1)
+        scores = tf.concat([scores, initial_score], axis=1)
+
+        backpointers = tf.cast(backpointers, tf.int32)
+        backpointers = tf.reverse_sequence(
+            backpointers, sequence_length_less_one, seq_axis=1
+        )
+
+        initial_state = tf.cast(tf.argmax(last_score, axis=1), dtype=tf.int32)
+        initial_state = tf.expand_dims(initial_state, axis=-1)
+
+        decode_tags = crf_decode_backward(backpointers, initial_state)
+        decode_tags = tf.squeeze(decode_tags, axis=[2])
+        decode_tags = tf.concat([initial_state, decode_tags], axis=1)
+        decode_tags = tf.reverse_sequence(decode_tags, sequence_length, seq_axis=1)
+
+        return decode_tags, scores
+
+    if potentials.shape[1] is not None:
+        # shape is statically know, so we just execute
+        # the appropriate code path
+        if potentials.shape[1] == 1:
+            return _single_seq_fn()
+        else:
+            return _multi_seq_fn()
+    else:
+        return tf.cond(
+            tf.equal(tf.shape(potentials)[1], 1), _single_seq_fn, _multi_seq_fn
+        )

--- a/rasa/utils/tensorflow/layers.py
+++ b/rasa/utils/tensorflow/layers.py
@@ -477,17 +477,20 @@ class CRF(tf.keras.layers.Layer):
             A [batch_size, max_seq_len] matrix, with dtype `tf.float32`.
             Contains the confidence values of the highest scoring tag indices.
         """
-        pred_ids, scores = rasa.utils.tensorflow.crf.crf_decode(
+        predicted_ids, scores = rasa.utils.tensorflow.crf.crf_decode(
             logits, self.transition_params, sequence_lengths
         )
         # set prediction index for padding to `0`
         mask = tf.sequence_mask(
-            sequence_lengths, maxlen=tf.shape(pred_ids)[1], dtype=pred_ids.dtype
+            sequence_lengths,
+            maxlen=tf.shape(predicted_ids)[1],
+            dtype=predicted_ids.dtype,
         )
 
-        confidence_values = tf.nn.sigmoid(scores * tf.cast(mask, tf.float32))
+        confidence_values = scores * tf.cast(mask, tf.float32)
+        predicted_ids = predicted_ids * mask
 
-        return pred_ids * mask, confidence_values
+        return predicted_ids, confidence_values
 
     def loss(
         self, logits: tf.Tensor, tag_indices: tf.Tensor, sequence_lengths: tf.Tensor

--- a/rasa/utils/tensorflow/layers.py
+++ b/rasa/utils/tensorflow/layers.py
@@ -485,7 +485,7 @@ class CRF(tf.keras.layers.Layer):
             sequence_lengths, maxlen=tf.shape(pred_ids)[1], dtype=pred_ids.dtype
         )
 
-        confidence_values = tf.nn.softmax(scores * tf.cast(mask, tf.float32))
+        confidence_values = tf.nn.sigmoid(scores * tf.cast(mask, tf.float32))
 
         return pred_ids * mask, confidence_values
 

--- a/rasa/utils/tensorflow/layers.py
+++ b/rasa/utils/tensorflow/layers.py
@@ -477,7 +477,7 @@ class CRF(tf.keras.layers.Layer):
             A [batch_size, max_seq_len] matrix, with dtype `tf.float32`.
             Contains the confidence values of the highest scoring tag indices.
         """
-        predicted_ids, scores = rasa.utils.tensorflow.crf.crf_decode(
+        predicted_ids, scores, _ = rasa.utils.tensorflow.crf.crf_decode(
             logits, self.transition_params, sequence_lengths
         )
         # set prediction index for padding to `0`

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -253,6 +253,21 @@ def test_determine_token_labels_with_extractors():
             ["CRFEntityExtractor"],
             0.87,
         ),
+        (
+            Token("pizza", 4),
+            [
+                {
+                    "start": 4,
+                    "end": 9,
+                    "value": "pizza",
+                    "entity": "food",
+                    "confidence_entity": 0.87,
+                    "extractor": "DIETClassfifier",
+                }
+            ],
+            ["DIETClassfifier"],
+            0.87,
+        ),
     ],
 )
 def test_get_entity_confidences(

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -262,10 +262,10 @@ def test_determine_token_labels_with_extractors():
                     "value": "pizza",
                     "entity": "food",
                     "confidence_entity": 0.87,
-                    "extractor": "DIETClassfifier",
+                    "extractor": "DIETClassifier",
                 }
             ],
-            ["DIETClassfifier"],
+            ["DIETClassifier"],
             0.87,
         ),
     ],


### PR DESCRIPTION
**Proposed changes**:
- Update the CRF to return scores that can be used as confidence values.
- `DIETClassifier` now adds a confidence value to entity predictions.

closes https://github.com/RasaHQ/rasa/issues/5481

(Will also make a PR to tensorflow addons directly. If they take the changes and adapt the CRF, we can remove our custom CRF again.)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
