### PR TITLE
fix: Update ConveRT model URL

### DIFF
--- a/changelog/6741.bugfix.md
+++ b/changelog/6741.bugfix.md
@@ -1,0 +1,1 @@
+Update ConveRT model URL to new hosting location

--- a/rasa/nlu/tokenizers/convert_tokenizer.py
+++ b/rasa/nlu/tokenizers/convert_tokenizer.py
@@ -11,7 +11,9 @@ import rasa.utils.train_utils as train_utils
 import tensorflow as tf
 
 
-TF_HUB_MODULE_URL = "http://models.poly-ai.com/convert/v1/model.tar.gz"
+TF_HUB_MODULE_URL = (
+    "https://github.com/PolyAI-LDN/polyai-models/releases/download/v1.0/model.tar.gz"
+)
 
 
 class ConveRTTokenizer(WhitespaceTokenizer):


### PR DESCRIPTION
**Proposed changes**:
- PolyAI recently updated the URL at which the ConveRT TensorFlow Hub model is hosted. These changes modify Rasa to load the ConveRT model from the new, updated URL.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
