### PR TITLE
No warning during prediction if Response Selector was not trained

### DIFF
--- a/rasa/nlu/selectors/response_selector.py
+++ b/rasa/nlu/selectors/response_selector.py
@@ -372,7 +372,7 @@ class ResponseSelector(DIETClassifier):
         )
         label_response_templates = self.responses.get(label_intent_response_key)
 
-        if not label_response_templates:
+        if label_intent_response_key and not label_response_templates:
             # response templates seem to be unavailable,
             # likely an issue with the training data
             # we'll use a fallback instead


### PR DESCRIPTION
**Proposed changes**:
- `label_intent_response_key` is `None` when response selector wasn't trained. The check for response templates should be skipped then.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
