### PR TITLE
Fix slow training of CRFEntityExtractor when using Entity Roles and Groups

### DIFF
--- a/changelog/6549.bugfix.rst
+++ b/changelog/6549.bugfix.rst
@@ -1,0 +1,1 @@
+Fix slow training of ``CRFEntityExtractor`` when using Entity Roles and Groups.

--- a/rasa/nlu/extractors/crf_entity_extractor.py
+++ b/rasa/nlu/extractors/crf_entity_extractor.py
@@ -406,14 +406,18 @@ class CRFEntityExtractor(EntityExtractor):
                 # get the features to extract for the token we are currently looking at
                 current_feature_idx = pointer_position + half_window_size
                 features = configured_features[current_feature_idx]
-                # we add the 'entity' feature to include the entity type as features
-                # for the role and group CRFs
-                if include_tag_features:
-                    features.append("entity")
 
                 prefix = prefixes[current_feature_idx]
 
-                for feature in features:
+                # we add the 'entity' feature to include the entity type as features
+                # for the role and group CRFs
+                # (do not modify features, otherwise we will end up adding 'entity'
+                # over and over again, making training very slow)
+                additional_features = []
+                if include_tag_features:
+                    additional_features.append("entity")
+
+                for feature in features + additional_features:
                     if feature == "pattern":
                         # add all regexes extracted from the 'RegexFeaturizer' as a
                         # feature: 'pattern_name' is the name of the pattern the user


### PR DESCRIPTION
**Proposed changes**:
Fix slow training of CRFEntityExtractor when using Entity Roles and Groups.

related to https://github.com/RasaHQ/research/issues/105

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
