### PR TITLE
Allow old school rule-like policies with RulePolicy

### DIFF
--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -52,7 +52,7 @@ and Rule Policies might both predict with confidence 1), the priority of the
 policies is considered. Rasa policies have default priorities that are set to ensure the
 expected outcome in the case of a tie. They look like this, where higher numbers have higher priority:
 
-5. `RulePolicy`
+6. `RulePolicy`
 
 3. `MemoizationPolicy` and `AugmentedMemoizationPolicy`
 

--- a/rasa/cli/data.py
+++ b/rasa/cli/data.py
@@ -457,11 +457,13 @@ def _get_configuration(path: Path) -> Dict:
 
     policy_names = [p.get("name") for p in config.get("policies", [])]
 
-    _assert_no_form_policy_present(policy_names)
     _assert_config_needs_migration(policy_names)
     _assert_nlu_pipeline_given(config, policy_names)
     _assert_two_stage_fallback_policy_is_migratable(config)
     _assert_only_one_fallback_policy_present(policy_names)
+
+    if FormPolicy.__name__ in policy_names:
+        _warn_about_manual_forms_migration()
 
     return config
 
@@ -481,15 +483,14 @@ def _assert_config_needs_migration(policies: List[Text]) -> None:
         )
 
 
-def _assert_no_form_policy_present(policy_names: List[Text]) -> None:
-    if FormPolicy.__name__ in policy_names:
-        rasa.shared.utils.cli.print_error_and_exit(
-            f"Your model configuration contains the '{FormPolicy.__name__}'. "
-            f"Forms have to be migrated manually before '{MappingPolicy.__name__}', "
-            f"'{FallbackPolicy.__name__}', or '{TwoStageFallbackPolicy.__name__}' "
-            f"can be migrated. Please see the migration guide for further details: "
-            f" {DOCS_URL_MIGRATION_GUIDE}"
-        )
+def _warn_about_manual_forms_migration() -> None:
+    rasa.shared.utils.cli.print_warning(
+        f"Your model configuration contains the '{FormPolicy.__name__}'. "
+        f"Note that this command does not migrate the '{FormPolicy.__name__}' and "
+        f"you have to migrate the '{FormPolicy.__name__}' manually. "
+        f"Please see the migration guide for further details: "
+        f"{DOCS_URL_MIGRATION_GUIDE}"
+    )
 
 
 def _assert_nlu_pipeline_given(config: Dict, policy_names: List[Text]) -> None:

--- a/rasa/core/constants.py
+++ b/rasa/core/constants.py
@@ -32,6 +32,11 @@ FALLBACK_POLICY_PRIORITY = 4
 # it is the highest to prioritize form to the rest of the policies
 FORM_POLICY_PRIORITY = 5
 
+# The priority of the `RulePolicy` is higher than the priorities for `FallbackPolicy`,
+# `TwoStageFallbackPolicy` and `FormPolicy` to make it possible to use the
+# `RulePolicy` in conjunction with these deprecated policies.
+RULE_POLICY_PRIORITY = 6
+
 DIALOGUE = "dialogue"
 
 # RabbitMQ message property header added to events published using `rasa export`

--- a/rasa/core/constants.py
+++ b/rasa/core/constants.py
@@ -31,7 +31,6 @@ FALLBACK_POLICY_PRIORITY = 4
 # the priority intended to be used by form policies
 # it is the highest to prioritize form to the rest of the policies
 FORM_POLICY_PRIORITY = 5
-
 # The priority of the `RulePolicy` is higher than the priorities for `FallbackPolicy`,
 # `TwoStageFallbackPolicy` and `FormPolicy` to make it possible to use the
 # `RulePolicy` in conjunction with these deprecated policies.

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -410,10 +410,9 @@ class PolicyEnsemble:
                 parsed_policies.append(policy_object)
             except (ImportError, AttributeError):
                 raise InvalidPolicyConfig(
-                    "Module for policy '{}' could not "
-                    "be loaded. Please make sure the "
-                    "name is a valid policy."
-                    "".format(policy_name)
+                    f"Module for policy '{policy_name}' could not "
+                    f"be loaded. Please make sure the "
+                    f"name is a valid policy."
                 )
 
         cls._assert_rule_policy_not_used_with_other_rule_like_policy(parsed_policies)

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -415,7 +415,7 @@ class PolicyEnsemble:
                     f"name is a valid policy."
                 )
 
-        cls._assert_rule_policy_not_used_with_other_rule_like_policy(parsed_policies)
+        cls._check_if_rule_policy_used_with_rule_like_policies(parsed_policies)
 
         return parsed_policies
 
@@ -444,7 +444,7 @@ class PolicyEnsemble:
         return state_featurizer_func, state_featurizer_config
 
     @staticmethod
-    def _assert_rule_policy_not_used_with_other_rule_like_policy(
+    def _check_if_rule_policy_used_with_rule_like_policies(
         policies: List[Policy],
     ) -> None:
         if not any(isinstance(policy, RulePolicy) for policy in policies):
@@ -465,13 +465,15 @@ class PolicyEnsemble:
             isinstance(policy, policies_not_be_used_with_rule_policy)
             for policy in policies
         ):
-            raise InvalidPolicyConfig(
-                f"It is not possible to use the RulePolicy with "
+            rasa.shared.utils.io.raise_warning(
+                f"It is not recommended to use the '{RulePolicy.__name__}' with "
                 f"other policies which implement rule-like "
-                f"behavior. Either re-implement the desired "
-                f"behavior as rules or remove the RulePolicy from"
-                f"your policy configuration. Please see the Rasa Open Source 2.0 "
-                f"migration guide ({DOCS_URL_MIGRATION_GUIDE}) for more information."
+                f"behavior. It is highly recommended to migrate all deprecated "
+                f"policies to use the '{RulePolicy.__name__}'. Note that the "
+                f"'{RulePolicy.__name__}' will supersede the predictions of the "
+                f"deprecated policies if the confidence levels of the predictions are "
+                f"equal.",
+                docs=DOCS_URL_MIGRATION_GUIDE,
             )
 
 

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -18,7 +18,7 @@ from rasa.shared.core.trackers import (
     is_prev_action_listen_in_state,
 )
 from rasa.shared.core.generator import TrackerWithCachedStates
-from rasa.core.constants import FORM_POLICY_PRIORITY, DEFAULT_CORE_FALLBACK_THRESHOLD
+from rasa.core.constants import DEFAULT_CORE_FALLBACK_THRESHOLD, RULE_POLICY_PRIORITY
 from rasa.shared.core.constants import (
     USER_INTENT_RESTART,
     USER_INTENT_BACK,
@@ -94,7 +94,7 @@ class RulePolicy(MemoizationPolicy):
     def __init__(
         self,
         featurizer: Optional[TrackerFeaturizer] = None,
-        priority: int = FORM_POLICY_PRIORITY,
+        priority: int = RULE_POLICY_PRIORITY,
         lookup: Optional[Dict] = None,
         core_fallback_threshold: float = DEFAULT_CORE_FALLBACK_THRESHOLD,
         core_fallback_action_name: Text = ACTION_DEFAULT_FALLBACK_NAME,

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -551,7 +551,7 @@ def test_warning_for_form_migration(
     assert result.ret == 0
 
     output = "\n".join(result.outlines)
-    assert "you have to migrate it manually" in output
+    assert "you have to migrate the 'FormPolicy' manually" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -434,5 +434,5 @@ def test_mutual_exclusion_of_rule_policy_and_old_rule_like_policies(
     policies: List[Text],
 ):
     policy_config = [{"name": policy_name} for policy_name in policies]
-    with pytest.raises(InvalidPolicyConfig):
+    with pytest.warns(UserWarning):
         PolicyEnsemble.from_dict({"policies": policy_config})


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/6820#issuecomment-702246054
- make it possible to use the `RulePolicy` in conjunction with the old, deprecated "rule-style" policies. Motivation: As a user I want to migrate the assistant step by step. The procedure is roughly the following
   1. Migrate one policy
   2. Train assistant
   3. test
   4. Migrate next policy
  This was not possible without this PR as the training would have thrown an exception about the combined usage. This exception is now relaxed to a warning.
- give the `RulePolicy` a higher priority to make sure it can be used in conjunction with `MappingPolicy` and co
- change check for `FormPolicy` in `rasa data convert config` to a warning

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
