### PR TITLE
Change default augmentation parameter

### DIFF
--- a/changelog/6550.improvement.md
+++ b/changelog/6550.improvement.md
@@ -1,0 +1,1 @@
+Change the default parameter for `augmentation` for `rasa train` commands from `50` to `0`.

--- a/rasa/cli/arguments/train.py
+++ b/rasa/cli/arguments/train.py
@@ -106,7 +106,7 @@ def add_augmentation_param(
     parser.add_argument(
         "--augmentation",
         type=int,
-        default=50,
+        default=0,
         help="How much data augmentation to use during training.",
     )
 

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -649,7 +649,7 @@ class Agent:
         training_resource: Union[Text, TrainingDataImporter],
         remove_duplicates: bool = True,
         unique_last_num_states: Optional[int] = None,
-        augmentation_factor: int = 50,
+        augmentation_factor: int = 0,
         tracker_limit: Optional[int] = None,
         use_story_concatenation: bool = True,
         debug_plots: bool = False,

--- a/rasa/core/training/generator.py
+++ b/rasa/core/training/generator.py
@@ -183,7 +183,7 @@ class TrainingDataGenerator:
         domain: Domain,
         remove_duplicates: bool = True,
         unique_last_num_states: Optional[int] = None,
-        augmentation_factor: int = 50,
+        augmentation_factor: int = 0,
         tracker_limit: Optional[int] = None,
         use_story_concatenation: bool = True,
         debug_plots: bool = False,


### PR DESCRIPTION
**Proposed changes**:
Change the default parameter for `augmentation` for `rasa train` commands from `50` to `0`.

closes #6550 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
