### PR TITLE
Action server documentation

### DIFF
--- a/docs/docs/action-server-api.mdx
+++ b/docs/docs/action-server-api.mdx
@@ -1,0 +1,26 @@
+---
+id: action-server-api
+sidebar_label: Action Server API Spec
+title: Action Server API Spec
+---
+
+The [action server](action-server.mdx) must implement an endpoint with the spec below to receive HTTP `POST` requests from the Rasa Server.
+The action server can serve any other additional endpoints, but the Rasa server will only send
+requests to the one specified in 
+`endpoints.yml`.
+
+For a Rasa SDK action server running locally, the endpoint would look like this:
+
+```yaml-rasa
+action_endpoint:
+  url: "http://action-server:5055/webhook"
+```
+
+The Rasa server will send a `POST` request to this endpoint
+ and will expect a response in the format specified below.
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import Redoc from '@site/src/components/redoc';
+
+
+<Redoc specUrl={useBaseUrl("/spec/action-server.yml")} />

--- a/docs/docs/action-server.mdx
+++ b/docs/docs/action-server.mdx
@@ -2,11 +2,44 @@
 id: action-server
 sidebar_label: Action Server
 title: Action Server
-description: Check out the API docs for open source chatbot framework Rasa's action server, which allows you to define your own custom actions.
-hide_table_of_contents: true
+description: Find out about SDKs for writing custom actions and running the action server
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import Redoc from '@site/src/components/redoc';
+Custom actions are run by the action server. 
+When your assistant predicts a custom action, the Rasa server sends 
+a `POST` request to the action server with a json payload including
+the name of the predicted action,
+the conversation ID, the contents of the tracker and the contents of the domain.
 
-<Redoc specUrl={useBaseUrl("/spec/action-server.yml")} />
+When the action server finishes running a custom action, it returns a json payload
+of [responses](responses.mdx) and [events](events.mdx). The Rasa server then returns
+the responses to the user and adds the events
+to the conversation tracker. 
+
+See the [action server API spec](action-server-api.mdx) for details of the payload sent to the action server
+and the expected response format.
+See the [documentation for events](events.mdx) for details
+about event types that can be returned.
+
+
+## SDKs for Custom Actions
+
+### Rasa SDK (Python)
+
+The [Rasa SDK]() is a Python SDK for running custom actions. It provides
+the required endpoint and the base `Action` class, as well as methods for interacting
+with the tracker and sending messages in specific formats (e.g. images, buttons, custom payloads for 
+specific messaging channels). If you don't yet have an action server and don't need it
+to be in a language other than Python, using the Rasa SDK will be the easiest way
+to get started.
+See the [docs for the Rasa SDK]() for more details.
+
+### SDKs in Other Languages
+
+If you have legacy code or existing business logic in a language 
+other than Python, you may not want to use the Rasa SDK. In this case you can write
+your own action server in any language you want. The only requirement
+for the action server is that it provide an endpoint which accepts HTTP `POST` requests
+from the Rasa server and returns a list of [events](events.mdx). 
+See the [page on custom actions]() for details about the information that will be passed
+to the action server and what can be done with it.

--- a/docs/docs/custom-actions.mdx
+++ b/docs/docs/custom-actions.mdx
@@ -45,6 +45,86 @@ the action server, with the following information:
 ```
 
 Your action server should respond with a list of events and responses:
+An action can run any code you want. Custom actions can turn on the lights,
+add an event to a calendar, check a user's bank balance, send the user a message,
+or anything
+else you can imagine.
+
+Custom actions are run by the [action server](action-server.mdx), which could 
+be the Rasa SDK or an SDK in any other language. 
+
+## Input to Custom Actions
+
+Regardless of which language your action 
+server is written in, 
+your custom actions will have access to the same conversation data. 
+The payload sent to your custom action server includes the 
+`domain` (your bot's domain) and the `tracker`.
+
+### Tracker
+
+The tracker lets you access the state of the conversation in your custom
+actions. You can get information about past events and the current state of the
+conversation by querying the tracker.
+
+The following are available as attributes of a `Tracker` object:
+
+* `sender_id` - The unique ID of person talking to the bot.
+
+* `slots` - The list of slots that can be filled as defined in the
+  domain.
+
+* `latest_message` - A dictionary containing the attributes of the latest
+  message: `intent`, `entities` and `text`.
+
+* `events` - A list of all previous events.
+
+* `active_form` - The name of the currently active form.
+
+* `latest_action_name` - The name of the last action the bot executed.
+
+For example, using the informaton in the tracker, you could
+
+- Get the value of a slot from the `slots` field and query a database according to it's value
+- Validate a slot value during an active [form](forms.mdx)
+
+## Output from Custom Actions
+
+The expected response from the action server is a dictionary of responses and events. 
+For example, the following response payload would result in the slot 
+`user_is_registered` being set to `False`, and the user would receive
+a message saying, "You are not yet registered on this platform". 
+
+```json
+{
+  "events": [
+    {
+      "SlotSet": 
+      {
+        "user_is_registered":false
+        }
+    }
+  ],
+  "responses": [
+    {
+      "text": "You are not yet registered on this platform",
+      "buttons": [],
+      "elements": [],
+      "custom": {},
+      "template": null,
+      "image": null,
+      "attachment": null
+    }
+  ]
+}
+```
+
+## Generating Responses from Custom Actions
+
+
+
+
+## Events
 
 ```json
 {

--- a/docs/docs/messaging-and-voice-channels.mdx
+++ b/docs/docs/messaging-and-voice-channels.mdx
@@ -50,7 +50,7 @@ Learn how to make your assistant available on:
 
 You can use [ngrok](https://ngrok.com/) to create a connection to your local
 computer that is publicly available on the internet.
-You don't need this when running Rasa on a server because, you can set up a domain
+You don't need this when running Rasa on a server because you can set up a domain
 name to point to that server's IP address, or use the IP address itself.
 
 After installing ngrok, run:

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -122,17 +122,7 @@ module.exports = {
               items: [
                 'custom-actions',
                 'knowledge-bases',
-                {
-                  type: 'category',
-                  label: 'Rasa SDK',
-                  collapsed: true,
-                  items: [
-                    // 'running-action-server',
-                    // 'tracker-dispatcher',
-                    // 'events',
-                    // 'rasa-sdk-changelog'
-                  ],
-                },
+                'action-server'
               ],
             },
             'retrieval-actions',
@@ -174,7 +164,15 @@ module.exports = {
           type: 'category',
           label: 'HTTP API',
           collapsed: true,
+<<<<<<< HEAD
           items: ['http-api', 'http-api-spec'],
+=======
+          items: [
+            'http-api',
+            'http-api-spec',
+            'action-server-api',
+          ],
+>>>>>>> a2a99c8c804... sdk docs shuffle
         },
         'jupyter-notebooks',
       ],

--- a/docs/static/spec/action-server.yml
+++ b/docs/static/spec/action-server.yml
@@ -1,13 +1,10 @@
 openapi: "3.0.2"
 info:
-  title: "Rasa SDK - Action Server Endpoint"
+  title: "Action Server Endpoint"
   version: "0.0.0"
   description: >-
     API of the action server which is used by Rasa
     to execute custom actions.
-servers:
-  - url: "http://localhost:5055/webhook"
-    description: "Local development action server"
 paths:
   /:
     post:


### PR DESCRIPTION
**Proposed changes**:
- Move Rasa SDK specific documentation to the SDK repo
- Improve description of action server and the required (?) API

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

Open questions/issues:
- [x] Where should the API spec live?  - on the action server docs 
- [x] Is it still called an API spec since it describes the requirements for an endpoint for an "unknown" server? - yes
- [x] Is the division of action server & custom actions pages sensible? - redivided, action server docs will contain everything, rasa docs will contain only references to action server docs for custom actions
- [x] "events" section of custom actions page - this will live in action server docs

This PR will remove stuff that goes to action server docs