### PR TITLE
Webex Channel Fix: personId -> roomId

### DIFF
--- a/changelog/6078.bugfix.rst
+++ b/changelog/6078.bugfix.rst
@@ -1,1 +1,1 @@
-The assistant will respond through the `webex` channel to any user (room) communicating to it. Before the bot responded only to a fixed ``roomId`` set in the ``credentials.yml``config file.
+The assistant will respond through the `webex` channel to any user (room) communicating to it. Before the bot responded only to a fixed ``roomId`` set in the ``credentials.yml`` config file.

--- a/changelog/6078.bugfix.rst
+++ b/changelog/6078.bugfix.rst
@@ -1,1 +1,1 @@
-bot will respond through `webex` channel to any user(room) communicating to it. Earlier bot responds only to fixed `roomId` set in credentials.yml config file correctly.
+The assistant will respond through the `webex` channel to any user (room) communicating to it. Before the bot responded only to a fixed ``roomId`` set in the ``credentials.yml``config file.

--- a/changelog/6078.bugfix.rst
+++ b/changelog/6078.bugfix.rst
@@ -1,0 +1,1 @@
+bot will respond through `webex` channel to any user(room) communicating to it. Earlier bot responds only to fixed `roomId` set in credentials.yml config file correctly.

--- a/rasa/core/channels/webexteams.py
+++ b/rasa/core/channels/webexteams.py
@@ -39,7 +39,7 @@ class WebexTeamsBot(OutputChannel):
     async def send_custom_json(
         self, recipient_id: Text, json_message: Dict[Text, Any], **kwargs: Any
     ) -> None:
-        json_message.setdefault("roomID", recipient_id)
+        json_message.setdefault("roomId", recipient_id)
         return self.api.messages.create(**json_message)
 
 
@@ -128,7 +128,7 @@ class WebexTeamsInput(InputChannel):
             else:
                 metadata = self.get_metadata(request)
                 await self.process_message(
-                    on_new_message, message.text, message.personId, metadata
+                    on_new_message, message.text, message.roomId, metadata
                 )
                 return response.text("")
 


### PR DESCRIPTION
This is a much needed fix because presently we are unable to have the rasa-bot respond back to the specific room that sends the message thus enabling `no reply` to the user

The fix is also presented at https://github.com/RasaHQ/rasa/pull/5460 but since it will be released at 1.11.0 thenn we need to hotfix it soon.

References RasaHQ/rasa#5460

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
