### PR TITLE
[1.10] Bump rasabaster version to 0.7.34

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2211,7 +2211,7 @@ description = "A configurable sidebar-enabled Sphinx theme"
 name = "rasabaster"
 optional = false
 python-versions = "*"
-version = "0.7.33"
+version = "0.7.34"
 
 [package.dependencies]
 "ruamel.yaml" = ">=0.16.10,<0.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ sphinxcontrib-websupport = "^1.1.0"
 sphinxcontrib-trio = "==1.1.1"
 sphinx-tabs = "~1.1.13"
 sphinx-autodoc-typehints = "==1.6.0"
-rasabaster = "^0.7.33"
+rasabaster = "^0.7.34"
 pep440-version-utils = "^0.3.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
**Proposed changes**:
- Updates to 0.7.34, 0.7.33 had a z-index issue that only surfaced with the production deployment