### PR TITLE
fix fingerprinting of domains with `triggers: `

### DIFF
--- a/rasa/core/domain.py
+++ b/rasa/core/domain.py
@@ -450,11 +450,11 @@ class Domain:
         self._check_domain_sanity()
 
     def __hash__(self) -> int:
-
         self_as_dict = self.as_dict()
         self_as_dict[KEY_INTENTS] = sort_list_of_dicts_by_first_key(
             self_as_dict[KEY_INTENTS]
         )
+        self_as_dict[KEY_ACTIONS] = self.action_names
         self_as_string = json.dumps(self_as_dict, sort_keys=True)
         text_hash = utils.get_text_hash(self_as_string)
 

--- a/rasa/model.py
+++ b/rasa/model.py
@@ -276,9 +276,6 @@ async def model_fingerprint(file_importer: "TrainingDataImporter") -> Fingerprin
         The fingerprint.
 
     """
-    from rasa.core.domain import Domain
-
-    import rasa
     import time
 
     config = await file_importer.get_config()
@@ -286,9 +283,11 @@ async def model_fingerprint(file_importer: "TrainingDataImporter") -> Fingerprin
     stories = await file_importer.get_stories()
     nlu_data = await file_importer.get_nlu_data()
 
-    domain_dict = domain.as_dict()
-    responses = domain_dict.pop("responses")
-    domain_without_nlg = Domain.from_dict(domain_dict)
+    responses = domain.templates
+
+    # don't include the response texts in the fingerprint.
+    # Their fingerprint is separate.
+    domain.templates = []
 
     return {
         FINGERPRINT_CONFIG_KEY: _get_hash_of_config(config, exclude_keys=CONFIG_KEYS),
@@ -298,7 +297,7 @@ async def model_fingerprint(file_importer: "TrainingDataImporter") -> Fingerprin
         FINGERPRINT_CONFIG_NLU_KEY: _get_hash_of_config(
             config, include_keys=CONFIG_KEYS_NLU
         ),
-        FINGERPRINT_DOMAIN_WITHOUT_NLG_KEY: hash(domain_without_nlg),
+        FINGERPRINT_DOMAIN_WITHOUT_NLG_KEY: hash(domain),
         FINGERPRINT_NLG_KEY: get_dict_hash(responses),
         FINGERPRINT_NLU_DATA_KEY: hash(nlu_data),
         FINGERPRINT_STORIES_KEY: hash(stories),

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -4,14 +4,11 @@ import tempfile
 import time
 import shutil
 from pathlib import Path
-from typing import Text, Optional, Any, List
+from typing import Text, Optional, Any
 from unittest.mock import Mock
 
 import pytest
 
-import rasa
-import rasa.core
-import rasa.nlu
 from rasa.importers.importer import TrainingDataImporter
 from rasa.importers.rasa import RasaFileImporter
 from rasa.constants import (
@@ -21,7 +18,6 @@ from rasa.constants import (
     DEFAULT_CORE_SUBDIRECTORY_NAME,
 )
 from rasa.core.domain import Domain, KEY_RESPONSES
-from rasa.core.utils import get_dict_hash
 from rasa import model
 from rasa.model import (
     FINGERPRINT_CONFIG_KEY,
@@ -51,8 +47,6 @@ from tests.core.conftest import DEFAULT_DOMAIN_PATH_WITH_MAPPING
 
 
 def test_get_latest_model(trained_rasa_model: str):
-    import shutil
-
     path_of_latest = os.path.join(os.path.dirname(trained_rasa_model), "latest.tar.gz")
     shutil.copy(trained_rasa_model, path_of_latest)
 
@@ -76,7 +70,7 @@ def test_get_model_context_manager(trained_rasa_model: str):
 
 
 @pytest.mark.parametrize("model_path", ["foobar", "rasa", "README.md", None])
-def test_get_model_exception(model_path):
+def test_get_model_exception(model_path: Optional[Text]):
     with pytest.raises(ModelNotFound):
         get_model(model_path)
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,17 +1,18 @@
+import asyncio
 import os
 import tempfile
 import time
 import shutil
 from pathlib import Path
-from typing import Text, Optional, Any
+from typing import Text, Optional, Any, List
 from unittest.mock import Mock
 
 import pytest
-from _pytest.tmpdir import TempdirFactory
 
 import rasa
 import rasa.core
 import rasa.nlu
+from rasa.importers.importer import TrainingDataImporter
 from rasa.importers.rasa import RasaFileImporter
 from rasa.constants import (
     DEFAULT_CONFIG_PATH,
@@ -19,7 +20,7 @@ from rasa.constants import (
     DEFAULT_DOMAIN_PATH,
     DEFAULT_CORE_SUBDIRECTORY_NAME,
 )
-from rasa.core.domain import Domain
+from rasa.core.domain import Domain, KEY_RESPONSES
 from rasa.core.utils import get_dict_hash
 from rasa import model
 from rasa.model import (
@@ -46,6 +47,7 @@ from rasa.model import (
     FingerprintComparisonResult,
 )
 from rasa.exceptions import ModelNotFound
+from tests.core.conftest import DEFAULT_DOMAIN_PATH_WITH_MAPPING
 
 
 def test_get_latest_model(trained_rasa_model: str):
@@ -92,7 +94,7 @@ def test_get_model_from_directory_with_subdirectories(
         get_model_subdirectories(str(tmp_path))  # temp path should be empty
 
 
-def test_get_model_from_directory_nlu_only(trained_rasa_model):
+def test_get_model_from_directory_nlu_only(trained_rasa_model: Text):
     unpacked = get_model(trained_rasa_model)
     shutil.rmtree(os.path.join(unpacked, DEFAULT_CORE_SUBDIRECTORY_NAME))
     unpacked_core, unpacked_nlu = get_model_subdirectories(unpacked)
@@ -182,43 +184,100 @@ def test_nlu_fingerprint_changed(fingerprint2, changed):
 
 
 def _project_files(
-    project,
-    config_file=DEFAULT_CONFIG_PATH,
-    domain=DEFAULT_DOMAIN_PATH,
-    training_files=DEFAULT_DATA_PATH,
-):
+    project: Text,
+    config_file: Text = DEFAULT_CONFIG_PATH,
+    domain: Text = DEFAULT_DOMAIN_PATH,
+    training_files: Text = DEFAULT_DATA_PATH,
+) -> TrainingDataImporter:
     paths = {
         "config_file": config_file,
         "domain_path": domain,
         "training_data_paths": training_files,
     }
-
-    paths = {k: v if v is None else os.path.join(project, v) for k, v in paths.items()}
+    paths = {
+        k: v if v is None or Path(v).is_absolute() else os.path.join(project, v)
+        for k, v in paths.items()
+    }
     paths["training_data_paths"] = [paths["training_data_paths"]]
 
     return RasaFileImporter(**paths)
 
 
-async def test_create_fingerprint_from_paths(project):
-    project_files = _project_files(project)
+@pytest.mark.parametrize(
+    "domain_path",
+    [
+        DEFAULT_DOMAIN_PATH,
+        str((Path(".") / DEFAULT_DOMAIN_PATH_WITH_MAPPING).absolute()),
+    ],
+)
+async def test_create_fingerprint_from_paths(project: Text, domain_path: Text):
+    project_files = _project_files(project, domain=domain_path)
 
     assert await model_fingerprint(project_files)
+
+
+async def test_fingerprinting_changed_response_text(project: Text):
+    importer = _project_files(project)
+
+    old_fingerprint = await model_fingerprint(importer)
+    old_domain = await importer.get_domain()
+
+    # Change NLG content but keep actions the same
+    domain_with_changed_nlg = old_domain.as_dict()
+    domain_with_changed_nlg[KEY_RESPONSES]["utter_greet"].append({"text": "hi"})
+    domain_with_changed_nlg = Domain.from_dict(domain_with_changed_nlg)
+
+    importer.get_domain = asyncio.coroutine(lambda: domain_with_changed_nlg)
+
+    new_fingerprint = await model_fingerprint(importer)
+
+    assert (
+        old_fingerprint[FINGERPRINT_DOMAIN_WITHOUT_NLG_KEY]
+        == new_fingerprint[FINGERPRINT_DOMAIN_WITHOUT_NLG_KEY]
+    )
+    assert old_fingerprint[FINGERPRINT_NLG_KEY] != new_fingerprint[FINGERPRINT_NLG_KEY]
+
+
+async def test_fingerprinting_additional_action(project: Text):
+    importer = _project_files(project)
+
+    old_fingerprint = await model_fingerprint(importer)
+    old_domain = await importer.get_domain()
+
+    domain_with_new_action = old_domain.as_dict()
+    domain_with_new_action[KEY_RESPONSES]["utter_new"] = [{"text": "hi"}]
+    domain_with_new_action = Domain.from_dict(domain_with_new_action)
+
+    importer.get_domain = asyncio.coroutine(lambda: domain_with_new_action)
+
+    new_fingerprint = await model_fingerprint(importer)
+
+    assert (
+        old_fingerprint[FINGERPRINT_DOMAIN_WITHOUT_NLG_KEY]
+        != new_fingerprint[FINGERPRINT_DOMAIN_WITHOUT_NLG_KEY]
+    )
+    assert old_fingerprint[FINGERPRINT_NLG_KEY] != new_fingerprint[FINGERPRINT_NLG_KEY]
 
 
 @pytest.mark.parametrize(
     "project_files", [["invalid", "invalid", "invalid"], [None, None, None]]
 )
-async def test_create_fingerprint_from_invalid_paths(project, project_files):
+async def test_create_fingerprint_from_invalid_paths(
+    project: Text, project_files: List[Optional[Text]]
+):
     from rasa.nlu.training_data import TrainingData
     from rasa.core.training.structures import StoryGraph
 
     project_files = _project_files(project, *project_files)
+    domain = Domain.empty()
+    responses = domain.templates
+    domain.templates = []
     expected = _fingerprint(
         config="",
         config_nlu="",
         config_core="",
-        domain=hash(Domain.empty()),
-        nlg=get_dict_hash(Domain.empty().templates),
+        domain=hash(domain),
+        nlg=get_dict_hash(responses),
         stories=hash(StoryGraph([])),
         nlu=hash(TrainingData()),
         rasa_version=rasa.__version__,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -259,39 +259,6 @@ async def test_fingerprinting_additional_action(project: Text):
     assert old_fingerprint[FINGERPRINT_NLG_KEY] != new_fingerprint[FINGERPRINT_NLG_KEY]
 
 
-@pytest.mark.parametrize(
-    "project_files", [["invalid", "invalid", "invalid"], [None, None, None]]
-)
-async def test_create_fingerprint_from_invalid_paths(
-    project: Text, project_files: List[Optional[Text]]
-):
-    from rasa.nlu.training_data import TrainingData
-    from rasa.core.training.structures import StoryGraph
-
-    project_files = _project_files(project, *project_files)
-    domain = Domain.empty()
-    responses = domain.templates
-    domain.templates = []
-    expected = _fingerprint(
-        config="",
-        config_nlu="",
-        config_core="",
-        domain=hash(domain),
-        nlg=get_dict_hash(responses),
-        stories=hash(StoryGraph([])),
-        nlu=hash(TrainingData()),
-        rasa_version=rasa.__version__,
-    )
-
-    actual = await model_fingerprint(project_files)
-    assert actual[FINGERPRINT_TRAINED_AT_KEY] is not None
-
-    del actual[FINGERPRINT_TRAINED_AT_KEY]
-    del expected[FINGERPRINT_TRAINED_AT_KEY]
-
-    assert actual == expected
-
-
 @pytest.mark.parametrize("use_fingerprint", [True, False])
 async def test_rasa_packaging(
     trained_rasa_model: Text, project: Text, use_fingerprint: bool, tmp_path: Path


### PR DESCRIPTION
**Proposed changes**:
- fix a bug when fingerprinting models which have a domain with `trigger: ` intents. The problem was that the fingerprinting removed the `responses` from the domain and then created domain which was checked for its validity. As the responses were missing, the related actions were also missing. This caused an error in the domain sanity check as the triggered actions aren't existing
- remove `test_create_fingerprint_from_invalid_paths`: This test just tested the behavior of `RasaFileImporter` but not the actual fingerprinting functionality
- added more tests, mainly to make sure that changed response texts only affect the NLG fingerprint
- added more typing

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
