### PR TITLE
End-to-End bot utterances

### DIFF
--- a/docs/static/spec/rasa.yml
+++ b/docs/static/spec/rasa.yml
@@ -1143,6 +1143,12 @@ components:
           items:
             type: string
           example: ['action_greet', 'action_goodbye', 'action_listen']
+        end_to_end_utterances:
+          description: End-to-End bot utterances from story training data.
+          type: array
+          items:
+            type: string
+          example: ["Hi, how are you?"]
 
     BotMessage:
       type: object

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -115,18 +115,27 @@ def combine_with_templates(
 
 
 def action_from_name(
-    name: Text,
-    action_endpoint: Optional[EndpointConfig],
-    user_actions: List[Text],
-    should_use_form_action: bool = False,
+    name: Text, action_endpoint: Optional[EndpointConfig], domain: "Domain"
 ) -> "Action":
-    """Return an action instance for the name."""
+    """Return an action instance for the name.
+
+    Args:
+        name: The name of the action which should be instantiated.
+        action_endpoint: An action endpoint which can be used to execute custom actions.
+        domain: The current domain of the model.
+
+    Returns:
+        An `Action` instance.
+    """
 
     defaults = {a.name(): a for a in default_actions(action_endpoint)}
+    should_use_form_action = name in domain.form_names and domain.slot_mapping_for_form(
+        name
+    )
 
-    if name in defaults and name not in user_actions:
+    if name in defaults and name not in domain.user_actions:
         return defaults[name]
-    elif name.startswith(UTTER_PREFIX):
+    elif name.startswith(UTTER_PREFIX) or name in domain.end_to_end_utterances:
         return ActionUtterTemplate(name)
     elif name.startswith(RESPOND_PREFIX):
         return ActionRetrieveResponse(name)

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -138,18 +138,6 @@ def action_from_name(
         return RemoteAction(name, action_endpoint)
 
 
-def actions_from_names(
-    action_names: List[Text],
-    action_endpoint: Optional[EndpointConfig],
-    user_actions: List[Text],
-) -> List["Action"]:
-    """Converts the names of actions into class instances."""
-
-    return [
-        action_from_name(name, action_endpoint, user_actions) for name in action_names
-    ]
-
-
 def create_bot_utterance(message: Dict[Text, Any]) -> BotUttered:
     """Create BotUttered event from message."""
 

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -466,7 +466,7 @@ class FormAction(LoopAction):
         logger.debug(f"Request next slot '{slot_name}'")
 
         action_to_ask_for_next_slot = action.action_from_name(
-            self._name_of_utterance(domain, slot_name), None, domain.user_actions
+            self._name_of_utterance(domain, slot_name), None, domain
         )
         events_to_ask_for_next_slot = await action_to_ask_for_next_slot.run(
             output_channel, nlg, tracker, domain

--- a/rasa/core/actions/two_stage_fallback.py
+++ b/rasa/core/actions/two_stage_fallback.py
@@ -56,9 +56,7 @@ class TwoStageFallbackAction(LoopAction):
         domain: Domain,
     ) -> List[Event]:
         affirm_action = action.action_from_name(
-            ACTION_DEFAULT_ASK_AFFIRMATION_NAME,
-            self._action_endpoint,
-            domain.user_actions,
+            ACTION_DEFAULT_ASK_AFFIRMATION_NAME, self._action_endpoint, domain
         )
 
         return await affirm_action.run(output_channel, nlg, tracker, domain)
@@ -71,7 +69,7 @@ class TwoStageFallbackAction(LoopAction):
         domain: Domain,
     ) -> List[Event]:
         rephrase = action.action_from_name(
-            ACTION_DEFAULT_ASK_REPHRASE_NAME, self._action_endpoint, domain.user_actions
+            ACTION_DEFAULT_ASK_REPHRASE_NAME, self._action_endpoint, domain
         )
 
         return await rephrase.run(output_channel, nlg, tracker, domain)
@@ -139,7 +137,7 @@ class TwoStageFallbackAction(LoopAction):
         domain: Domain,
     ) -> List[Event]:
         fallback = action.action_from_name(
-            ACTION_DEFAULT_FALLBACK_NAME, self._action_endpoint, domain.user_actions
+            ACTION_DEFAULT_FALLBACK_NAME, self._action_endpoint, domain
         )
 
         return await fallback.run(output_channel, nlg, tracker, domain)

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -478,6 +478,22 @@ class Domain:
         store_entities_as_slots: bool = True,
         session_config: SessionConfig = SessionConfig.default(),
     ) -> None:
+        """Instantiate a `Domain`.
+
+        Args:
+            intents: Intent labels.
+            entities: The name of the entities which might be present in user messages.
+            slots: Slots to store information during the conversation.
+            templates: Bot responses. If an action with the same name is executed, it
+                will send the matching response to the user.
+            action_names: Names of custom actions.
+            forms: Form names and their slot mappings.
+            end_to_end_utterances: End-to-End bot utterances from end-to-end stories.
+            store_entities_as_slots: If `True` Rasa will automatically create `SlotSet`
+                events for entities if there are slots with the same name as the entity.
+            session_config: Configuration for conversation sessions. Conversation are
+                restarted at the end of a session.
+        """
 
         self.intent_properties = self.collect_intent_properties(intents, entities)
         self.entities = entities

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -11,11 +11,7 @@ from ruamel.yaml import YAMLError
 
 import rasa.core.constants
 from rasa.nlu.constants import INTENT_NAME_KEY
-from rasa.utils.common import (
-    raise_warning,
-    lazy_property,
-    sort_list_of_dicts_by_first_key,
-)
+from rasa.utils import common as common_utils
 import rasa.utils.io
 from rasa.cli.utils import bcolors, wrap_with_color
 from rasa.constants import (
@@ -168,7 +164,7 @@ class Domain:
     def from_dict(cls, data: Dict) -> "Domain":
         utter_templates = cls.collect_templates(data.get(KEY_RESPONSES, {}))
         if "templates" in data:
-            raise_warning(
+            common_utils.raise_warning(
                 "Your domain file contains the key: 'templates'. This has been "
                 "deprecated and renamed to 'responses'. The 'templates' key will "
                 "no longer work in future versions of Rasa. Please replace "
@@ -342,7 +338,7 @@ class Domain:
         explicitly_included = isinstance(properties[USE_ENTITIES_KEY], list)
         ambiguous_entities = included_entities.intersection(excluded_entities)
         if explicitly_included and ambiguous_entities:
-            raise_warning(
+            common_utils.raise_warning(
                 f"Entities: '{ambiguous_entities}' are explicitly included and"
                 f" excluded for intent '{name}'."
                 f"Excluding takes precedence in this case. "
@@ -437,7 +433,7 @@ class Domain:
 
                 # responses should be a dict with options
                 if isinstance(t, str):
-                    raise_warning(
+                    common_utils.raise_warning(
                         f"Responses should not be strings anymore. "
                         f"Response '{template_key}' should contain "
                         f"either a '- text: ' or a '- custom: ' "
@@ -506,7 +502,7 @@ class Domain:
     def __hash__(self) -> int:
 
         self_as_dict = self.as_dict()
-        self_as_dict[KEY_INTENTS] = sort_list_of_dicts_by_first_key(
+        self_as_dict[KEY_INTENTS] = common_utils.sort_list_of_dicts_by_first_key(
             self_as_dict[KEY_INTENTS]
         )
         self_as_string = json.dumps(self_as_dict, sort_keys=True)
@@ -514,20 +510,20 @@ class Domain:
 
         return int(text_hash, 16)
 
-    @lazy_property
+    @common_utils.lazy_property
     def user_actions_and_forms(self):
         """Returns combination of user actions and forms."""
 
         return self.user_actions + self.form_names
 
-    @lazy_property
+    @common_utils.lazy_property
     def num_actions(self):
         """Returns the number of available actions."""
 
         # noinspection PyTypeChecker
         return len(self.action_names)
 
-    @lazy_property
+    @common_utils.lazy_property
     def num_states(self):
         """Number of used input states for the action prediction."""
 
@@ -642,7 +638,7 @@ class Domain:
             return None
 
     # noinspection PyTypeChecker
-    @lazy_property
+    @common_utils.lazy_property
     def slot_states(self) -> List[Text]:
         """Returns all available slot state strings."""
 
@@ -653,37 +649,37 @@ class Domain:
         ]
 
     # noinspection PyTypeChecker
-    @lazy_property
+    @common_utils.lazy_property
     def prev_action_states(self) -> List[Text]:
         """Returns all available previous action state strings."""
 
         return [PREV_PREFIX + a for a in self.action_names]
 
     # noinspection PyTypeChecker
-    @lazy_property
+    @common_utils.lazy_property
     def intent_states(self) -> List[Text]:
         """Returns all available previous action state strings."""
 
         return [f"intent_{i}" for i in self.intents]
 
     # noinspection PyTypeChecker
-    @lazy_property
+    @common_utils.lazy_property
     def entity_states(self) -> List[Text]:
         """Returns all available previous action state strings."""
 
         return [f"entity_{e}" for e in self.entities]
 
     # noinspection PyTypeChecker
-    @lazy_property
+    @common_utils.lazy_property
     def form_states(self) -> List[Text]:
         return [f"active_form_{f}" for f in self.form_names]
 
-    @lazy_property
+    @common_utils.lazy_property
     def input_state_map(self) -> Dict[Text, int]:
         """Provide a mapping from state names to indices."""
         return {f: i for i, f in enumerate(self.input_states)}
 
-    @lazy_property
+    @common_utils.lazy_property
     def input_states(self) -> List[Text]:
         """Returns all available states."""
 
@@ -964,7 +960,7 @@ class Domain:
         """Return the configuration for an intent."""
         return self.intent_properties.get(intent_name, {})
 
-    @lazy_property
+    @common_utils.lazy_property
     def intents(self):
         return sorted(self.intent_properties.keys())
 
@@ -1153,7 +1149,7 @@ class Domain:
 
         if missing_templates:
             for template in missing_templates:
-                raise_warning(
+                common_utils.raise_warning(
                     f"Action '{template}' is listed as a "
                     f"response action in the domain file, but there is "
                     f"no matching response defined. Please "

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -632,6 +632,11 @@ class Domain:
     def random_template_for(self, utter_action: Text) -> Optional[Dict[Text, Any]]:
         import numpy as np
 
+        common_utils.raise_warning(
+            "This method is deprecated and will be removed in " "future versions.",
+            category=DeprecationWarning,
+        )
+
         if utter_action in self.templates:
             return np.random.choice(self.templates[utter_action])
         else:

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -595,16 +595,7 @@ class Domain:
         if action_name not in self.action_names:
             self._raise_action_not_found_exception(action_name)
 
-        should_use_form_action = (
-            action_name in self.form_names and self.slot_mapping_for_form(action_name)
-        )
-
-        return action.action_from_name(
-            action_name,
-            action_endpoint,
-            self.user_actions_and_forms,
-            should_use_form_action,
-        )
+        return action.action_from_name(action_name, action_endpoint, self)
 
     def action_for_index(
         self, index: int, action_endpoint: Optional[EndpointConfig]

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -938,6 +938,9 @@ class Domain:
         if domain_data["config"]["store_entities_as_slots"]:
             del domain_data["config"]["store_entities_as_slots"]
 
+        # End-to-end utterances should not be dumped in the cleaned version.
+        domain_data.pop(KEY_END_TO_END_BOT_UTTERANCES, None)
+
         # clean empty keys
         return {
             k: v

--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -54,7 +54,7 @@ KEY_ENTITIES = "entities"
 KEY_RESPONSES = "responses"
 KEY_ACTIONS = "actions"
 KEY_FORMS = "forms"
-KEY_E2E_ACTIONS = "e2e_actions"
+KEY_END_TO_END_BOT_UTTERANCES = "end_to_end_bot_utterances"
 
 ALL_DOMAIN_KEYS = [
     KEY_SLOTS,
@@ -63,7 +63,7 @@ ALL_DOMAIN_KEYS = [
     KEY_ENTITIES,
     KEY_INTENTS,
     KEY_RESPONSES,
-    KEY_E2E_ACTIONS,
+    KEY_END_TO_END_BOT_UTTERANCES,
 ]
 
 
@@ -186,7 +186,7 @@ class Domain:
             utter_templates,
             data.get(KEY_ACTIONS, []),
             data.get(KEY_FORMS, []),
-            data.get(KEY_E2E_ACTIONS, []),
+            data.get(KEY_END_TO_END_BOT_UTTERANCES, []),
             session_config=session_config,
             **additional_arguments,
         )
@@ -277,7 +277,7 @@ class Domain:
             if form in domain_dict[KEY_ACTIONS]:
                 domain_dict[KEY_ACTIONS].remove(form)
 
-        for key in [KEY_ENTITIES, KEY_ACTIONS, KEY_E2E_ACTIONS]:
+        for key in [KEY_ENTITIES, KEY_ACTIONS, KEY_END_TO_END_BOT_UTTERANCES]:
             combined[key] = merge_lists(combined[key], domain_dict[key])
 
         for key in [KEY_RESPONSES, KEY_SLOTS]:
@@ -462,7 +462,7 @@ class Domain:
         templates: Dict[Text, List[Dict[Text, Any]]],
         action_names: List[Text],
         forms: List[Union[Text, Dict]],
-        e2e_action_texts: Optional[List[Text]] = None,
+        end_to_end_bot_utterances: Optional[List[Text]] = None,
         store_entities_as_slots: bool = True,
         session_config: SessionConfig = SessionConfig.default(),
     ) -> None:
@@ -481,7 +481,7 @@ class Domain:
 
         self.slots = slots
         self.templates = templates
-        self.e2e_action_texts = e2e_action_texts or []
+        self.end_to_end_bot_utterances = end_to_end_bot_utterances or []
         self.session_config = session_config
 
         self._custom_actions = action_names
@@ -493,7 +493,7 @@ class Domain:
         self.action_names = (
             action.combine_user_with_default_actions(self.user_actions)
             + self.form_names
-            + self.e2e_action_texts
+            + self.end_to_end_bot_utterances
         )
 
         self.store_entities_as_slots = store_entities_as_slots
@@ -863,9 +863,9 @@ class Domain:
             KEY_ENTITIES: self.entities,
             KEY_SLOTS: self._slot_definitions(),
             KEY_RESPONSES: self.templates,
-            KEY_ACTIONS: self._custom_actions,  # class names of the actions
+            KEY_ACTIONS: self._custom_actions,
             KEY_FORMS: self.forms,
-            KEY_E2E_ACTIONS: self.e2e_action_texts,
+            KEY_END_TO_END_BOT_UTTERANCES: self.end_to_end_bot_utterances,
         }
 
     def persist(self, filename: Union[Text, Path]) -> None:

--- a/rasa/importers/importer.py
+++ b/rasa/importers/importer.py
@@ -302,9 +302,9 @@ class E2EImporter(TrainingDataImporter):
 
         stories = await self.get_stories()
 
-        e2e_action_texts = set()
+        e2e_utterances = set()
         for story_step in stories.story_steps:
-            e2e_action_texts.update(
+            e2e_utterances.update(
                 {
                     event.e2e_text
                     for event in story_step.events
@@ -312,7 +312,7 @@ class E2EImporter(TrainingDataImporter):
                 }
             )
 
-        e2e_action_texts = list(e2e_action_texts)
+        e2e_utterances = list(e2e_utterances)
 
         return Domain(
             [],
@@ -321,7 +321,7 @@ class E2EImporter(TrainingDataImporter):
             {},
             action_names=[],
             forms=[],
-            end_to_end_utterances=e2e_action_texts,
+            end_to_end_utterances=e2e_utterances,
         )
 
     async def get_stories(

--- a/rasa/importers/importer.py
+++ b/rasa/importers/importer.py
@@ -220,7 +220,7 @@ class CoreDataImporter(TrainingDataImporter):
         exclusion_percentage: Optional[int] = None,
     ) -> StoryGraph:
         return await self._importer.get_stories(
-            interpreter, template_variables, use_e2e, exclusion_percentage,
+            interpreter, template_variables, use_e2e, exclusion_percentage
         )
 
     async def get_config(self) -> Dict:
@@ -315,7 +315,13 @@ class E2EImporter(TrainingDataImporter):
         e2e_action_texts = list(e2e_action_texts)
 
         return Domain(
-            [], [], [], {}, action_names=[], forms=[], e2e_action_texts=e2e_action_texts
+            [],
+            [],
+            [],
+            {},
+            action_names=[],
+            forms=[],
+            end_to_end_bot_utterances=e2e_action_texts,
         )
 
     async def get_stories(
@@ -375,7 +381,7 @@ class E2EImporter(TrainingDataImporter):
         additional_messages_from_actions_in_domain = [
             Message.build_from_action(action_name=action_name)
             for action_name in domain.action_names
-            if action_name not in domain.e2e_action_texts
+            if action_name not in domain.end_to_end_bot_utterances
         ]
 
         return TrainingData(additional_messages_from_actions_in_domain)
@@ -396,7 +402,7 @@ def _messages_from_user_utterance(event: UserUttered) -> Message:
 
 def _messages_from_action(event: ActionExecuted) -> Message:
     return Message.build_from_action(
-        action_name=event.action_name, action_text=event.e2e_text or "",
+        action_name=event.action_name, action_text=event.e2e_text or ""
     )
 
 

--- a/rasa/importers/importer.py
+++ b/rasa/importers/importer.py
@@ -321,7 +321,7 @@ class E2EImporter(TrainingDataImporter):
             {},
             action_names=[],
             forms=[],
-            end_to_end_bot_utterances=e2e_action_texts,
+            end_to_end_utterances=e2e_action_texts,
         )
 
     async def get_stories(
@@ -381,7 +381,7 @@ class E2EImporter(TrainingDataImporter):
         additional_messages_from_actions_in_domain = [
             Message.build_from_action(action_name=action_name)
             for action_name in domain.action_names
-            if action_name not in domain.end_to_end_bot_utterances
+            if action_name not in domain.end_to_end_utterances
         ]
 
         return TrainingData(additional_messages_from_actions_in_domain)

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -87,23 +87,6 @@ def test_text_format():
     )
 
 
-def test_action_instantiation_from_names():
-    instantiated_actions = action.actions_from_names(
-        ["random_name", "utter_test", "respond_test"],
-        None,
-        ["random_name", "utter_test"],
-    )
-    assert len(instantiated_actions) == 3
-    assert isinstance(instantiated_actions[0], RemoteAction)
-    assert instantiated_actions[0].name() == "random_name"
-
-    assert isinstance(instantiated_actions[1], ActionUtterTemplate)
-    assert instantiated_actions[1].name() == "utter_test"
-
-    assert isinstance(instantiated_actions[2], ActionRetrieveResponse)
-    assert instantiated_actions[2].name() == "respond_test"
-
-
 def test_domain_action_instantiation():
     domain = Domain(
         intents={},

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -707,7 +707,7 @@ def test_get_end_to_end_utterance_action():
         f"""
     actions:
     - my_action
-    
+
     {KEY_END_TO_END_UTTERANCES}:
     - {end_to_end_utterance}
     - Bye Bye

--- a/tests/core/test_domain.py
+++ b/tests/core/test_domain.py
@@ -761,6 +761,29 @@ def test_clean_domain_deprecated_templates():
     assert hash(actual) == hash(expected)
 
 
+def test_domain_cleaning_end_to_end_bot_utterances():
+    domain = Domain.from_yaml(
+        """
+intents:
+- greet
+- bye
+
+actions:
+- utter_greet
+
+end_to_end_bot_utterances:
+- hi
+- bye
+    """
+    )
+
+    end_to_end_utterances = ["hi", "bye"]
+    assert domain.end_to_end_bot_utterances == end_to_end_utterances
+
+    cleaned = domain.cleaned_domain()
+    assert KEY_END_TO_END_BOT_UTTERANCES not in cleaned
+
+
 def test_add_knowledge_base_slots(default_domain):
     # don't modify default domain as it is used in other tests
     test_domain = copy.deepcopy(default_domain)

--- a/tests/core/test_domain.py
+++ b/tests/core/test_domain.py
@@ -188,7 +188,8 @@ def test_utter_templates():
             {"title": "super sad", "payload": "/mood_unhappy"},
         ],
     }
-    assert domain.random_template_for("utter_greet") == expected_template
+    with pytest.warns(DeprecationWarning):
+        assert domain.random_template_for("utter_greet") == expected_template
 
 
 def test_custom_slot_type(tmpdir: Path):

--- a/tests/importers/test_importer.py
+++ b/tests/importers/test_importer.py
@@ -215,7 +215,7 @@ async def test_import_nlu_training_data_from_e2e_stories(project: Text):
         Message(data={ACTION_NAME: "utter_greet_from_stories", ACTION_TEXT: ""}),
         Message(data={TEXT: "how are you doing?", INTENT_NAME: None}),
         Message(
-            data={ACTION_NAME: "utter_greet_from_stories", ACTION_TEXT: "Hi Joey.",},
+            data={ACTION_NAME: "utter_greet_from_stories", ACTION_TEXT: "Hi Joey."}
         ),
     ]
 
@@ -291,3 +291,7 @@ async def test_adding_e2e_actions_to_domain(project: Text):
     domain = await importer.get_domain()
 
     assert all(action_name in domain.action_names for action_name in additional_actions)
+    assert set(additional_actions) == set(domain.end_to_end_utterances)
+    assert all(
+        action_name in domain.templates.keys() for action_name in additional_actions
+    )


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/6410
- add more tests for uncovered Domain code
- add end to end utterances to the templates (they won't be dumped in the `responses` section)
- don't dump end-to-end-utterances when getting the `Domain.cleaned_domain()` (we need it in the regular `domain.as_dict` as the model needs the end to end actions when reading it in)
- deprecate `random_template_for` as it's unused
- remove `actions_from_names` as it's unused an not part of the public API
- run `ActionUtterTemplate` for end-to-end utterances: It's a slight overkill at the moment since we have pure text utterances. I went for it as it's more consistent and enables simple extendability

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
