### PR TITLE
issue #6721 fix

### DIFF
--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -425,7 +425,10 @@ class DialogueStateTracker:
                     event.action_name, applied_events
                 )
             else:
-                applied_events.append(event)
+                if isinstance(event, (SlotSet)):
+                    logger.info("Skipped putting SlotSet event on applied events queue")
+                else:
+                    applied_events.append(event)
 
         return applied_events
 


### PR DESCRIPTION
**Proposed changes**:
- update to shared/cored/trackers.py:
  - do not include SlotSet events on the applied_events queue
  - this means when only SlotSet events are on the events queue, the applied events queue will be empty

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
