### PR TITLE
Fix empty strings as output of whitespace tokenizer

### DIFF
--- a/changelog/6143.bugfix.rst
+++ b/changelog/6143.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent ``WhitespaceTokenizer`` from outputting empty list of tokens.

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -70,11 +70,11 @@ class WhitespaceTokenizer(Tokenizer):
             text,
         ).split()
 
+        words = [self.remove_emoji(w) for w in words]
+        words = [w for w in words if w]
+
         # if we removed everything like smiles `:)`, use the whole text as 1 token
         if not words:
             words = [text]
-
-        words = [self.remove_emoji(w) for w in words]
-        words = [w for w in words if w]
 
         return self._convert_words_to_tokens(words, text)

--- a/tests/nlu/tokenizers/test_whitespace_tokenizer.py
+++ b/tests/nlu/tokenizers/test_whitespace_tokenizer.py
@@ -65,6 +65,7 @@ from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
         ),
         (":)", [":)"], [(0, 2)]),
         ("Hi :-)", ["Hi"], [(0, 2)]),
+        ("👍", ["👍"], [(0, 1)]),
     ],
 )
 def test_whitespace(text, expected_tokens, expected_indices):


### PR DESCRIPTION
**Proposed changes**:
- If the original utterance contains just an emoji like "👍" then the output tokens should be ["👍"] and not [].

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
