### PR TITLE
`rasa data convert` should be able to convert forms to `YAML` format

### DIFF
--- a/rasa/cli/data.py
+++ b/rasa/cli/data.py
@@ -8,7 +8,7 @@ from typing import List
 from rasa import data
 from rasa.cli.arguments import data as arguments
 import rasa.cli.utils
-from rasa.constants import DEFAULT_DATA_PATH
+from rasa.constants import DEFAULT_DATA_PATH, DOCS_URL_RULES
 from rasa.core.training.story_reader.markdown_story_reader import MarkdownStoryReader
 from rasa.core.training.story_writer.yaml_story_writer import YAMLStoryWriter
 from rasa.nlu.convert import convert_training_data
@@ -287,11 +287,23 @@ def _write_nlu_yaml(
 def _write_core_yaml(
     training_data_path: Path, output_path: Path, source_path: Path
 ) -> None:
+    from rasa.core.training.story_reader.yaml_story_reader import KEY_ACTIVE_LOOP
+
     reader = MarkdownStoryReader()
     writer = YAMLStoryWriter()
 
     loop = asyncio.get_event_loop()
     steps = loop.run_until_complete(reader.read_from_file(training_data_path))
+
+    if YAMLStoryWriter.stories_contain_loops(steps):
+        print_warning(
+            f"Training data file '{source_path}' contains forms. "
+            f"Any 'form' events will be converted to '{KEY_ACTIVE_LOOP}' events. "
+            f"Please note that in order for these stories to work you still "
+            f"need the 'FormPolicy' to be active. However the 'FormPolicy' is "
+            f"deprecated, please consider switching to the new 'RulePolicy', "
+            f"for which you can find the documentation here: {DOCS_URL_RULES}."
+        )
 
     writer.dump(output_path, steps)
 

--- a/rasa/core/training/story_writer/yaml_story_writer.py
+++ b/rasa/core/training/story_writer/yaml_story_writer.py
@@ -1,18 +1,16 @@
 from collections import OrderedDict
 from pathlib import Path
-
-from ruamel import yaml
 from typing import Any, Dict, List, Text, Union, Optional
 
+from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.scalarstring import (
     DoubleQuotedScalarString,
     LiteralScalarString,
 )
 
-from rasa.utils.common import raise_warning
-
-from rasa.constants import LATEST_TRAINING_DATA_FORMAT_VERSION, DOCS_URL_STORIES
+import rasa.utils.io as io_utils
+from rasa.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.core.events import UserUttered, ActionExecuted, SlotSet, ActiveLoop
 from rasa.core.training.story_reader.yaml_story_reader import (
     KEY_STORIES,
@@ -26,10 +24,9 @@ from rasa.core.training.story_reader.yaml_story_reader import (
     KEY_CHECKPOINT_SLOTS,
     KEY_OR,
     KEY_USER_MESSAGE,
+    KEY_ACTIVE_LOOP,
 )
 from rasa.core.training.structures import StoryStep, Checkpoint
-
-import rasa.utils.io as io_utils
 
 
 class YAMLStoryWriter:
@@ -71,8 +68,7 @@ class YAMLStoryWriter:
         stories = []
         for story_step in story_steps:
             processed_story_step = self.process_story_step(story_step)
-            if processed_story_step:
-                stories.append(processed_story_step)
+            stories.append(processed_story_step)
 
         result = OrderedDict()
         result[KEY_TRAINING_DATA_FORMAT_VERSION] = DoubleQuotedScalarString(
@@ -82,7 +78,7 @@ class YAMLStoryWriter:
         result[KEY_STORIES] = stories
         return result
 
-    def process_story_step(self, story_step: StoryStep) -> Optional[OrderedDict]:
+    def process_story_step(self, story_step: StoryStep) -> OrderedDict:
         """Converts a single story step into an ordered dict.
 
         Args:
@@ -91,17 +87,6 @@ class YAMLStoryWriter:
         Returns:
             Dict with a story step.
         """
-        if self.story_contains_forms(story_step):
-            raise_warning(
-                f'Training data file contains a story "{story_step.block_name}" '
-                f"that has form(s) in it. This story cannot be converted automatically "
-                f"because of the new Rules system in Rasa Open Source "
-                f"version {LATEST_TRAINING_DATA_FORMAT_VERSION}. "
-                f"Please convert this story manually, it will be skipped now.",
-                docs=DOCS_URL_STORIES,
-            )
-            return None
-
         result = OrderedDict()
         result[KEY_STORY_NAME] = story_step.block_name
         steps = self.process_checkpoints(story_step.start_checkpoints)
@@ -117,6 +102,8 @@ class YAMLStoryWriter:
                 steps.append(self.process_action(event))
             elif isinstance(event, SlotSet):
                 steps.append(self.process_slot(event))
+            elif isinstance(event, ActiveLoop):
+                steps.append(self.process_active_loop(event))
 
         steps.extend(self.process_checkpoints(story_step.end_checkpoints))
 
@@ -125,18 +112,21 @@ class YAMLStoryWriter:
         return result
 
     @staticmethod
-    def story_contains_forms(story_step) -> bool:
-        """Checks if the story step contains form actions.
+    def stories_contain_loops(stories: List[StoryStep]) -> bool:
+        """Checks if the stories contain at least one active loop.
 
         Args:
-            story_step: A single story step.
+            stories: Stories steps.
 
         Returns:
-            `True` if the `story_step` contains at least one form action,
+            `True` if the `stories` contain at least one active loop.
             `False` otherwise.
         """
         return any(
-            [event for event in story_step.events if isinstance(event, ActiveLoop)]
+            [
+                [event for event in story_step.events if isinstance(event, ActiveLoop)]
+                for story_step in stories
+            ]
         )
 
     @staticmethod
@@ -248,3 +238,15 @@ class YAMLStoryWriter:
                 )
             ]
         )
+
+    @staticmethod
+    def process_active_loop(event: ActiveLoop) -> OrderedDict:
+        """Converts ActiveLoop event into an ordered dict.
+
+        Args:
+            event: ActiveLoop event.
+
+        Returns:
+            Converted event.
+        """
+        return OrderedDict([(KEY_ACTIVE_LOOP, event.name)])

--- a/rasa/utils/io.py
+++ b/rasa/utils/io.py
@@ -293,6 +293,12 @@ def write_yaml(
     # no wrap lines
     dumper.width = YAML_LINE_MAX_WIDTH
 
+    # use `null` to represent `None`
+    dumper.representer.add_representer(
+        type(None),
+        lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", "null"),
+    )
+
     if isinstance(target, StringIO):
         dumper.dump(data, target)
         return

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -133,6 +133,7 @@ def test_rasa_data_convert_to_yaml(
     ## happy path
     * greet
         - utter_greet
+        - form{"name": null}
     """
 
     with open("data/stories.md", "w") as f:

--- a/tests/core/training/story_writer/test_yaml_story_writer.py
+++ b/tests/core/training/story_writer/test_yaml_story_writer.py
@@ -31,6 +31,8 @@ async def test_simple_story(
     )
     original_md_story_steps = await original_md_reader.read_from_file(input_md_file)
 
+    assert not YAMLStoryWriter.stories_contain_loops(original_md_story_steps)
+
     original_yaml_reader = YAMLStoryReader(default_domain, None, False)
     original_yaml_story_steps = await original_yaml_reader.read_from_file(
         input_yaml_file
@@ -52,7 +54,7 @@ async def test_simple_story(
         assert len(processed_step.events) == len(original_step.events)
 
 
-async def test_forms_are_skipped_with_warning(default_domain: Domain):
+async def test_forms_are_converted(default_domain: Domain):
     original_md_reader = MarkdownStoryReader(
         default_domain, None, False, unfold_or_utterances=False,
     )
@@ -60,13 +62,14 @@ async def test_forms_are_skipped_with_warning(default_domain: Domain):
         "data/test_stories/stories_form.md"
     )
 
+    assert YAMLStoryWriter.stories_contain_loops(original_md_story_steps)
+
     writer = YAMLStoryWriter()
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(None) as record:
         writer.dumps(original_md_story_steps)
 
-    # We skip 5 stories with the forms and warn users
-    assert len(record) == 5
+    assert len(record) == 0
 
 
 def test_yaml_writer_dumps_user_messages():


### PR DESCRIPTION
Closes #6501 

**Proposed changes**:
- `form` is converted to `active_loop`
- users are warned that `FormPolicy` has to be activated

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
