### PR TITLE
sort and deduplicate story events before adding them to NLU training data

### DIFF
--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -278,13 +278,7 @@ class UserUttered(Event):
         )
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                self.text,
-                self.intent.get(INTENT_NAME_KEY),
-                jsonpickle.encode(self.entities),
-            )
-        )
+        return hash((self.text, self.intent_name, jsonpickle.encode(self.entities)))
 
     @property
     def intent_name(self) -> Optional[Text]:

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -496,7 +496,9 @@ class E2EImporter(TrainingDataImporter):
         sorted_utterances = sorted(
             utterances, key=lambda user: user.intent_name or user.text
         )
-        sorted_actions = sorted(actions, key=lambda action: action.action_name)
+        sorted_actions = sorted(
+            actions, key=lambda action: action.action_name or action.action_text
+        )
 
         additional_messages_from_stories = [
             _messages_from_action(action) for action in sorted_actions

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -494,9 +494,9 @@ class E2EImporter(TrainingDataImporter):
         # model has to be retrained due to changes in the event order within
         # the stories.
         sorted_utterances = sorted(
-            list(utterances), key=lambda user: user.intent_name or user.text
+            utterances, key=lambda user: user.intent_name or user.text
         )
-        sorted_actions = sorted(list(actions), key=lambda action: action.action_name)
+        sorted_actions = sorted(actions, key=lambda action: action.action_name)
 
         additional_messages_from_stories = [
             _messages_from_action(action) for action in sorted_actions

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -271,7 +271,7 @@ async def test_different_story_order_doesnt_change_nlu_training_data(
     # effect on the NLU training data
     stories = list(reversed(stories))
 
-    # Make sure importer doesnt cache stories
+    # Make sure importer doesn't cache stories
     default_importer._cached_stories = None
 
     training_data2 = await default_importer.get_nlu_data()

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -179,7 +179,7 @@ async def test_core_only(project: Text):
 
 
 async def test_import_nlu_training_data_from_e2e_stories(
-    default_importer: TrainingDataImporter
+    default_importer: TrainingDataImporter,
 ):
     # The `E2EImporter` correctly wraps the underlying `CombinedDataImporter`
     assert isinstance(default_importer, E2EImporter)
@@ -239,7 +239,7 @@ async def test_import_nlu_training_data_from_e2e_stories(
 
 
 async def test_different_story_order_doesnt_change_nlu_training_data(
-    default_importer: E2EImporter
+    default_importer: E2EImporter,
 ):
     stories = [
         StoryStep(
@@ -280,7 +280,7 @@ async def test_different_story_order_doesnt_change_nlu_training_data(
 
 
 async def test_import_nlu_training_data_with_default_actions(
-    default_importer: TrainingDataImporter
+    default_importer: TrainingDataImporter,
 ):
     assert isinstance(default_importer, E2EImporter)
     importer_without_e2e = default_importer.importer


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/6659
- A change of the story order or the order within the steps should not affect the NLU training data. If this constraint is not respected, then the NLU model will be retrained whenever the story or event order changed. To guarantee the stableness of the NLU data, the events are deduplicated and ordered before generating the `Message` objects from them. Note: New actions / utterances still need to cause a new training of the NLU model as this is required for the end-to-end support
- get rid of a couple of `asyncio.coroutine` usages as this function is deprecated as of Python 3.8

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
