### PR TITLE
fix misleading function name

### DIFF
--- a/rasa/core/brokers/broker.py
+++ b/rasa/core/brokers/broker.py
@@ -69,14 +69,14 @@ def _create_from_endpoint_config(
 
         broker = KafkaEventBroker.from_endpoint_config(endpoint_config)
     else:
-        broker = _load_from_module_string(endpoint_config)
+        broker = _load_from_endpoint_config(endpoint_config)
 
     if broker:
         logger.debug(f"Instantiated event broker to '{broker.__class__.__name__}'.")
     return broker
 
 
-def _load_from_module_string(broker_config: EndpointConfig,) -> Optional["EventBroker"]:
+def _load_from_endpoint_config(broker_config: EndpointConfig,) -> Optional["EventBroker"]:
     """Instantiate an event broker based on its class name."""
     try:
         event_broker_class = common.class_from_module_path(broker_config.type)

--- a/rasa/core/brokers/broker.py
+++ b/rasa/core/brokers/broker.py
@@ -76,7 +76,9 @@ def _create_from_endpoint_config(
     return broker
 
 
-def _load_from_endpoint_config(broker_config: EndpointConfig,) -> Optional["EventBroker"]:
+def _load_from_endpoint_config(
+    broker_config: EndpointConfig,
+) -> Optional["EventBroker"]:
     """Instantiate an event broker based on its class name."""
     try:
         event_broker_class = common.class_from_module_path(broker_config.type)

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -293,10 +293,10 @@ def _create_from_endpoint_config(
     elif endpoint_config.type is None or endpoint_config.type.lower() == "http":
         return RasaNLUHttpInterpreter(endpoint_config=endpoint_config)
     else:
-        return _load_from_module_string(endpoint_config)
+        return _load_from_endpoint_config(endpoint_config)
 
 
-def _load_from_module_string(
+def _load_from_endpoint_config(
     endpoint_config: EndpointConfig,
 ) -> "NaturalLanguageInterpreter":
     """Instantiate an event channel based on its class name."""

--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -247,14 +247,14 @@ def _create_from_endpoint_config(
     elif endpoint_config.type == "redis":
         lock_store = RedisLockStore(host=endpoint_config.url, **endpoint_config.kwargs)
     else:
-        lock_store = _load_from_module_string(endpoint_config)
+        lock_store = _load_from_endpoint_config(endpoint_config)
 
     logger.debug(f"Connected to lock store '{lock_store.__class__.__name__}'.")
 
     return lock_store
 
 
-def _load_from_module_string(endpoint_config: EndpointConfig) -> "LockStore":
+def _load_from_endpoint_config(endpoint_config: EndpointConfig) -> "LockStore":
     """Given the name of a `LockStore` module tries to retrieve it."""
 
     try:

--- a/rasa/core/nlg/generator.py
+++ b/rasa/core/nlg/generator.py
@@ -67,13 +67,13 @@ def _create_from_endpoint_config(
 
         nlg = TemplatedNaturalLanguageGenerator(domain.templates)
     else:
-        nlg = _load_from_module_string(endpoint_config, domain)
+        nlg = _load_from_endpoint_config(endpoint_config, domain)
 
     logger.debug(f"Instantiated NLG to '{nlg.__class__.__name__}'.")
     return nlg
 
 
-def _load_from_module_string(
+def _load_from_endpoint_config(
     endpoint_config: EndpointConfig, domain: Domain
 ) -> "NaturalLanguageGenerator":
     """Initializes a custom natural language generator.

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1055,14 +1055,14 @@ def _create_from_endpoint_config(
             domain=domain, event_broker=event_broker, **endpoint_config.kwargs
         )
     else:
-        tracker_store = _load_from_module_string(domain, endpoint_config, event_broker)
+        tracker_store = _load_from_endpoint_config(domain, endpoint_config, event_broker)
 
     logger.debug(f"Connected to {tracker_store.__class__.__name__}.")
 
     return tracker_store
 
 
-def _load_from_module_string(
+def _load_from_endpoint_config(
     domain: Domain, store: EndpointConfig, event_broker: Optional[EventBroker] = None
 ) -> "TrackerStore":
     """Initializes a custom tracker.

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1055,7 +1055,9 @@ def _create_from_endpoint_config(
             domain=domain, event_broker=event_broker, **endpoint_config.kwargs
         )
     else:
-        tracker_store = _load_from_endpoint_config(domain, endpoint_config, event_broker)
+        tracker_store = _load_from_endpoint_config(
+            domain, endpoint_config, event_broker
+        )
 
     logger.debug(f"Connected to {tracker_store.__class__.__name__}.")
 


### PR DESCRIPTION
Related to issue #6101

**Proposed changes**:
- Rename function _load_from_module_string to a more significant name. Since all versions of this function take as argument an EndpointConfig I propose to rename it as _load_from_endpoint_config
- Update all function calls to reflect this name change.

**Notes**:
- Since this is a small, internal change I have not added a changelog file, nor updated the documentation.
- It provides no new functionality, so I haven't added tests either.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
