### PR TITLE
Exclude FallbackClassifier from core featurization

### DIFF
--- a/rasa/nlu/classifiers/fallback_classifier.py
+++ b/rasa/nlu/classifiers/fallback_classifier.py
@@ -19,7 +19,7 @@ AMBIGUITY_THRESHOLD_KEY = "ambiguity_threshold"
 logger = logging.getLogger(__name__)
 
 
-class FallbackClassifier(Component):
+class FallbackClassifier(IntentClassifier):
 
     # please make sure to update the docs when changing a default parameter
     defaults = {

--- a/rasa/nlu/model.py
+++ b/rasa/nlu/model.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Text
 
 import rasa.nlu
 import rasa.utils.io
-from rasa.nlu.classifiers.fallback_classifier import FallbackClassifier
 from rasa.constants import MINIMUM_COMPATIBLE_VERSION
 from rasa.nlu import components, utils  # pytype: disable=pyi-error
 from rasa.nlu.classifiers.classifier import (  # pytype: disable=pyi-error
@@ -413,8 +412,6 @@ class Interpreter:
         """
 
         for component in self.pipeline:
-            if not isinstance(
-                component, (EntityExtractor, IntentClassifier, FallbackClassifier)
-            ):
+            if not isinstance(component, (EntityExtractor, IntentClassifier)):
                 component.process(message, **self.context)
         return message

--- a/rasa/nlu/model.py
+++ b/rasa/nlu/model.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Text
 
 import rasa.nlu
 import rasa.utils.io
+from rasa.nlu.classifiers.fallback_classifier import FallbackClassifier
 from rasa.constants import MINIMUM_COMPATIBLE_VERSION
 from rasa.nlu import components, utils  # pytype: disable=pyi-error
 from rasa.nlu.classifiers.classifier import (  # pytype: disable=pyi-error
@@ -412,6 +413,8 @@ class Interpreter:
         """
 
         for component in self.pipeline:
-            if not isinstance(component, (EntityExtractor, IntentClassifier)):
+            if not isinstance(
+                component, (EntityExtractor, IntentClassifier, FallbackClassifier)
+            ):
                 component.process(message, **self.context)
         return message


### PR DESCRIPTION
**Proposed changes**:
Do not featurize message using the `FallbackClassifier` during core featurization when training with `rasa train`.
`FallbackClassifier` is an `IntentClassifier`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
