### PR TITLE
correctly (don't) interpolate non-text values in custom responses

### DIFF
--- a/changelog/6280.rst
+++ b/changelog/6280.rst
@@ -1,0 +1,1 @@
+Fixed ``TypeError: expected string or bytes-like object`` issue caused by integer, boolean, and null values in templates.

--- a/rasa/core/nlg/interpolator.py
+++ b/rasa/core/nlg/interpolator.py
@@ -10,7 +10,7 @@ def interpolate_text(template: Text, values: Dict[Text, Text]) -> Text:
 
     Transform template tags from "{tag_name}" to "{0[tag_name]}" as described here:
     https://stackoverflow.com/questions/7934620/python-dots-in-the-name-of-variable-in-a-format-string#comment9695339_7934969
-    Block list characters, making sure not to allow:
+    Block characters, making sure not to allow:
     (a) newline in slot name
     (b) { or } in slot name
 

--- a/rasa/core/nlg/interpolator.py
+++ b/rasa/core/nlg/interpolator.py
@@ -6,13 +6,23 @@ logger = logging.getLogger(__name__)
 
 
 def interpolate_text(template: Text, values: Dict[Text, Text]) -> Text:
-    # transforming template tags from
-    # "{tag_name}" to "{0[tag_name]}"
-    # as described here:
-    # https://stackoverflow.com/questions/7934620/python-dots-in-the-name-of-variable-in-a-format-string#comment9695339_7934969
-    # black list character and make sure to not to allow
-    # (a) newline in slot name
-    # (b) { or } in slot name
+    """Interpolate values into templates with placeholders.
+
+    Transform template tags from "{tag_name}" to "{0[tag_name]}" as described here:
+    https://stackoverflow.com/questions/7934620/python-dots-in-the-name-of-variable-in-a-format-string#comment9695339_7934969
+    Block list characters, making sure not to allow:
+    (a) newline in slot name
+    (b) { or } in slot name
+
+    Args:
+        template: The piece of text that should be interpolated.
+        values: A dictionary of keys and the values that those
+            keys should be replaced with.
+
+    Returns:
+        The piece of text with any replacements made.
+    """
+
     try:
         text = re.sub(r"{([^\n{}]+?)}", r"{0[\1]}", template)
         text = text.format(values)
@@ -27,13 +37,12 @@ def interpolate_text(template: Text, values: Dict[Text, Text]) -> Text:
         return text
     except KeyError as e:
         logger.exception(
-            "Failed to fill utterance template '{}'. "
-            "Tried to replace '{}' but could not find "
-            "a value for it. There is no slot with this "
-            "name nor did you pass the value explicitly "
-            "when calling the template. Return template "
-            "without filling the template. "
-            "".format(template, e.args[0])
+            f"Failed to fill utterance template '{template}'. "
+            f"Tried to replace '{e.args[0]}' but could not find "
+            f"a value for it. There is no slot with this "
+            f"name nor did you pass the value explicitly "
+            f"when calling the template. Return template "
+            f"without filling the template. "
         )
         return template
 
@@ -41,6 +50,16 @@ def interpolate_text(template: Text, values: Dict[Text, Text]) -> Text:
 def interpolate(
     template: Union[Dict[Text, Any], Text], values: Dict[Text, Text]
 ) -> Union[Dict[Text, Any], Text]:
+    """Recursively process template and interpolate any text keys.
+
+    Args:
+        template: The template that should be interpolated.
+        values: A dictionary of keys and the values that those
+            keys should be replaced with.
+
+    Returns:
+        The template with any replacements made.
+    """
     if isinstance(template, str):
         return interpolate_text(template, values)
     elif isinstance(template, dict):
@@ -49,7 +68,7 @@ def interpolate(
                 interpolate(v, values)
             elif isinstance(v, list):
                 template[k] = [interpolate(i, values) for i in v]
-            else:
+            elif isinstance(v, str):
                 template[k] = interpolate_text(v, values)
         return template
     return template

--- a/rasa/core/nlg/template.py
+++ b/rasa/core/nlg/template.py
@@ -5,7 +5,9 @@ from rasa.core.trackers import DialogueStateTracker
 from typing import Text, Any, Dict, Optional, List
 
 from rasa.core.nlg import interpolator
-from rasa.core.nlg.generator import NaturalLanguageGenerator
+from rasa.core.nlg.generator import (
+    NaturalLanguageGenerator,
+)  # pytype: disable=pyi-error
 
 logger = logging.getLogger(__name__)
 

--- a/rasa/core/nlg/template.py
+++ b/rasa/core/nlg/template.py
@@ -4,10 +4,8 @@ import logging
 from rasa.core.trackers import DialogueStateTracker
 from typing import Text, Any, Dict, Optional, List
 
-from rasa.core.nlg import interpolator
-from rasa.core.nlg.generator import (
-    NaturalLanguageGenerator,
-)  # pytype: disable=pyi-error
+from rasa.core.nlg import interpolator  # pytype: disable=pyi-error
+from rasa.core.nlg.generator import NaturalLanguageGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/rasa/core/nlg/template.py
+++ b/rasa/core/nlg/template.py
@@ -1,12 +1,11 @@
 import copy
 import logging
-from collections import defaultdict
 
 from rasa.core.trackers import DialogueStateTracker
 from typing import Text, Any, Dict, Optional, List
 
+from rasa.core.nlg import interpolator
 from rasa.core.nlg.generator import NaturalLanguageGenerator
-from rasa.core.nlg.interpolator import interpolate_text, interpolate
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +115,9 @@ class TemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
         if template_vars:
             for key in keys_to_interpolate:
                 if key in template:
-                    template[key] = interpolate(template[key], template_vars)
+                    template[key] = interpolator.interpolate(
+                        template[key], template_vars
+                    )
         return template
 
     @staticmethod

--- a/tests/core/test_nlg.py
+++ b/tests/core/test_nlg.py
@@ -138,6 +138,8 @@ def test_nlg_fill_template_custom(slot_name: Text, slot_value: Any):
         "custom": {
             "field": f"{{{slot_name}}}",
             "properties": {"field_prefixed": f"prefix_{{{slot_name}}}"},
+            "bool_field": True,
+            "int_field:": 42,
         }
     }
     t = TemplatedNaturalLanguageGenerator(templates=dict())
@@ -146,7 +148,9 @@ def test_nlg_fill_template_custom(slot_name: Text, slot_value: Any):
     assert result == {
         "custom": {
             "field": str(slot_value),
-            "properties": {"field_prefixed": f"prefix_{str(slot_value)}"},
+            "properties": {"field_prefixed": f"prefix_{slot_value}"},
+            "bool_field": True,
+            "int_field:": 42,
         }
     }
 

--- a/tests/core/test_nlg.py
+++ b/tests/core/test_nlg.py
@@ -140,6 +140,7 @@ def test_nlg_fill_template_custom(slot_name: Text, slot_value: Any):
             "properties": {"field_prefixed": f"prefix_{{{slot_name}}}"},
             "bool_field": True,
             "int_field:": 42,
+            "empty_field": None,
         }
     }
     t = TemplatedNaturalLanguageGenerator(templates=dict())
@@ -151,6 +152,7 @@ def test_nlg_fill_template_custom(slot_name: Text, slot_value: Any):
             "properties": {"field_prefixed": f"prefix_{slot_value}"},
             "bool_field": True,
             "int_field:": 42,
+            "empty_field": None,
         }
     }
 


### PR DESCRIPTION
**Proposed changes**:
- revert [this change](https://github.com/RasaHQ/rasa/pull/5875/files), which turned all template values into strings in interpolation in order to avoid int and None values from breaking templates 
- fix #5453 by bypassing interpolation for int, None, and bool values
- avoid turning ints, Nones, and bools into strings, which can negatively affect the type of the value sent to the connector

Note: when 1.10.x is merged to master, we need to revert the change in the above PR, as it won't show in the diff

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
