### PR TITLE
Added Config Note on EntitySynonymMapper

### DIFF
--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -138,7 +138,7 @@ HFTransformersNLP
             model_name: "bert"
             # Pre-Trained weights to be loaded
             model_weights: "bert-base-uncased"
-            
+
             # An optional path to a specific directory to download and cache the pre-trained model weights.
             # The `default` cache_dir is the same as https://huggingface.co/transformers/serialization.html#cache-directory .
             cache_dir: null
@@ -1128,6 +1128,9 @@ EntitySynonymMapper
 
         pipeline:
         - name: "EntitySynonymMapper"
+
+    .. note::
+        When using the EntitySynonymMapper as part of a larger pipeline, it will need to be placed below the Entity Extractor in the configuration file.
 
 .. _CRFEntityExtractor:
 

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -1130,7 +1130,7 @@ EntitySynonymMapper
         - name: "EntitySynonymMapper"
 
     .. note::
-        When using the EntitySynonymMapper as part of a larger pipeline, it will need to be placed below the Entity Extractor in the configuration file.
+        When using the EntitySynonymMapper as part of an NLU pipeline, it will need to be placed below the Entity Extractor in the configuration file.
 
 .. _CRFEntityExtractor:
 

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -1130,7 +1130,9 @@ EntitySynonymMapper
         - name: "EntitySynonymMapper"
 
     .. note::
-        When using the EntitySynonymMapper as part of an NLU pipeline, it will need to be placed below the Entity Extractor in the configuration file.
+
+        When using the ``EntitySynonymMapper`` as part of an NLU pipeline, it will need to be placed
+        below any entity extractors in the configuration file.
 
 .. _CRFEntityExtractor:
 

--- a/docs/nlu/training-data-format.rst
+++ b/docs/nlu/training-data-format.rst
@@ -66,7 +66,7 @@ Synonyms will map extracted entities to the same name, for example mapping "my s
 However, this only happens *after* the entities have been extracted, so you need to provide examples with the synonyms
 present so that Rasa can learn to pick them up.
 
-Lookup tables may be specified as plain text files containing newline-separated words or 
+Lookup tables may be specified as plain text files containing newline-separated words or
 phrases. Upon loading the training data, these files are used to generate
 case-insensitive regex patterns that are added to the regex features.
 
@@ -221,7 +221,7 @@ If you define entities as having the same value they will be treated as synonyms
 .. code-block:: md
 
     ## intent:search
-    - in the center of [NYC]{"entity": "city", "value": "New York City")
+    - in the center of [NYC]{"entity": "city", "value": "New York City"}
     - in the centre of [New York City](city)
 
 


### PR DESCRIPTION
**Proposed changes**:
- Doc update on EntitySynonymMapper based on customer feedback
- Update adds a note that EntitySynonymMapper needs to be placed below the Entity Extractor in config.yml to work properly (Rasa will train if this doesn't happen, but the synonym mapper won't work) 
- Included a few minor doc formatting fixes as well

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
