### PR TITLE
HTTP Proxy Support for Slack Connector in Rasa 1.10.x

### DIFF
--- a/changelog/6894.improvement.md
+++ b/changelog/6894.improvement.md
@@ -1,0 +1,1 @@
+Environment variables for HTTP-Proxies (HTTP_PROXY, HTTPS_PROXY) will be trusted by the slackclient.

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -8,6 +8,8 @@ from rasa.utils.common import raise_warning
 from sanic import Blueprint, response
 from sanic.request import Request
 from sanic.response import HTTPResponse
+
+from aiohttp import ClientSession
 from slack import WebClient
 
 logger = logging.getLogger(__name__)
@@ -23,7 +25,7 @@ class SlackBot(OutputChannel):
     def __init__(self, token: Text, slack_channel: Optional[Text] = None) -> None:
 
         self.slack_channel = slack_channel
-        self.client = WebClient(token, run_async=True)
+        self.client = WebClient(token, run_async=True, session=ClientSession(trust_env=True))
         super().__init__()
 
     @staticmethod

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -25,7 +25,9 @@ class SlackBot(OutputChannel):
     def __init__(self, token: Text, slack_channel: Optional[Text] = None) -> None:
 
         self.slack_channel = slack_channel
-        self.client = WebClient(token, run_async=True, session=ClientSession(trust_env=True))
+        self.client = WebClient(
+            token, run_async=True, session=ClientSession(trust_env=True)
+        )
         super().__init__()
 
     @staticmethod


### PR DESCRIPTION
**Proposed changes**:
- Environment variables for HTTP-Proxies (`HTTP_PROXY`, `HTTPS_PROXY`) will be trusted by the slackclient. Since Rasa is using the async mode of the slackclient, the `trust_env` parameter has to be passed to the [AIOHTTP Client](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support).

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
