### PR TITLE
Fix lock store bug

### DIFF
--- a/changelog/6031.bugfix.rst
+++ b/changelog/6031.bugfix.rst
@@ -1,2 +1,2 @@
 Previously, specifying a lock store in the endpoint configuration with a type other than ``redis`` or ``in_memory``
-would lead to an `AttributeError: 'str' object has no attribute 'type'``. This bug is fixed now.
+would lead to an ``AttributeError: 'str' object has no attribute 'type'``. This bug is fixed now.

--- a/changelog/6031.bugfix.rst
+++ b/changelog/6031.bugfix.rst
@@ -1,0 +1,2 @@
+Previously, specifying a lock store in the endpoint configuration with a type other than ``redis`` or ``in_memory``
+would lead to an `AttributeError: 'str' object has no attribute 'type'``. This bug is fixed now.

--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -247,7 +247,7 @@ def _create_from_endpoint_config(
     elif endpoint_config.type == "redis":
         lock_store = RedisLockStore(host=endpoint_config.url, **endpoint_config.kwargs)
     else:
-        lock_store = _load_from_module_string(endpoint_config.type)
+        lock_store = _load_from_module_string(endpoint_config)
 
     logger.debug(f"Connected to lock store '{lock_store.__class__.__name__}'.")
 


### PR DESCRIPTION
**Proposed changes**:
fixes #6031 
Pass an `EndpointConfig` to `rasa.core.lock_store._load_from_module_string` instead of a string.

**Potential follow-up**
The name of the function implies that its input should be a string. We can't pass only the string, because the whole `EndpointConfig` is needed to load it. So we should probably adapt the name.
The same holds for the `_load_from_module_string` functions in some other `rasa.core` modules, namely `nlg.generator`, `broker`, `interpreter` and `tracker_store`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
