### PR TITLE
Added a schema and a writer for the 2.0 Core training data

### DIFF
--- a/changelog/6374.feature.md
+++ b/changelog/6374.feature.md
@@ -1,0 +1,1 @@
+Added a YAML schema and a writer for 2.0 Training Core data.

--- a/data/test_mixed_yaml_md_stories/stories_part_1.yml
+++ b/data/test_mixed_yaml_md_stories/stories_part_1.yml
@@ -15,6 +15,6 @@ stories:
   steps:
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter
   - checkpoint: check_greet # checkpoint defining the end of this turn

--- a/data/test_multifile_yaml_stories/stories_part_1.yml
+++ b/data/test_multifile_yaml_stories/stories_part_1.yml
@@ -15,6 +15,6 @@ stories:
   steps:
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter
   - checkpoint: check_greet # checkpoint defining the end of this turn

--- a/data/test_yaml_stories/rules_without_stories.yml
+++ b/data/test_yaml_stories/rules_without_stories.yml
@@ -2,8 +2,8 @@ rules:
 - rule: Rule with condition
   condition:
   - active_loop: loop_q_form
-  - slot_was_set: requested_slot
-    value: some_slot
+  - slot_was_set:
+    - requested_slot: some_slot
   steps:
   - intent: inform
     entities:

--- a/data/test_yaml_stories/simple_story_with_only_end.yml
+++ b/data/test_yaml_stories/simple_story_with_only_end.yml
@@ -3,5 +3,5 @@ stories:
   steps:
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter

--- a/data/test_yaml_stories/stories.yml
+++ b/data/test_yaml_stories/stories.yml
@@ -15,8 +15,8 @@ stories:
   steps:
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter
   - checkpoint: check_greet # checkpoint defining the end of this turn
 
 - story: simple_story_with_multiple_turns

--- a/data/test_yaml_stories/stories_and_rules.yml
+++ b/data/test_yaml_stories/stories_and_rules.yml
@@ -2,8 +2,8 @@ rules:
 - rule: rule 1
   condition:
   - active_loop: loop_q_form
-  - slot_was_set: requested_slot
-    value: some_slot
+  - slot_was_set:
+    - requested_slot: some_slot
   steps:
   - intent: inform
     entities:
@@ -13,8 +13,8 @@ rules:
 - rule: rule 2
   condition:
   - active_loop: loop_q_form
-  - slot_was_set: requested_slot
-    value: some_slot
+  - slot_was_set:
+    - requested_slot: some_slot
   steps:
   - intent: explain
   - action: utter_explain_some_slot
@@ -25,7 +25,6 @@ rules:
   steps:
   - action: loop_q_form
   - active_loop: null
-  - slot_was_set: null
   - action: stop_q_form
 
 stories:
@@ -45,6 +44,6 @@ stories:
   steps:
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter
   - checkpoint: check_greet # checkpoint defining the end of this turn

--- a/data/test_yaml_stories/stories_defaultdomain.yml
+++ b/data/test_yaml_stories/stories_defaultdomain.yml
@@ -7,15 +7,11 @@ stories:
 
 - story: simple_story_with_only_end
   steps:
-  - intent: greet
-  - action: utter_greet
-  - checkpoint: check_greet # checkpoint defining the end of this turn
-
-- story: simple_story_with_only_end
-  steps:
-  - intent: greet
-    entities:
-    - name: Peter
+  - or:
+    - intent: greet
+    - intent: greet
+      entities:
+      - name: Peter
   - action: utter_greet
   - checkpoint: check_greet # checkpoint defining the end of this turn
 

--- a/data/test_yaml_stories/stories_unused_checkpoints.yml
+++ b/data/test_yaml_stories/stories_unused_checkpoints.yml
@@ -10,8 +10,8 @@ stories:
   steps:
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter
   - checkpoint: check_end_2
 
 - story:  simple_story_with_start
@@ -19,5 +19,5 @@ stories:
   - checkpoint: check_start
   - intent: hello
   - action: utter_greet
-  - slot_was_set: name
-    value: peter
+  - slot_was_set:
+    - name: peter

--- a/data/test_yaml_stories/stories_unused_checkpoints.yml
+++ b/data/test_yaml_stories/stories_unused_checkpoints.yml
@@ -20,4 +20,4 @@ stories:
   - intent: hello
   - action: utter_greet
   - slot_was_set: name
-    name: peter
+    value: peter

--- a/data/test_yaml_stories/story_with_slot_was_set.yml
+++ b/data/test_yaml_stories/story_with_slot_was_set.yml
@@ -1,0 +1,5 @@
+stories:
+- story: story with slot
+  steps:
+  - slot_was_set:
+    - name

--- a/examples/rules/data/rules.yml
+++ b/examples/rules/data/rules.yml
@@ -19,8 +19,8 @@ rules:
   condition:
   # Condition that form is active.
   - active_loop: loop_q_form
-  - slot_was_set: requested_slot
-    value: some_slot
+  - slot_was_set:
+    - requested_slot: some_slot
   steps:
   # This unhappy path handles the case of an intent `explain`.
   - intent: explain
@@ -35,8 +35,8 @@ rules:
   steps:
   - action: loop_q_form
   - active_loop: null
-  - slot_was_set: requested_slot
-    value: null
+  - slot_was_set:
+    - requested_slot: null
   # The action we want to run when the form is submitted.
   - action: utter_stop
 
@@ -52,16 +52,16 @@ rules:
 
 - rule: FAQ simple
   condition:
-  - slot_was_set: detailed_faq
-    value: false
+  - slot_was_set:
+    - detailed_faq: false
   steps:
   - intent: faq
   - action: utter_faq
 
 - rule: FAQ detailed
   condition:
-  - slot_was_set: detailed_faq
-    value: true
+  - slot_was_set:
+    - detailed_faq: true
   steps:
   - intent: faq
   - action: utter_faq
@@ -70,8 +70,8 @@ rules:
 
 - rule: FAQ helped - continue
   condition:
-  - slot_was_set: detailed_faq
-    value: true
+  - slot_was_set:
+    - detailed_faq: true
   steps:
   - action: utter_faq
   - action: utter_ask_did_help
@@ -80,8 +80,8 @@ rules:
 
 - rule: FAQ did not help
   condition:
-  - slot_was_set: detailed_faq
-    value: true
+  - slot_was_set:
+    - detailed_faq: true
   steps:
   - action: utter_faq
   - action: utter_ask_did_help
@@ -92,8 +92,8 @@ rules:
 
 - rule: Detailed FAQ did not help - continue
   condition:
-  - slot_was_set: detailed_faq
-    value: true
+  - slot_was_set:
+    - detailed_faq: true
   steps:
   - action: utter_detailed_faq
   - action: utter_ask_did_help
@@ -104,8 +104,8 @@ rules:
 
 - rule: Detailed FAQ did not help - stop
   condition:
-  - slot_was_set: detailed_faq
-    value: true
+  - slot_was_set:
+    - detailed_faq: true
   steps:
   - action: utter_detailed_faq
   - action: utter_ask_did_help

--- a/rasa/core/schemas/stories.yml
+++ b/rasa/core/schemas/stories.yml
@@ -41,25 +41,23 @@ mapping:
                 type: "str"
                 allowempty: False
           - type: "map"
-            mapping: &slot_was_set_map
-              slot_was_set:
-                type: "str"
-                allowempty: False
-              value:
-                type: "str"
-                allowempty: False
-          - type: "map"
             mapping: &slot_was_set_seq
               slot_was_set: &slot_was_set_seq_value
                 type: "seq"
+                matching: "any"
                 sequence:
                   - type: "map"
                     mapping:
                       regex;(.*):
                         type: "str"
+                  - type: "map"
+                    mapping:
+                      regex;(.*):
+                        type: "bool"
+                  - type: "str"
           - type: "map"
             matching-rule: 'any'
-            mapping: &checkpoint
+            mapping:
               checkpoint:
                 type: "str"
                 allowempty: False
@@ -95,8 +93,6 @@ mapping:
                 type: "str"
                 allowempty: False
           - type: "map"
-            mapping: *slot_was_set_map
-          - type: "map"
             mapping: *slot_was_set_seq
         condition:
           type: "seq"
@@ -105,8 +101,6 @@ mapping:
           - type: "map"
             mapping: *active_loop
           - type: "map"
-            mapping: *slot_was_set_map
-          - type: "map"
             mapping: *slot_was_set_seq
         conversation_start:
           type: "bool"
@@ -114,5 +108,3 @@ mapping:
         wait_for_user_input:
           type: "bool"
           allowempty: False
-
-

--- a/rasa/core/schemas/stories.yml
+++ b/rasa/core/schemas/stories.yml
@@ -1,0 +1,118 @@
+allowempty: True
+mapping:
+  version:
+    type: "str"
+    required: False
+    allowempty: False
+  stories:
+    type: "seq"
+    matching: "any"
+    sequence:
+    - type: "map"
+      mapping:
+        story:
+          type: "str"
+          allowempty: False
+        metadata:
+          type: "any"
+          required: False
+        steps:
+          type: "seq"
+          matching: "any"
+          sequence:
+          - type: "map"
+            mapping: &intent_and_entities
+              intent:
+                type: "str"
+                required: True
+                allowempty: False
+              entities:
+                type: "seq"
+                matching: "any"
+                sequence:
+                - type: "map"
+                  mapping:
+                    regex;(.*):
+                      type: "str"
+                - type: "str"
+          - type: "map"
+            mapping: &action
+              action:
+                type: "str"
+                allowempty: False
+          - type: "map"
+            mapping: &slot_was_set_map
+              slot_was_set:
+                type: "str"
+                allowempty: False
+              value:
+                type: "str"
+                allowempty: False
+          - type: "map"
+            mapping: &slot_was_set_seq
+              slot_was_set: &slot_was_set_seq_value
+                type: "seq"
+                sequence:
+                  - type: "map"
+                    mapping:
+                      regex;(.*):
+                        type: "str"
+          - type: "map"
+            matching-rule: 'any'
+            mapping: &checkpoint
+              checkpoint:
+                type: "str"
+                allowempty: False
+              slot_was_set: *slot_was_set_seq_value
+          - type: "map"
+            mapping:
+              or:
+                type: "seq"
+                matching: "any"
+                sequence:
+                - type: "map"
+                  mapping: *intent_and_entities
+  rules:
+    type: "seq"
+    matching: "any"
+    sequence:
+    - type: "map"
+      mapping:
+        rule:
+          type: "str"
+          allowempty: False
+        steps:
+          type: "seq"
+          matching: "any"
+          sequence:
+          - type: "map"
+            mapping: *intent_and_entities
+          - type: "map"
+            mapping: *action
+          - type: "map"
+            mapping: &active_loop
+              active_loop:
+                type: "str"
+                allowempty: False
+          - type: "map"
+            mapping: *slot_was_set_map
+          - type: "map"
+            mapping: *slot_was_set_seq
+        condition:
+          type: "seq"
+          matching: "any"
+          sequence:
+          - type: "map"
+            mapping: *active_loop
+          - type: "map"
+            mapping: *slot_was_set_map
+          - type: "map"
+            mapping: *slot_was_set_seq
+        conversation_start:
+          type: "bool"
+          allowempty: False
+        wait_for_user_input:
+          type: "bool"
+          allowempty: False
+
+

--- a/rasa/core/training/story_reader/markdown_story_reader.py
+++ b/rasa/core/training/story_reader/markdown_story_reader.py
@@ -182,7 +182,9 @@ class MarkdownStoryReader(StoryReader):
         parsed_messages = await asyncio.gather(
             *[self._parse_message(m, line_num) for m in messages]
         )
-        self.current_step_builder.add_user_messages(parsed_messages)
+        self.current_step_builder.add_user_messages(
+            parsed_messages, self.unfold_or_utterances
+        )
 
     async def _add_e2e_messages(self, e2e_messages: List[Text], line_num: int) -> None:
         if not self.current_step_builder:

--- a/rasa/core/training/story_reader/story_reader.py
+++ b/rasa/core/training/story_reader/story_reader.py
@@ -21,6 +21,7 @@ class StoryReader:
         template_vars: Optional[Dict] = None,
         use_e2e: bool = False,
         source_name: Text = None,
+        unfold_or_utterances: bool = True,
     ) -> None:
         self.story_steps = []
         self.current_step_builder: Optional[StoryStepBuilder] = None
@@ -29,6 +30,7 @@ class StoryReader:
         self.template_variables = template_vars if template_vars else {}
         self.use_e2e = use_e2e
         self.source_name = source_name
+        self.unfold_or_utterances = unfold_or_utterances
 
     async def read_from_file(self, filename: Text) -> List[StoryStep]:
         raise NotImplementedError

--- a/rasa/core/training/story_reader/story_reader.py
+++ b/rasa/core/training/story_reader/story_reader.py
@@ -23,6 +23,21 @@ class StoryReader:
         source_name: Text = None,
         unfold_or_utterances: bool = True,
     ) -> None:
+        """Constructor for the StoryReader.
+
+        Args:
+            interpreter: Interpreter to be used to parse intents.
+            domain: Domain object.
+            template_vars: Template variables to be replaced.
+            use_e2e: Specifies whether to use the e2e parser or not.
+            source_name: Name of the training data source.
+            unfold_or_utterances: Identifies if the user utterance is a part of
+              OR statement. This parameter is used only to simplify the conversation
+              from MD story files. Don't use it other ways, because it ends up
+              in a invalid story that cannot be user for real training.
+              Default value is `True`, which preserves the expected behavior
+              of the reader.
+        """
         self.story_steps = []
         self.current_step_builder: Optional[StoryStepBuilder] = None
         self.domain = domain

--- a/rasa/core/training/story_reader/story_step_builder.py
+++ b/rasa/core/training/story_reader/story_step_builder.py
@@ -65,11 +65,11 @@ class StoryStepBuilder:
         Args:
             messages: User utterances.
             unfold_or_utterances: Identifies if the user utterance is a part of
-                                  OR statement. This parameter is used only to
-                                  simplify the conversation from MD story files.
-                                  Don't use it other ways, because it ends up
-                                  in a invalid story that cannot be user for
-                                  real training.
+              OR statement. This parameter is used only to simplify the conversation
+              from MD story files. Don't use it other ways, because it ends up
+              in a invalid story that cannot be user for real training.
+              Default value is `True`, which preserves the expected behavior
+              of the reader.
         """
         self.ensure_current_steps()
 

--- a/rasa/core/training/story_reader/story_step_builder.py
+++ b/rasa/core/training/story_reader/story_step_builder.py
@@ -57,7 +57,20 @@ class StoryStepBuilder:
             end_names = {e.name for s in self.current_steps for e in s.end_checkpoints}
             return [Checkpoint(name) for name in end_names]
 
-    def add_user_messages(self, messages: List[UserUttered]) -> None:
+    def add_user_messages(
+        self, messages: List[UserUttered], unfold_or_utterances: bool = True
+    ) -> None:
+        """Adds next story steps with the user's utterances.
+
+        Args:
+            messages: User utterances.
+            unfold_or_utterances: Identifies if the user utterance is a part of
+                                  OR statement. This parameter is used only to
+                                  simplify the conversation from MD story files.
+                                  Don't use it other ways, because it ends up
+                                  in a invalid story that cannot be user for
+                                  real training.
+        """
         self.ensure_current_steps()
 
         if len(messages) == 1:
@@ -65,6 +78,12 @@ class StoryStepBuilder:
             for t in self.current_steps:
                 t.add_user_message(messages[0])
         else:
+            # this simplifies conversion between formats, but breaks the logic
+            if not unfold_or_utterances:
+                for t in self.current_steps:
+                    t.add_events(messages)
+                return
+
             # If there are multiple different intents the
             # user can use the express the same thing
             # we need to copy the blocks and create one

--- a/rasa/core/training/story_writer/yaml_story_writer.py
+++ b/rasa/core/training/story_writer/yaml_story_writer.py
@@ -1,0 +1,145 @@
+from collections import OrderedDict
+
+import ruamel.yaml as ruamel_yaml
+from typing import List, Text, Union, Optional
+
+from rasa.utils.common import raise_warning
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+from rasa.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
+from rasa.core.events import UserUttered, ActionExecuted, SlotSet, Form
+from rasa.core.training.story_reader.yaml_story_reader import (
+    KEY_STORIES,
+    KEY_STORY_NAME,
+    KEY_USER_INTENT,
+    KEY_ENTITIES,
+    KEY_ACTION,
+    KEY_STEPS,
+    KEY_CHECKPOINT,
+    KEY_SLOT_NAME,
+    KEY_SLOT_VALUE,
+    KEY_CHECKPOINT_SLOTS,
+    KEY_OR,
+)
+from rasa.core.training.structures import StoryStep, Checkpoint
+
+import rasa.utils.io as io_utils
+
+
+class YAMLStoryWriter:
+    def dumps(self, story_steps: List[StoryStep]) -> Text:
+        """Turns Story steps into a string."""
+        stream = ruamel_yaml.StringIO()
+        self.dump(stream, story_steps)
+        return stream.getvalue()
+
+    def dump(
+        self, target: Union[Text, ruamel_yaml.StringIO], story_steps: List[StoryStep],
+    ) -> None:
+        from rasa.validator import KEY_TRAINING_DATA_FORMAT_VERSION
+
+        self.target = target
+
+        stories = []
+        for story_step in story_steps:
+            processed_story_step = self.process_story_step(story_step)
+            if processed_story_step:
+                stories.append(processed_story_step)
+
+        result = OrderedDict()
+        result[KEY_TRAINING_DATA_FORMAT_VERSION] = DoubleQuotedScalarString(
+            LATEST_TRAINING_DATA_FORMAT_VERSION
+        )
+        result[KEY_STORIES] = stories
+
+        io_utils.write_yaml(result, self.target, True)
+
+    def process_story_step(self, story_step: StoryStep) -> Optional[OrderedDict]:
+
+        if self.story_contains_forms(story_step):
+            raise_warning(
+                f'File "{self.target}" contains a story "{story_step.block_name}" '
+                f"that has form(s) in it. This story cannot be converted automatically "
+                f"because of the new Rules system in the Rasa Open Source "
+                f"{LATEST_TRAINING_DATA_FORMAT_VERSION} version."
+                f"Please convert this story manually, it will be skipped now."
+            )
+            return None
+
+        result = OrderedDict()
+        result[KEY_STORY_NAME] = story_step.block_name
+        steps = self.process_checkpoints(story_step.start_checkpoints)
+
+        for event in story_step.events:
+            if isinstance(event, list):
+                utterances = self.process_or_utterances(event)
+                steps.append(utterances)
+            elif isinstance(event, UserUttered):
+                utterances = self.process_user_utterance(event)
+                steps.append(utterances)
+            elif isinstance(event, ActionExecuted):
+                steps.append(self.process_action(event))
+            elif isinstance(event, SlotSet):
+                steps.append(self.process_slot(event))
+
+        steps.extend(self.process_checkpoints(story_step.end_checkpoints))
+
+        result[KEY_STEPS] = steps
+
+        return result
+
+    @staticmethod
+    def story_contains_forms(story_step):
+        return any([event for event in story_step.events if isinstance(event, Form)])
+
+    @staticmethod
+    def process_user_utterance(user_utterance: UserUttered) -> OrderedDict:
+        result = OrderedDict()
+        result[KEY_USER_INTENT] = user_utterance.intent["name"]
+
+        if len(user_utterance.entities):
+            entities = []
+            for entity in user_utterance.entities:
+                if entity["value"]:
+                    entities.append(OrderedDict([(entity["entity"], entity["value"])]))
+                else:
+                    entities.append(entity["entity"])
+            result[KEY_ENTITIES] = entities
+
+        return result
+
+    @staticmethod
+    def process_action(action: ActionExecuted) -> OrderedDict:
+        result = OrderedDict()
+        result[KEY_ACTION] = action.action_name
+
+        return result
+
+    @staticmethod
+    def process_slot(event: SlotSet):
+        return OrderedDict([(KEY_SLOT_NAME, event.key), (KEY_SLOT_VALUE, event.value)])
+
+    @staticmethod
+    def process_checkpoints(checkpoints: List[Checkpoint]) -> List[OrderedDict]:
+        result = []
+        for checkpoint in checkpoints:
+            next_checkpoint = OrderedDict([(KEY_CHECKPOINT, checkpoint.name)])
+            if checkpoint.conditions:
+                next_checkpoint[KEY_CHECKPOINT_SLOTS] = [
+                    {key: value} for key, value in checkpoint.conditions.items()
+                ]
+            result.append(next_checkpoint)
+        return result
+
+    def process_or_utterances(self, utterances: List[UserUttered]) -> OrderedDict:
+        return OrderedDict(
+            [
+                (
+                    KEY_OR,
+                    [
+                        self.process_user_utterance(utterance)
+                        for utterance in utterances
+                    ],
+                )
+            ]
+        )

--- a/rasa/core/training/story_writer/yaml_story_writer.py
+++ b/rasa/core/training/story_writer/yaml_story_writer.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from pathlib import Path
 
 import ruamel.yaml as ruamel_yaml
 from typing import List, Text, Union, Optional
@@ -6,7 +7,7 @@ from typing import List, Text, Union, Optional
 from rasa.utils.common import raise_warning
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
-from rasa.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
+from rasa.constants import LATEST_TRAINING_DATA_FORMAT_VERSION, DOCS_URL_STORIES
 from rasa.core.events import UserUttered, ActionExecuted, SlotSet, Form
 from rasa.core.training.story_reader.yaml_story_reader import (
     KEY_STORIES,
@@ -27,15 +28,32 @@ import rasa.utils.io as io_utils
 
 
 class YAMLStoryWriter:
+    """Writes Core training data into a file in a YAML format. """
+
     def dumps(self, story_steps: List[StoryStep]) -> Text:
-        """Turns Story steps into a string."""
+        """Turns Story steps into a string.
+
+        Args:
+            story_steps: Original story steps to be converted to the YAML.
+
+        Returns:
+            String with story steps in the YAML format.
+        """
         stream = ruamel_yaml.StringIO()
         self.dump(stream, story_steps)
         return stream.getvalue()
 
     def dump(
-        self, target: Union[Text, ruamel_yaml.StringIO], story_steps: List[StoryStep],
+        self,
+        target: Union[Text, Path, ruamel_yaml.StringIO],
+        story_steps: List[StoryStep],
     ) -> None:
+        """Writes Story steps into a target file/stream.
+
+        Args:
+            target: name of the target file/stream to write the YAML to.
+            story_steps: Original story steps to be converted to the YAML.
+        """
         from rasa.validator import KEY_TRAINING_DATA_FORMAT_VERSION
 
         self.target = target
@@ -55,14 +73,22 @@ class YAMLStoryWriter:
         io_utils.write_yaml(result, self.target, True)
 
     def process_story_step(self, story_step: StoryStep) -> Optional[OrderedDict]:
+        """Converts a single story step into an ordered dict.
 
+        Args:
+            story_step: A single story step to be converted to the dict.
+
+        Returns:
+            Dict with a story step.
+        """
         if self.story_contains_forms(story_step):
             raise_warning(
                 f'File "{self.target}" contains a story "{story_step.block_name}" '
                 f"that has form(s) in it. This story cannot be converted automatically "
-                f"because of the new Rules system in the Rasa Open Source "
-                f"{LATEST_TRAINING_DATA_FORMAT_VERSION} version."
-                f"Please convert this story manually, it will be skipped now."
+                f"because of the new Rules system in Rasa Open Source "
+                f"version {LATEST_TRAINING_DATA_FORMAT_VERSION}. "
+                f"Please convert this story manually, it will be skipped now.",
+                docs=DOCS_URL_STORIES,
             )
             return None
 
@@ -89,11 +115,28 @@ class YAMLStoryWriter:
         return result
 
     @staticmethod
-    def story_contains_forms(story_step):
+    def story_contains_forms(story_step) -> bool:
+        """Checks if the story step contains form actions.
+
+        Args:
+            story_step: A single story step.
+
+        Returns:
+            `True` if the `story_step` contains at least one form action,
+            `False` otherwise.
+        """
         return any([event for event in story_step.events if isinstance(event, Form)])
 
     @staticmethod
     def process_user_utterance(user_utterance: UserUttered) -> OrderedDict:
+        """Converts a single user utterance into an ordered dict.
+
+        Args:
+            user_utterance: Original user utterance object.
+
+        Returns:
+            Dict with a user utterance.
+        """
         result = OrderedDict()
         result[KEY_USER_INTENT] = user_utterance.intent["name"]
 
@@ -110,6 +153,14 @@ class YAMLStoryWriter:
 
     @staticmethod
     def process_action(action: ActionExecuted) -> OrderedDict:
+        """Converts a single action into an ordered dict.
+
+        Args:
+            action: Original action object.
+
+        Returns:
+            Dict with an action.
+        """
         result = OrderedDict()
         result[KEY_ACTION] = action.action_name
 
@@ -117,10 +168,26 @@ class YAMLStoryWriter:
 
     @staticmethod
     def process_slot(event: SlotSet):
-        return OrderedDict([(KEY_SLOT_NAME, event.key), (KEY_SLOT_VALUE, event.value)])
+        """Converts a single `SlotSet` event into an ordered dict.
+
+        Args:
+            event: Original `SlotSet` event.
+
+        Returns:
+            Dict with an `SlotSet` event.
+        """
+        return OrderedDict([(KEY_SLOT_NAME, [{event.key: event.value}])])
 
     @staticmethod
     def process_checkpoints(checkpoints: List[Checkpoint]) -> List[OrderedDict]:
+        """Converts checkpoints event into an ordered dict.
+
+        Args:
+            checkpoints: List of original checkpoint.
+
+        Returns:
+            List of converted checkpoints.
+        """
         result = []
         for checkpoint in checkpoints:
             next_checkpoint = OrderedDict([(KEY_CHECKPOINT, checkpoint.name)])
@@ -132,6 +199,14 @@ class YAMLStoryWriter:
         return result
 
     def process_or_utterances(self, utterances: List[UserUttered]) -> OrderedDict:
+        """Converts user utterance containing the `OR` statement.
+
+        Args:
+            utterances: User utterances belonging to the same `OR` statement.
+
+        Returns:
+            Dict with converted user utterances.
+        """
         return OrderedDict(
             [
                 (

--- a/rasa/core/training/structures.py
+++ b/rasa/core/training/structures.py
@@ -4,7 +4,7 @@ from collections import deque, defaultdict
 
 import uuid
 import typing
-from typing import List, Text, Dict, Optional, Tuple, Any, Set, ValuesView
+from typing import List, Text, Dict, Optional, Tuple, Any, Set, ValuesView, Union
 
 from rasa.core import utils
 from rasa.core.actions.action import ACTION_LISTEN_NAME, ACTION_SESSION_START_NAME
@@ -79,7 +79,7 @@ class StoryStep:
         block_name: Optional[Text] = None,
         start_checkpoints: Optional[List[Checkpoint]] = None,
         end_checkpoints: Optional[List[Checkpoint]] = None,
-        events: Optional[List[Event]] = None,
+        events: Optional[List[Union[Event, List[Event]]]] = None,
         source_name: Optional[Text] = None,
         is_rule: bool = None,
     ) -> None:
@@ -113,6 +113,9 @@ class StoryStep:
 
     def add_event(self, event: Event) -> None:
         self.events.append(event)
+
+    def add_events(self, events: List[Event]) -> None:
+        self.events.append(events)
 
     @staticmethod
     def _checkpoint_string(story_step_element: Checkpoint) -> Text:

--- a/rasa/core/training/structures.py
+++ b/rasa/core/training/structures.py
@@ -188,7 +188,7 @@ class StoryStep:
 
     def explicit_events(
         self, domain: Domain, should_append_final_listen: bool = True
-    ) -> List[Event]:
+    ) -> List[Union[Event, List[Event]]]:
         """Returns events contained in the story step including implicit events.
 
         Not all events are always listed in the story dsl. This

--- a/tests/core/training/story_reader/test_yaml_story_reader.py
+++ b/tests/core/training/story_reader/test_yaml_story_reader.py
@@ -131,6 +131,20 @@ async def test_yaml_intent_with_leading_slash_warning(default_domain: Domain):
     assert tracker[0].latest_message == UserUttered("simple", {"name": "simple"})
 
 
+async def test_yaml_slot_without_value_is_parsed(default_domain: Domain):
+    yaml_file = "data/test_yaml_stories/story_with_slot_was_set.yml"
+
+    tracker = await training.load_data(
+        yaml_file,
+        default_domain,
+        use_story_concatenation=False,
+        tracker_limit=1000,
+        remove_duplicates=False,
+    )
+
+    assert tracker[0].events[-2] == SlotSet(key="name", value=None)
+
+
 async def test_yaml_wrong_yaml_format_warning(default_domain: Domain):
     yaml_file = "data/test_wrong_yaml_stories/wrong_yaml.yml"
 

--- a/tests/core/training/story_writer/test_yaml_story_writer.py
+++ b/tests/core/training/story_writer/test_yaml_story_writer.py
@@ -1,0 +1,58 @@
+from typing import Text
+
+import pytest
+
+from rasa.core.domain import Domain
+from rasa.core.interpreter import RegexInterpreter
+from rasa.core.training.story_reader.markdown_story_reader import MarkdownStoryReader
+from rasa.core.training.story_reader.yaml_story_reader import YAMLStoryReader
+from rasa.core.training.story_writer.yaml_story_writer import YAMLStoryWriter
+
+
+@pytest.mark.parametrize(
+    "input_md_file, input_yaml_file",
+    [
+        ["data/test_stories/stories.md", "data/test_yaml_stories/stories.yml"],
+        [
+            "data/test_stories/stories_defaultdomain.md",
+            "data/test_yaml_stories/stories_defaultdomain.yml",
+        ],
+    ],
+)
+async def test_simple_story(
+    tmpdir, default_domain: Domain, input_md_file: Text, input_yaml_file: Text
+):
+
+    original_md_reader = MarkdownStoryReader(
+        RegexInterpreter(),
+        default_domain,
+        None,
+        False,
+        input_yaml_file,
+        unfold_or_utterances=False,
+    )
+    original_md_story_steps = await original_md_reader.read_from_file(input_md_file)
+
+    original_yaml_reader = YAMLStoryReader(
+        RegexInterpreter(), default_domain, None, False
+    )
+    original_yaml_story_steps = await original_yaml_reader.read_from_file(
+        input_yaml_file
+    )
+
+    target_story_filename = tmpdir / "test.yml"
+    writer = YAMLStoryWriter()
+    writer.dump(target_story_filename, original_md_story_steps)
+
+    processed_yaml_reader = YAMLStoryReader(
+        RegexInterpreter(), default_domain, None, False
+    )
+    processed_yaml_story_steps = await processed_yaml_reader.read_from_file(
+        target_story_filename
+    )
+
+    assert len(processed_yaml_story_steps) == len(original_yaml_story_steps)
+    for processed_step, original_step in zip(
+        processed_yaml_story_steps, original_yaml_story_steps
+    ):
+        assert len(processed_step.events) == len(original_step.events)


### PR DESCRIPTION
Closes #6374 

**Proposed changes:**

- Added a schema and a writer for the 2.0 Core format
- Unified the syntax for `slot_was_set` event
- In this implementation we skip stories that contain forms
- This implementation of writer is done with "old MD -> YAML" in mind, so neither forms nor rules are supported now

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
