### PR TITLE
Ignore tests that use ConveRT for now

### DIFF
--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -134,12 +134,11 @@ async def test_train_persist_load_with_different_settings_non_windows(
 ):
     pipeline = [
         {
-            "name": "ConveRTTokenizer",
+            "name": "WhitespaceTokenizer",
             "intent_tokenization_flag": True,
             "intent_split_symbol": "+",
         },
         {"name": "CountVectorsFeaturizer"},
-        {"name": "ConveRTFeaturizer"},
         {"name": "DIETClassifier", MASKED_LM: True, EPOCHS: 1},
     ]
     await _train_persist_load_with_different_settings(

--- a/tests/nlu/featurizers/test_convert_featurizer.py
+++ b/tests/nlu/featurizers/test_convert_featurizer.py
@@ -10,6 +10,10 @@ from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.featurizers.dense_featurizer.convert_featurizer import ConveRTFeaturizer
 
 
+# TODO
+#   skip tests as the ConveRT model is not publicly available anymore (see https://github.com/RasaHQ/rasa/issues/6806)
+
+
 @pytest.mark.skip
 def test_convert_featurizer_process(component_builder):
     tokenizer = component_builder.create_component_from_class(ConveRTTokenizer)

--- a/tests/nlu/featurizers/test_convert_featurizer.py
+++ b/tests/nlu/featurizers/test_convert_featurizer.py
@@ -10,7 +10,7 @@ from rasa.nlu.config import RasaNLUModelConfig
 from rasa.nlu.featurizers.dense_featurizer.convert_featurizer import ConveRTFeaturizer
 
 
-@pytest.mark.skip_on_windows
+@pytest.mark.skip
 def test_convert_featurizer_process(component_builder):
     tokenizer = component_builder.create_component_from_class(ConveRTTokenizer)
     featurizer = component_builder.create_component_from_class(ConveRTFeaturizer)
@@ -37,7 +37,7 @@ def test_convert_featurizer_process(component_builder):
     assert np.allclose(sent_vecs[-1][:5], expected_cls, atol=1e-5)
 
 
-@pytest.mark.skip_on_windows
+@pytest.mark.skip
 def test_convert_featurizer_train(component_builder):
     tokenizer = component_builder.create_component_from_class(ConveRTTokenizer)
     featurizer = component_builder.create_component_from_class(ConveRTFeaturizer)
@@ -94,7 +94,7 @@ def test_convert_featurizer_train(component_builder):
         ("ńöñàśçií", "ńöñàśçií"),
     ],
 )
-@pytest.mark.skip_on_windows
+@pytest.mark.skip
 def test_convert_featurizer_tokens_to_text(component_builder, sentence, expected_text):
     tokenizer = component_builder.create_component_from_class(ConveRTTokenizer)
     tokens = tokenizer.tokenize(Message(data={TEXT: sentence}), attribute=TEXT)

--- a/tests/nlu/test_config.py
+++ b/tests/nlu/test_config.py
@@ -53,14 +53,14 @@ def test_invalid_many_tokenizers_in_config():
             {
                 "pipeline": [
                     {"name": "WhitespaceTokenizer"},
-                    {"name": "ConveRTFeaturizer"},
+                    #{"name": "ConveRTFeaturizer"},
                 ]
             }
         ),
         pytest.param(
             {
                 "pipeline": [
-                    {"name": "ConveRTTokenizer"},
+                    #{"name": "ConveRTTokenizer"},
                     {"name": "LanguageModelFeaturizer"},
                 ]
             }

--- a/tests/nlu/test_config.py
+++ b/tests/nlu/test_config.py
@@ -53,14 +53,6 @@ def test_invalid_many_tokenizers_in_config():
             {
                 "pipeline": [
                     {"name": "WhitespaceTokenizer"},
-                    #{"name": "ConveRTFeaturizer"},
-                ]
-            }
-        ),
-        pytest.param(
-            {
-                "pipeline": [
-                    #{"name": "ConveRTTokenizer"},
                     {"name": "LanguageModelFeaturizer"},
                 ]
             }

--- a/tests/nlu/test_train.py
+++ b/tests/nlu/test_train.py
@@ -107,7 +107,9 @@ def test_all_components_are_in_at_least_one_test_pipeline():
 
     for cls in registry.component_classes:
         if "convert" in cls.name.lower():
-            # TODO ignore ConveRT for now as the model cannot be downloaded
+            # TODO
+            #   skip ConveRTTokenizer and ConveRTFeaturizer as the ConveRT model is not publicly available anymore
+            #   (see https://github.com/RasaHQ/rasa/issues/6806)
             continue
         assert (
             cls.name in all_components

--- a/tests/nlu/test_train.py
+++ b/tests/nlu/test_train.py
@@ -78,7 +78,7 @@ def pipelines_for_non_windows_tests() -> List[Tuple[Text, List[Dict[Text, Any]]]
 
     # first is language followed by list of components
     return [
-        ("en", as_pipeline("ConveRTTokenizer", "ConveRTFeaturizer", "DIETClassifier")),
+        ("en", as_pipeline("SpacyNLP", "SpacyTokenizer", "SpacyFeaturizer", "DIETClassifier")),
         (
             "en",
             as_pipeline(
@@ -101,6 +101,9 @@ def test_all_components_are_in_at_least_one_test_pipeline():
     all_components = [c["name"] for _, p in all_pipelines for c in p]
 
     for cls in registry.component_classes:
+        if "convert" in cls.name.lower():
+            # TODO ignore ConveRT for now as the model cannot be downloaded
+            continue
         assert (
             cls.name in all_components
         ), "`all_components` template is missing component."

--- a/tests/nlu/test_train.py
+++ b/tests/nlu/test_train.py
@@ -78,7 +78,12 @@ def pipelines_for_non_windows_tests() -> List[Tuple[Text, List[Dict[Text, Any]]]
 
     # first is language followed by list of components
     return [
-        ("en", as_pipeline("SpacyNLP", "SpacyTokenizer", "SpacyFeaturizer", "DIETClassifier")),
+        (
+            "en",
+            as_pipeline(
+                "SpacyNLP", "SpacyTokenizer", "SpacyFeaturizer", "DIETClassifier"
+            ),
+        ),
         (
             "en",
             as_pipeline(

--- a/tests/nlu/tokenizers/test_convert_tokenizer.py
+++ b/tests/nlu/tokenizers/test_convert_tokenizer.py
@@ -6,6 +6,9 @@ from rasa.nlu.constants import TOKENS_NAMES, NUMBER_OF_SUB_TOKENS
 from rasa.shared.nlu.constants import TEXT, INTENT
 from rasa.nlu.tokenizers.convert_tokenizer import ConveRTTokenizer
 
+# TODO
+#   skip tests as the ConveRT model is not publicly available anymore (see https://github.com/RasaHQ/rasa/issues/6806)
+
 
 @pytest.mark.parametrize(
     "text, expected_tokens, expected_indices",

--- a/tests/nlu/tokenizers/test_convert_tokenizer.py
+++ b/tests/nlu/tokenizers/test_convert_tokenizer.py
@@ -22,7 +22,7 @@ from rasa.nlu.tokenizers.convert_tokenizer import ConveRTTokenizer
         ("ńöñàśçií", ["ńöñàśçií"], [(0, 8)]),
     ],
 )
-@pytest.mark.skip_on_windows
+@pytest.mark.skip
 def test_convert_tokenizer_edge_cases(
     component_builder, text, expected_tokens, expected_indices
 ):
@@ -42,7 +42,7 @@ def test_convert_tokenizer_edge_cases(
         ("Forecast for LUNCH", ["Forecast for LUNCH"]),
     ],
 )
-@pytest.mark.skip_on_windows
+@pytest.mark.skip
 def test_custom_intent_symbol(component_builder, text, expected_tokens):
     tk = component_builder.create_component_from_class(
         ConveRTTokenizer, intent_tokenization_flag=True, intent_split_symbol="+"
@@ -60,7 +60,7 @@ def test_custom_intent_symbol(component_builder, text, expected_tokens):
     "text, expected_number_of_sub_tokens",
     [("Aarhus is a city", [2, 1, 1, 1]), ("sentence embeddings", [1, 3])],
 )
-@pytest.mark.skip_on_windows
+@pytest.mark.skip
 def test_convert_tokenizer_number_of_sub_tokens(
     component_builder, text, expected_number_of_sub_tokens
 ):


### PR DESCRIPTION
**Proposed changes**:
As the ConveRT model is not available right now (https://github.com/RasaHQ/rasa/issues/6806), ignore all tests that would download the ConveRT model so that we are still able to merge other PRs.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
