### PR TITLE
Add EntityExtractor as a requirement for EntitySynonymMapper

### DIFF
--- a/changelog/6198.bugfix.rst
+++ b/changelog/6198.bugfix.rst
@@ -1,0 +1,1 @@
+Add ``EntityExtractor`` as a required component for ``EntitySynonymMapper`` in a pipeline.

--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -818,6 +818,8 @@ DIETClassifier
     You can find the detailed description of the :ref:`diet-classifier` under the section
     `Combined Entity Extractors and Intent Classifiers`.
 
+.. _EntityExtractors:
+
 Entity Extractors
 -----------------
 
@@ -905,7 +907,7 @@ EntitySynonymMapper
 
 :Short: Maps synonymous entity values to the same value.
 :Outputs: Modifies existing entities that previous entity extraction components found.
-:Requires: Nothing
+:Requires: An extractor from :ref:`EntityExtractors`
 :Description:
     If the training data contains defined synonyms, this component will make sure that detected entity values will
     be mapped to the same value. For example, if your training data contains the following examples:

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -1,6 +1,7 @@
 import os
-from typing import Any, Dict, Optional, Text
+from typing import Any, Dict, List, Optional, Text, Type
 
+from rasa.nlu.components import Component
 from rasa.constants import DOCS_URL_TRAINING_DATA_NLU
 from rasa.nlu.constants import ENTITIES
 from rasa.nlu.config import RasaNLUModelConfig
@@ -13,6 +14,10 @@ from rasa.utils.common import raise_warning
 
 
 class EntitySynonymMapper(EntityExtractor):
+    @classmethod
+    def required_components(cls) -> List[Type[Component]]:
+        return [EntityExtractor]
+
     def __init__(
         self,
         component_config: Optional[Dict[Text, Any]] = None,


### PR DESCRIPTION
Closes #6198

**Proposed changes**:
- Add `EntityExtractor` as a requirement for `EntitySynonymMapper` in a pipeline

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

**Comment**:
I failed to test the PR locally (I have missed up with my clone and I haven't been able to build Rasa from source yet).
I would really appreciate if you can test the edit.
The change is intuitive yet it needs to be tested.