### PR TITLE
The triggers after EXTERNAL_REMINDER: SHOULD HAVE A TAB SPACE

### DIFF
--- a/docs/core/reminders-and-external-events.rst
+++ b/docs/core/reminders-and-external-events.rst
@@ -57,7 +57,7 @@ Finally, we define another custom action ``action_react_to_reminder`` and link i
 .. code-block:: md
 
   - EXTERNAL_reminder:
-    triggers: action_react_to_reminder
+      triggers: action_react_to_reminder
 
 where the ``action_react_to_reminder`` is
 


### PR DESCRIPTION
Otherwise it would throw an error

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
