### PR TITLE
Convert entity values from Duckling to strings for testing

### DIFF
--- a/changelog/6042.bugfix.rst
+++ b/changelog/6042.bugfix.rst
@@ -1,0 +1,2 @@
+Convert entity values coming from ``DucklingHTTPExtractor`` to string during evaluation to avoid mismatches due to
+different types.

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -6,6 +6,14 @@ from collections import defaultdict, namedtuple
 from typing import Any, Dict, List, Optional, Text, Tuple, Union
 
 import rasa.utils.io as io_utils
+from rasa.nlu.constants import (
+    EXTRACTOR,
+    ENTITY_ATTRIBUTE_VALUE,
+    ENTITY_ATTRIBUTE_TEXT,
+    ENTITY_ATTRIBUTE_START,
+    ENTITY_ATTRIBUTE_END,
+    ENTITY_ATTRIBUTE_TYPE,
+)
 from rasa.constants import RESULTS_FILE, PERCENTAGE_KEY
 from rasa.core.utils import pad_lists_to_size
 from rasa.core.events import ActionExecuted, UserUttered
@@ -215,9 +223,22 @@ def _clean_entity_results(
     cleaned_entities = []
 
     for r in tuple(entity_results):
-        cleaned_entity = {"text": text}
-        for k in ("start", "end", "entity", "value"):
+        cleaned_entity = {ENTITY_ATTRIBUTE_TEXT: text}
+        for k in (
+            ENTITY_ATTRIBUTE_START,
+            ENTITY_ATTRIBUTE_END,
+            ENTITY_ATTRIBUTE_TYPE,
+            ENTITY_ATTRIBUTE_VALUE,
+        ):
             if k in set(r):
+                if (
+                    k == ENTITY_ATTRIBUTE_VALUE
+                    and EXTRACTOR in set(r)
+                    and r[EXTRACTOR] == "DucklingHTTPExtractor"
+                ):
+                    # convert values from duckling to strings for evaluation as
+                    # target values are all of type string
+                    r[k] = str(r[k])
                 cleaned_entity[k] = r[k]
         cleaned_entities.append(cleaned_entity)
 

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -231,12 +231,8 @@ def _clean_entity_results(
             ENTITY_ATTRIBUTE_VALUE,
         ):
             if k in set(r):
-                if (
-                    k == ENTITY_ATTRIBUTE_VALUE
-                    and EXTRACTOR in set(r)
-                    and r[EXTRACTOR] == "DucklingHTTPExtractor"
-                ):
-                    # convert values from duckling to strings for evaluation as
+                if k == ENTITY_ATTRIBUTE_VALUE and EXTRACTOR in set(r):
+                    # convert values to strings for evaluation as
                     # target values are all of type string
                     r[k] = str(r[k])
                 cleaned_entity[k] = r[k]

--- a/tests/core/test_evaluation.py
+++ b/tests/core/test_evaluation.py
@@ -1,5 +1,8 @@
 import os
 from pathlib import Path
+from typing import Any, Text, Dict
+
+import pytest
 
 import rasa.utils.io
 from rasa.core.test import (
@@ -10,6 +13,7 @@ from rasa.core.test import (
     CONFUSION_MATRIX_STORIES_FILE,
     REPORT_STORIES_FILE,
     SUCCESSFUL_STORIES_FILE,
+    _clean_entity_results,
 )
 from rasa.core.policies.memoization import MemoizationPolicy
 
@@ -165,3 +169,70 @@ async def test_end_to_evaluation_trips_circuit_breaker():
         story_evaluation.evaluation_store.action_predictions == circuit_trip_predicted
     )
     assert num_stories == 1
+
+
+@pytest.mark.parametrize(
+    "text, entity, expected_entity",
+    [
+        (
+            "The first one please.",
+            {
+                "extractor": "DucklingHTTPExtractor",
+                "entity": "ordinal",
+                "confidence": 0.87,
+                "start": 4,
+                "end": 9,
+                "value": 1,
+            },
+            {
+                "text": "The first one please.",
+                "entity": "ordinal",
+                "start": 4,
+                "end": 9,
+                "value": "1",
+            },
+        ),
+        (
+            "The first one please.",
+            {
+                "extractor": "CRFEntityExtractor",
+                "entity": "ordinal",
+                "confidence": 0.87,
+                "start": 4,
+                "end": 9,
+                "value": "1",
+            },
+            {
+                "text": "The first one please.",
+                "entity": "ordinal",
+                "start": 4,
+                "end": 9,
+                "value": "1",
+            },
+        ),
+        (
+            "Italian food",
+            {
+                "extractor": "DIETClassifier",
+                "entity": "cuisine",
+                "confidence": 0.99,
+                "start": 0,
+                "end": 7,
+                "value": "Italian",
+            },
+            {
+                "text": "Italian food",
+                "entity": "cuisine",
+                "start": 0,
+                "end": 7,
+                "value": "Italian",
+            },
+        ),
+    ],
+)
+def test_event_has_proper_implementation(
+    text: Text, entity: Dict[Text, Any], expected_entity: Dict[Text, Any]
+):
+    actual_entities = _clean_entity_results(text, [entity])
+
+    assert actual_entities[0] == expected_entity


### PR DESCRIPTION
**Proposed changes**:
In our tests all entity values are of type string. However, values from duckling can be of any type. In order to correctly compare predicted and target entities, we need to convert the entity values from duckling to strings during our evaluation.

related to https://github.com/RasaHQ/rasa/pull/5977

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
