### PR TITLE
Add 'Access-Control-Expose-Headers' for 'filename' header (#6075)

### DIFF
--- a/changelog/6075.bugfix.rst.txt
+++ b/changelog/6075.bugfix.rst.txt
@@ -1,0 +1,1 @@
+Add 'Access-Control-Expose-Headers' for 'filename' header

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -369,6 +369,7 @@ def configure_cors(
     # https://github.com/miguelgrinberg/python-socketio/issues/205#issuecomment-493769183
     app.config.CORS_AUTOMATIC_OPTIONS = True
     app.config.CORS_SUPPORTS_CREDENTIALS = True
+    app.config.CORS_EXPOSE_HEADERS = "filename"
 
     CORS(
         app, resources={r"/*": {"origins": cors_origins or ""}}, automatic_options=True


### PR DESCRIPTION
**Proposed changes**:
- expose "filename" header for model download

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
