### PR TITLE
Support list for the `slot_was_set` action

### DIFF
--- a/data/test_stories/story_slot_different_types.md
+++ b/data/test_stories/story_slot_different_types.md
@@ -1,4 +1,4 @@
-## story: Customer loses a credit card, reviews transactions, and gets a new card
+## story: Story with all different slot types
 * card_lost
   - check_transactions
   - slot{"list_slot": ["value1", "value2"]}

--- a/data/test_stories/story_slot_different_types.md
+++ b/data/test_stories/story_slot_different_types.md
@@ -1,0 +1,6 @@
+## story: Customer loses a credit card, reviews transactions, and gets a new card
+* card_lost
+  - check_transactions
+  - slot{"list_slot": ["value1", "value2"]}
+  - slot{"bool_slot": true}
+  - slot{"text_slot": "some_text"}

--- a/data/test_yaml_stories/story_slot_different_types.yml
+++ b/data/test_yaml_stories/story_slot_different_types.yml
@@ -1,5 +1,5 @@
 stories:
-- story: Customer loses a credit card, reviews transactions, and gets a new card
+- story: Story with all different slot types
   steps:
   - intent: card_lost
   - action: check_transactions

--- a/data/test_yaml_stories/story_slot_different_types.yml
+++ b/data/test_yaml_stories/story_slot_different_types.yml
@@ -1,0 +1,9 @@
+stories:
+- story: Customer loses a credit card, reviews transactions, and gets a new card
+  steps:
+  - intent: card_lost
+  - action: check_transactions
+  - slot_was_set:
+    - list_slot: ["value1", "value2"]
+    - bool_slot: true
+    - text_slot: "some_text"

--- a/rasa/utils/schemas/stories.yml
+++ b/rasa/utils/schemas/stories.yml
@@ -76,6 +76,7 @@ mapping:
                         mapping:
                           regex;(.*):
                             type: "bool"
+                      - type: "text"
                 - type: "str"
           - type: "map"
             matching-rule: 'any'

--- a/tests/core/training/converters/test_story_markdown_to_yaml_converter.py
+++ b/tests/core/training/converters/test_story_markdown_to_yaml_converter.py
@@ -37,6 +37,7 @@ async def test_stories_are_converted(tmpdir: Path):
     * greet OR goodbye
         - utter_greet
         - form{"name": null}
+        - slot{"name": ["value1", "value2"]}
     """
 
     with open(training_data_file, "w") as f:
@@ -60,4 +61,8 @@ async def test_stories_are_converted(tmpdir: Path):
             "    - intent: goodbye\n"
             "  - action: utter_greet\n"
             "  - active_loop: null\n"
+            "  - slot_was_set:\n"
+            "    - name:\n"
+            "      - value1\n"
+            "      - value2\n"
         )

--- a/tests/shared/core/training_data/story_reader/test_markdown_story_reader.py
+++ b/tests/shared/core/training_data/story_reader/test_markdown_story_reader.py
@@ -251,14 +251,6 @@ async def test_read_stories_with_multiline_comments(tmpdir, default_domain: Doma
     assert len(story_steps[3].events) == 2
 
 
-async def test_read_stories_with_slot_list(tmpdir, default_domain: Domain):
-    reader = MarkdownStoryReader(default_domain)
-
-    story_steps = await reader.read_from_file("data/test_stories/stories_slot.md")
-
-    assert len(story_steps) == 4
-
-
 async def test_read_stories_with_rules(default_domain: Domain):
     story_steps = await loading.load_data_from_files(
         ["data/test_stories/stories_with_rules.md"], default_domain

--- a/tests/shared/core/training_data/story_reader/test_markdown_story_reader.py
+++ b/tests/shared/core/training_data/story_reader/test_markdown_story_reader.py
@@ -251,6 +251,14 @@ async def test_read_stories_with_multiline_comments(tmpdir, default_domain: Doma
     assert len(story_steps[3].events) == 2
 
 
+async def test_read_stories_with_slot_list(tmpdir, default_domain: Domain):
+    reader = MarkdownStoryReader(default_domain)
+
+    story_steps = await reader.read_from_file("data/test_stories/stories_slot.md")
+
+    assert len(story_steps) == 4
+
+
 async def test_read_stories_with_rules(default_domain: Domain):
     story_steps = await loading.load_data_from_files(
         ["data/test_stories/stories_with_rules.md"], default_domain


### PR DESCRIPTION
**Proposed changes**:
- Support `list` for the `slot_was_set` action in `2.0` Stories

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
