### PR TITLE
tag team instead of single developers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Code in the `rasa.shared` package is potentially re-used by downstream dependencies
 # such as Rasa X. Hence, changes within this package require double checking.
-/rasa/shared/ @alwx @ricwo @wochinge @degiz @federicotdn
+/rasa/shared/ @backend


### PR DESCRIPTION


**Proposed changes**:
- Tagging the team instead of single developers avoids that each developer is getting a review request. Instead GitHub will pick one developer from the team.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
