### PR TITLE
added logic to skip SlotSet events addition to applied_events when ap…

### DIFF
--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -425,7 +425,10 @@ class DialogueStateTracker:
                     event.action_name, applied_events
                 )
             else:
-                applied_events.append(event)
+                if (len(applied_events) == 0) and isinstance(event, SlotSet):
+                    logger.info("Skipping addition of SlotSet event on applied_events when applied_events is empty")
+                else:
+                    applied_events.append(event)
 
         return applied_events
 


### PR DESCRIPTION
…plied_events is empty

**Proposed changes**:
- added logic to skip putting SlotSet events on applied_events when applied_events is empty
this was causing the tracker to miss starting session for user_utterance when only SlotSet was on the applied_events List (issue #6721 )
Tested against scripts in issue #6721 ... shown to fix / validate

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
