### PR TITLE
Remove empty tokens from whitespace tokenizer

### DIFF
--- a/changelog/6119.bugfix.rst
+++ b/changelog/6119.bugfix.rst
@@ -1,1 +1,1 @@
-Remove all null unicode characters from the output of ``regex.sub`` inside ``WhitespaceTokenizer``
+Explicitly remove all emojis which appear as unicode characters from the output of ``regex.sub`` inside ``WhitespaceTokenizer``.

--- a/changelog/6119.bugfix.rst
+++ b/changelog/6119.bugfix.rst
@@ -1,0 +1,1 @@
+Remove all null unicode characters from the output of ``regex.sub`` inside ``WhitespaceTokenizer``

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -28,7 +28,7 @@ class WhitespaceTokenizer(Tokenizer):
         self.emoji_pattern = self.get_emoji_regex()
 
     @staticmethod
-    def get_emoji_regex():
+    def get_emoji_regex() -> re.Pattern:
         emoji_pattern = re.compile(
             "["
             "\U0001F600-\U0001F64F"  # emoticons
@@ -42,7 +42,7 @@ class WhitespaceTokenizer(Tokenizer):
         )
         return emoji_pattern
 
-    def remove_emoji(self, text: Text):
+    def remove_emoji(self, text: Text) -> Text:
 
         return self.emoji_pattern.sub(r"", text)
 

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Text
 
-import regex
+import regex, re
 
 from rasa.nlu.tokenizers.tokenizer import Token, Tokenizer
 from rasa.nlu.training_data import Message
@@ -50,5 +50,8 @@ class WhitespaceTokenizer(Tokenizer):
         # if we removed everything like smiles `:)`, use the whole text as 1 token
         if not words:
             words = [text]
+
+        # convert to ascii and check if the resultant string is empty
+        words = [w for w in words if w.encode("ascii", "ignore").strip()]
 
         return self._convert_words_to_tokens(words, text)

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Text
 
-import regex, re
+import regex
 
 from rasa.nlu.tokenizers.tokenizer import Token, Tokenizer
 from rasa.nlu.training_data import Message

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -28,7 +28,7 @@ class WhitespaceTokenizer(Tokenizer):
         self.emoji_pattern = self.get_emoji_regex()
 
     @staticmethod
-    def get_emoji_regex() -> re.Pattern:
+    def get_emoji_regex():
         emoji_pattern = re.compile(
             "["
             "\U0001F600-\U0001F64F"  # emoticons

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -25,7 +25,10 @@ class WhitespaceTokenizer(Tokenizer):
 
         self.case_sensitive = self.component_config["case_sensitive"]
 
-    def remove_emoji(self, text: Text):
+        self.emoji_pattern = self.get_emoji_regex()
+
+    @staticmethod
+    def get_emoji_regex():
         emoji_pattern = re.compile(
             "["
             "\U0001F600-\U0001F64F"  # emoticons
@@ -37,7 +40,11 @@ class WhitespaceTokenizer(Tokenizer):
             "]+",
             flags=re.UNICODE,
         )
-        return emoji_pattern.sub(r"", text)
+        return emoji_pattern
+
+    def remove_emoji(self, text: Text):
+
+        return self.emoji_pattern.sub(r"", text)
 
     def tokenize(self, message: Message, attribute: Text) -> List[Token]:
         text = message.get(attribute)
@@ -63,14 +70,11 @@ class WhitespaceTokenizer(Tokenizer):
             text,
         ).split()
 
-        words = [self.remove_emoji(w) for w in words]
-        words = [w for w in words if w]
-
         # if we removed everything like smiles `:)`, use the whole text as 1 token
         if not words:
             words = [text]
 
-        # convert to ascii and check if the resultant string is empty
-        words = [w for w in words if w.encode("ascii", "ignore").strip()]
+        words = [self.remove_emoji(w) for w in words]
+        words = [w for w in words if w]
 
         return self._convert_words_to_tokens(words, text)

--- a/tests/nlu/tokenizers/test_whitespace_tokenizer.py
+++ b/tests/nlu/tokenizers/test_whitespace_tokenizer.py
@@ -50,11 +50,6 @@ from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
             ],
         ),
         (
-            "Joselico gracias Dois 🙏🇺🇸🏦🛠🔥⭐️🦅👑💪",
-            ["Joselico", "gracias", "Dois"],
-            [(0, 8), (9, 16), (17, 21)],
-        ),
-        (
             "https://www.google.com/search?client=safari&rls=en&q=i+like+rasa&ie=UTF-8&oe=UTF-8 https://rasa.com/docs/nlu/components/#tokenizer-whitespace",
             [
                 "https://www.google.com/search?"

--- a/tests/nlu/tokenizers/test_whitespace_tokenizer.py
+++ b/tests/nlu/tokenizers/test_whitespace_tokenizer.py
@@ -52,7 +52,7 @@ from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
         (
             "Joselico gracias Dois 🙏🇺🇸🏦🛠🔥⭐️🦅👑💪",
             ["Joselico", "gracias", "Dois"],
-            [(0, 8), (9, 16), (17, 20)],
+            [(0, 8), (9, 16), (17, 21)],
         ),
         (
             "https://www.google.com/search?client=safari&rls=en&q=i+like+rasa&ie=UTF-8&oe=UTF-8 https://rasa.com/docs/nlu/components/#tokenizer-whitespace",

--- a/tests/nlu/tokenizers/test_whitespace_tokenizer.py
+++ b/tests/nlu/tokenizers/test_whitespace_tokenizer.py
@@ -50,6 +50,11 @@ from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
             ],
         ),
         (
+            "Joselico gracias Dois 🙏🇺🇸🏦🛠🔥⭐️🦅👑💪",
+            ["Joselico", "gracias", "Dois"],
+            [(0, 8), (9, 16), (17, 20)],
+        ),
+        (
             "https://www.google.com/search?client=safari&rls=en&q=i+like+rasa&ie=UTF-8&oe=UTF-8 https://rasa.com/docs/nlu/components/#tokenizer-whitespace",
             [
                 "https://www.google.com/search?"


### PR DESCRIPTION
**Proposed changes**:
- Since, we shifted away from `re` to `regex`, it looks like the `.sub` method introduces a few null unicode chars in the resultant string. These needed to be cleaned up.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
