### PR TITLE
Whitespace tokenizer vowel signs

### DIFF
--- a/changelog/5998.bugfix.rst
+++ b/changelog/5998.bugfix.rst
@@ -1,0 +1,1 @@
+``WhitespaceTokenizer`` does not remove vowel signs in Hindi anymore.

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -1,9 +1,9 @@
-import re
 from typing import Any, Dict, List, Text
+
+import regex
 
 from rasa.nlu.tokenizers.tokenizer import Token, Tokenizer
 from rasa.nlu.training_data import Message
-from rasa.nlu.constants import TOKENS_NAMES, MESSAGE_ATTRIBUTES
 
 
 class WhitespaceTokenizer(Tokenizer):
@@ -30,8 +30,11 @@ class WhitespaceTokenizer(Tokenizer):
         if not self.case_sensitive:
             text = text.lower()
 
+        # we need to use regex instead of re, because of
+        # https://stackoverflow.com/questions/12746458/python-unicode-regular-expression-matching-failing-with-some-unicode-characters
+
         # remove 'not a word character' if
-        words = re.sub(
+        words = regex.sub(
             # there is a space or an end of a string after it
             r"[^\w#@&]+(?=\s|$)|"
             # there is a space or beginning of a string before it

--- a/tests/nlu/tokenizers/test_whitespace_tokenizer.py
+++ b/tests/nlu/tokenizers/test_whitespace_tokenizer.py
@@ -2,7 +2,6 @@ import pytest
 
 from rasa.nlu.constants import TOKENS_NAMES, TEXT, INTENT
 from rasa.nlu.training_data import TrainingData, Message
-from tests.nlu import utilities
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 
 
@@ -18,6 +17,37 @@ from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
             "hey ńöñàśçií how're you?",
             ["hey", "ńöñàśçií", "how", "re", "you"],
             [(0, 3), (4, 12), (13, 16), (17, 19), (20, 23)],
+        ),
+        (
+            "50 क्या आपके पास डेरी मिल्क 10 वाले बॉक्स मिल सकते है",
+            [
+                "50",
+                "क्या",
+                "आपके",
+                "पास",
+                "डेरी",
+                "मिल्क",
+                "10",
+                "वाले",
+                "बॉक्स",
+                "मिल",
+                "सकते",
+                "है",
+            ],
+            [
+                (0, 2),
+                (3, 7),
+                (8, 12),
+                (13, 16),
+                (17, 21),
+                (22, 27),
+                (28, 30),
+                (31, 35),
+                (36, 41),
+                (42, 45),
+                (46, 50),
+                (51, 53),
+            ],
         ),
         (
             "https://www.google.com/search?client=safari&rls=en&q=i+like+rasa&ie=UTF-8&oe=UTF-8 https://rasa.com/docs/nlu/components/#tokenizer-whitespace",


### PR DESCRIPTION
**Proposed changes**:
Replace `re` with `regex` in `WhitespaceTokenizer` to consider UNICODE characters correctly.

closes #5998 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
