### PR TITLE
update the command to get the latest message

### DIFF
--- a/docs/docs/custom-actions.mdx
+++ b/docs/docs/custom-actions.mdx
@@ -64,7 +64,7 @@ Execute the side effects of this action.
   * **tracker** – the state tracker for the current
     user. You can access slot values using
     `tracker.get_slot(slot_name)`, the most recent user message
-    is `tracker.latest_message.text` and any other
+    is `tracker.latest_message.get('text')` and any other
     `rasa_sdk.Tracker` property.
 
   * **domain** – the bot's domain


### PR DESCRIPTION
**Proposed changes**:
- Quite common question I get from the community:`tracker.latest_message` returns a dictionary so when users try to get the latest message by using the command `tracker.latest_message.text` as mentioned in the docs, it throws an error. Updated an example showing how to access the latest message by returning the value based on the key.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
