### PR TITLE
rename `FormValidation`

### DIFF
--- a/changelog/6463.removal.md
+++ b/changelog/6463.removal.md
@@ -1,0 +1,2 @@
+The conversation event `form_validation` was renamed to `loop_unhappy`. Rasa Open Source
+will continue to be able to read and process old `form_validation` events.

--- a/rasa/core/policies/form_policy.py
+++ b/rasa/core/policies/form_policy.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Text, Optional, Any
 from rasa.constants import DOCS_URL_MIGRATION_GUIDE
 from rasa.core.actions.action import ACTION_LISTEN_NAME
 from rasa.core.domain import PREV_PREFIX, ACTIVE_FORM_PREFIX, Domain
-from rasa.core.events import FormValidation
+from rasa.core.events import LoopUnhappy
 from rasa.core.featurizers import TrackerFeaturizer
 from rasa.core.interpreter import NaturalLanguageInterpreter, RegexInterpreter
 from rasa.core.policies.memoization import MemoizationPolicy
@@ -148,7 +148,7 @@ class FormPolicy(MemoizationPolicy):
 
                 if tracker.active_loop.get("rejected"):
                     if self.state_is_unhappy(tracker, domain):
-                        tracker.update(FormValidation(False))
+                        tracker.update(LoopUnhappy(False))
                         return result
 
                 result = self._prediction_result(

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Text, Optional, Any, Set, TYPE_CHECKING
 import re
 from collections import defaultdict
 
-from rasa.core.events import FormValidation
+from rasa.core.events import LoopUnhappy
 from rasa.core.domain import PREV_PREFIX, ACTIVE_FORM_PREFIX, Domain, InvalidDomain
 from rasa.core.featurizers import TrackerFeaturizer
 from rasa.core.interpreter import NaturalLanguageInterpreter, RegexInterpreter
@@ -467,7 +467,7 @@ class RulePolicy(MemoizationPolicy):
 
             if DO_NOT_VALIDATE_FORM in unhappy_path_conditions:
                 logger.debug("Added `FormValidation(False)` event.")
-                tracker.update(FormValidation(False))
+                tracker.update(LoopUnhappy(False))
 
         if predicted_action_name is not None:
             logger.debug(

--- a/rasa/core/trackers.py
+++ b/rasa/core/trackers.py
@@ -234,9 +234,23 @@ class DialogueStateTracker:
         )
         self.change_loop_to(form_name)
 
-    def set_form_validation(self, validate: bool) -> None:
-        """Toggle form validation"""
+    # TODO: Change this :-D
+    def make_loop_unhappy(self, validate: bool) -> None:
+        """Toggle loop validation.
+
+        Args:
+            validate: `False` if the loop was run after an unhappy path.
+        """
         self.active_loop["validate"] = validate
+
+    def set_form_validation(self, validate: bool) -> None:
+        common_utils.raise_warning(
+            "`set_form_validation` is deprecated and will be removed "
+            "in future versions. Please use `change_loop_to` "
+            "instead.",
+            category=DeprecationWarning,
+        )
+        self.make_loop_unhappy(validate)
 
     def reject_action(self, action_name: Text) -> None:
         """Notify active loop that it was rejected"""

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -27,7 +27,7 @@ from rasa.core.events import (
     ActiveLoop,
     SlotSet,
     ActionExecutionRejected,
-    FormValidation,
+    LoopUnhappy,
 )
 from rasa.core.interpreter import RegexInterpreter
 from rasa.core.nlg import TemplatedNaturalLanguageGenerator
@@ -645,7 +645,7 @@ async def test_form_unhappy_path_no_validation_from_rule():
     action_probabilities = policy.predict_action_probabilities(tracker, domain)
     assert_predicted_action(action_probabilities, domain, form_name)
     # check that RulePolicy added FormValidation False event based on the training rule
-    assert tracker.events[-1] == FormValidation(False)
+    assert tracker.events[-1] == LoopUnhappy(False)
 
 
 async def test_form_unhappy_path_no_validation_from_story():
@@ -712,7 +712,7 @@ async def test_form_unhappy_path_no_validation_from_story():
     # there is no rule for next action
     assert max(action_probabilities) == policy._core_fallback_threshold
     # check that RulePolicy added FormValidation False event based on the training story
-    assert tracker.events[-1] == FormValidation(False)
+    assert tracker.events[-1] == LoopUnhappy(False)
 
 
 async def test_form_unhappy_path_without_rule():

--- a/tests/core/test_trackers.py
+++ b/tests/core/test_trackers.py
@@ -26,6 +26,8 @@ from rasa.core.events import (
     ActionExecutionRejected,
     BotUttered,
     LegacyForm,
+    LoopUnhappy,
+    LegacyFormValidation,
 )
 from rasa.core.slots import FloatSlot, BooleanSlot, ListSlot, TextSlot, DataSlot, Slot
 from rasa.core.tracker_store import (
@@ -1111,3 +1113,45 @@ def test_change_form_to_deprecation_warning():
         tracker.change_form_to(new_form)
 
     assert tracker.active_loop_name() == new_form
+
+
+def test_reading_of_trackers_with_legacy_form_validation_events():
+    tracker = DialogueStateTracker.from_dict(
+        "sender",
+        events_as_dict=[
+            {"event": LegacyFormValidation.type_name, "name": None, "validate": True},
+            {"event": LegacyFormValidation.type_name, "name": None, "validate": False},
+        ],
+    )
+
+    expected_events = [LegacyFormValidation(True), LegacyFormValidation(False)]
+    actual_events = list(tracker.events)
+    assert list(tracker.events) == expected_events
+    assert actual_events[0].validate
+    assert not actual_events[1].validate
+
+    assert not tracker.active_loop.get("validate")
+
+
+def test_writing_trackers_with_legacy_for_validation_events():
+    tracker = DialogueStateTracker.from_events(
+        "sender", evts=[LegacyFormValidation(True), LegacyFormValidation(False)]
+    )
+
+    events_as_dict = [event.as_dict() for event in tracker.events]
+
+    for event in events_as_dict:
+        assert event["event"] == LoopUnhappy.type_name
+
+    assert events_as_dict[0]["validate"]
+    assert not events_as_dict[1]["validate"]
+
+
+@pytest.mark.parametrize("validate", [True, False])
+def test_set_form_validation_deprecation_warning(validate: bool):
+    tracker = DialogueStateTracker.from_events("conversation", evts=[])
+
+    with pytest.warns(DeprecationWarning):
+        tracker.set_form_validation(validate)
+
+    assert tracker.active_loop["validate"] == validate

--- a/tests/core/training/story_reader/test_markdown_story_reader.py
+++ b/tests/core/training/story_reader/test_markdown_story_reader.py
@@ -6,7 +6,7 @@ from rasa.core.events import (
     ActionExecuted,
     ActionExecutionRejected,
     ActiveLoop,
-    FormValidation,
+    LoopUnhappy,
     SlotSet,
     LegacyForm,
 )
@@ -124,7 +124,7 @@ async def test_persist_legacy_form_story():
         ActionExecuted("action_listen"),
         # out of form input but continue with the form
         UserUttered(intent={"name": "affirm"}),
-        FormValidation(False),
+        LoopUnhappy(False),
         ActionExecuted("some_form"),
         ActionExecuted("action_listen"),
         # out of form input
@@ -134,7 +134,7 @@ async def test_persist_legacy_form_story():
         ActionExecuted("action_listen"),
         # form input
         UserUttered(intent={"name": "inform"}),
-        FormValidation(True),
+        LoopUnhappy(True),
         ActionExecuted("some_form"),
         ActionExecuted("action_listen"),
         ActiveLoop(None),
@@ -199,7 +199,7 @@ async def test_persist_form_story():
         ActionExecuted("action_listen"),
         # out of form input but continue with the form
         UserUttered(intent={"name": "affirm"}),
-        FormValidation(False),
+        LoopUnhappy(False),
         ActionExecuted("some_form"),
         ActionExecuted("action_listen"),
         # out of form input
@@ -209,7 +209,7 @@ async def test_persist_form_story():
         ActionExecuted("action_listen"),
         # form input
         UserUttered(intent={"name": "inform"}),
-        FormValidation(True),
+        LoopUnhappy(True),
         ActionExecuted("some_form"),
         ActionExecuted("action_listen"),
         ActiveLoop(None),


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/6463
- rename `FormValidation` event to `TBD` event
- introduced a class which can handle and represent the old `form_validation` events

**Todos**
- [ ] find a proper name

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
