### PR TITLE
Add a "version" key for the training data files

### DIFF
--- a/rasa/constants.py
+++ b/rasa/constants.py
@@ -61,6 +61,8 @@ CONFIG_AUTOCONFIGURABLE_KEYS = ["policies", "pipeline"]
 
 MINIMUM_COMPATIBLE_VERSION = "1.11.0a3"
 
+LATEST_TRAINING_DATA_FORMAT_VERSION = "2.0"
+
 GLOBAL_USER_CONFIG_PATH = os.path.expanduser("~/.config/rasa/global.yml")
 
 DEFAULT_LOG_LEVEL = "INFO"

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -143,16 +143,21 @@ class Domain:
 
     @classmethod
     def from_file(cls, path: Text) -> "Domain":
-        return cls.from_yaml(rasa.utils.io.read_file(path))
+        return cls.from_yaml(rasa.utils.io.read_file(path), path)
 
     @classmethod
-    def from_yaml(cls, yaml: Text) -> "Domain":
+    def from_yaml(cls, yaml: Text, original_filename: Text = "") -> "Domain":
+        from rasa.validator import Validator
+
         try:
             validate_yaml_schema(yaml, DOMAIN_SCHEMA_FILE)
         except InvalidYamlFileError as e:
             raise InvalidDomain(str(e))
 
         data = rasa.utils.io.read_yaml(yaml)
+        if not Validator.validate_training_data_format_version(data, original_filename):
+            return Domain.empty()
+
         return cls.from_dict(data)
 
     @classmethod

--- a/rasa/core/schemas/domain.yml
+++ b/rasa/core/schemas/domain.yml
@@ -1,5 +1,9 @@
 allowempty: True
 mapping:
+  version:
+    type: "str"
+    required: False
+    allowempty: False
   intents:
     type: "seq"
     sequence:

--- a/rasa/core/training/story_reader/yaml_story_reader.py
+++ b/rasa/core/training/story_reader/yaml_story_reader.py
@@ -71,6 +71,13 @@ class YAMLStoryReader(StoryReader):
         Returns:
             The parsed stories or rules.
         """
+        from rasa.validator import Validator
+
+        if not Validator.validate_training_data_format_version(
+            parsed_content, self.source_name
+        ):
+            return []
+
         stories = parsed_content.get(KEY_STORIES, [])
         self._parse_data(stories, is_rule_data=False)
 

--- a/rasa/nlu/training_data/formats/rasa_yaml.py
+++ b/rasa/nlu/training_data/formats/rasa_yaml.py
@@ -51,8 +51,14 @@ class RasaYAMLReader(TrainingDataReader):
             New `TrainingData` object with parsed training data.
         """
         from rasa.nlu.training_data import TrainingData
+        from rasa.validator import Validator
 
         yaml_content = io_utils.read_yaml(string)
+
+        if not Validator.validate_training_data_format_version(
+            yaml_content, self.filename
+        ):
+            return TrainingData()
 
         for key, value in yaml_content.items():  # pytype: disable=attribute-error
             if key == KEY_NLU:

--- a/rasa/validator.py
+++ b/rasa/validator.py
@@ -1,19 +1,30 @@
 import logging
 from collections import defaultdict
-from typing import Set, Text, Optional
+from typing import Set, Text, Optional, Dict, Any
+
+from packaging import version
+from packaging.version import LegacyVersion
+
+import rasa.core.training.story_conflict
+from rasa.constants import (
+    DOCS_URL_DOMAINS,
+    DOCS_URL_ACTIONS,
+    LATEST_TRAINING_DATA_FORMAT_VERSION,
+    DOCS_BASE_URL,
+)
+from rasa.core.constants import UTTER_PREFIX
 from rasa.core.domain import Domain
+from rasa.core.events import ActionExecuted
+from rasa.core.events import UserUttered
 from rasa.core.training.generator import TrainingDataGenerator
+from rasa.core.training.structures import StoryGraph
 from rasa.importers.importer import TrainingDataImporter
 from rasa.nlu.training_data import TrainingData
-from rasa.core.training.structures import StoryGraph
-from rasa.core.events import UserUttered
-from rasa.core.events import ActionExecuted
-from rasa.core.constants import UTTER_PREFIX
-import rasa.core.training.story_conflict
-from rasa.constants import DOCS_URL_DOMAINS, DOCS_URL_ACTIONS
 from rasa.utils.common import raise_warning
 
 logger = logging.getLogger(__name__)
+
+KEY_TRAINING_DATA_FORMAT_VERSION = "version"
 
 
 class Validator:
@@ -257,3 +268,63 @@ class Validator:
         An empty domain is invalid."""
 
         return not self.domain.is_empty()
+
+    @staticmethod
+    def validate_training_data_format_version(
+        yaml_file_content: Dict[Text, Any], filename: Text
+    ) -> bool:
+        """Validates version on the training data content using `version` field
+           and warns users if the file is not compatible with the current version of
+           Rasa Open Source.
+
+        Args:
+            yaml_file_content: Raw content of training data file as a dictionary.
+            filename: Name of the validated file.
+
+        Returns:
+            `True` if the file can be processed by current version of Rasa Open Source,
+            `False` otherwise.
+        """
+        if not isinstance(yaml_file_content, dict):
+            raise ValueError(f"Failed to validate {filename}.")
+
+        version_value = yaml_file_content.get(KEY_TRAINING_DATA_FORMAT_VERSION)
+
+        if not version_value:
+            raise_warning(
+                f"Training data file {filename} doesn't have a "
+                f"'{KEY_TRAINING_DATA_FORMAT_VERSION}' key. "
+                f"Rasa Open Source will read the file as a "
+                f"version '{LATEST_TRAINING_DATA_FORMAT_VERSION}' file.",
+                docs=DOCS_BASE_URL,
+            )
+            return True
+
+        try:
+            parsed_version = version.parse(version_value)
+            if isinstance(parsed_version, LegacyVersion):
+                raise TypeError
+
+            if version.parse(LATEST_TRAINING_DATA_FORMAT_VERSION) >= parsed_version:
+                return True
+
+        except TypeError:
+            raise_warning(
+                f"Training data file {filename} must specify "
+                f"'{KEY_TRAINING_DATA_FORMAT_VERSION}' as string, for example:\n"
+                f"{KEY_TRAINING_DATA_FORMAT_VERSION}: '{LATEST_TRAINING_DATA_FORMAT_VERSION}'\n"
+                f"Rasa Open Source will read the file as a "
+                f"version '{LATEST_TRAINING_DATA_FORMAT_VERSION}' file.",
+                docs=DOCS_BASE_URL,
+            )
+            return True
+
+        raise_warning(
+            f"Training data file {filename} has a greater format version than "
+            f"your Rasa Open Source installation: "
+            f"{version_value} > {LATEST_TRAINING_DATA_FORMAT_VERSION}. "
+            f"Please consider updating to the latest version of Rasa Open Source."
+            f"This file will be skipped.",
+            docs=DOCS_BASE_URL,
+        )
+        return False

--- a/tests/nlu/training_data/formats/test_rasa_yaml.py
+++ b/tests/nlu/training_data/formats/test_rasa_yaml.py
@@ -3,16 +3,18 @@ from typing import Text
 import pytest
 from ruamel.yaml import YAMLError
 
+from rasa.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.nlu.constants import INTENT
 from rasa.nlu.training_data.formats.rasa_yaml import RasaYAMLReader
 
-MULTILINE_INTENT_EXAMPLES = """
-nlu:
-- intent: intent_name
-  examples: |
-     - how much CO2 will that use?
-     - how much carbon will a one way flight from [new york]{"entity": "city", "role": "from"} to california produce?
-"""
+MULTILINE_INTENT_EXAMPLES = (
+    f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"\n'
+    f"nlu:\n"
+    f" - intent: intent_name\n"
+    f"   examples: |\n"
+    f"      - how much CO2 will that use?\n"
+    f'      - how much carbon will a one way flight from [new york]{{"entity": "city", "role": "from"}} to california produce?'
+)
 
 MULTILINE_INTENT_EXAMPLES_NO_LEADING_SYMBOL = """
 nlu:
@@ -22,18 +24,19 @@ nlu:
      - how much carbon will a one way flight from [new york]{"entity": "city", "role": "from"} to california produce?
 """
 
-INTENT_EXAMPLES_WITH_METADATA = """
-nlu:
-- intent: intent_name
-  metadata:
-  examples:
-  - text: |
-      how much CO2 will that use?
-    metadata:
-      sentiment: positive
-  - text: |
-      how much carbon will a one way flight from [new york]{"entity": "city", "role": "from"} to california produce?
-"""
+INTENT_EXAMPLES_WITH_METADATA = (
+    f"version: '{LATEST_TRAINING_DATA_FORMAT_VERSION}'\n"
+    f"nlu:\n"
+    f" - intent: intent_name\n"
+    f"   metadata:\n"
+    f"   examples:\n"
+    f"    - text: |\n"
+    f"        how much CO2 will that use?\n"
+    f"      metadata:\n"
+    f"        sentiment: positive\n"
+    f"    - text: |\n"
+    f'        how much carbon will a one way flight from [new york]{{"entity": "city", "role": "from"}} to california produce?'
+)
 
 
 def test_wrong_format_raises():
@@ -71,7 +74,8 @@ def test_multiline_intent_example_is_skipped_when_no_leading_symbol():
     with pytest.warns(None) as record:
         training_data = parser.reads(MULTILINE_INTENT_EXAMPLES_NO_LEADING_SYMBOL)
 
-    assert len(record)
+    # one for missing leading symbol, one for missing version
+    assert len(record) == 2
 
     assert len(training_data.training_examples) == 1
 


### PR DESCRIPTION
Closes #6246

**Proposed changes**:
- Users are warned if training data files are not compatible
- If no version is specified, latest one is assumed


**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
