### PR TITLE
form deactivations during validation

### DIFF
--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -585,11 +585,11 @@ class FormAction(LoopAction):
             - form validation was not cancelled
         """
         # no active_loop means that it is called during activation
-        need_validation = not tracker.active_loop or (
+        needs_validation = not tracker.active_loop or (
             tracker.latest_action_name == ACTION_LISTEN_NAME
             and not tracker.active_loop.get(LOOP_INTERRUPTED, False)
         )
-        if need_validation:
+        if needs_validation:
             logger.debug(f"Validating user input '{tracker.latest_message}'.")
             return await self.validate(tracker, domain, output_channel, nlg)
 

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -667,8 +667,11 @@ class FormAction(LoopAction):
         domain: "Domain",
         events_so_far: List[Event],
     ) -> bool:
-        # custom validation functions can decide to terminate the loop early by
-        # setting the requested slot to `None` or setting `ActiveLoop(None)`
+        # Custom validation actions can decide to terminate the loop early by
+        # setting the requested slot to `None` or setting `ActiveLoop(None)`.
+        # We explicitly check only the last occurrences for each possible termination
+        # event instead of doing `return event in events_so_far` to make it possible
+        # to override termination events which were returned earlier.
         return next(
             (
                 event

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -263,6 +263,34 @@ async def test_action_rejection():
                 SlotSet("num_people", "hi"),
             ],
         ),
+        # Validate function decides that no more slots should be requested
+        (
+            [
+                {"event": "slot", "name": "num_people", "value": None},
+                {"event": "slot", "name": REQUESTED_SLOT, "value": None},
+            ],
+            [
+                SlotSet("num_people", None),
+                SlotSet(REQUESTED_SLOT, None),
+                SlotSet("num_tables", 5),
+                SlotSet(REQUESTED_SLOT, None),
+                ActiveLoop(None),
+            ],
+        ),
+        # Validate function deactivates loop
+        (
+            [
+                {"event": "slot", "name": "num_people", "value": None},
+                {"event": "active_loop", "name": None},
+            ],
+            [
+                SlotSet("num_people", None),
+                ActiveLoop(None),
+                SlotSet("num_tables", 5),
+                SlotSet(REQUESTED_SLOT, None),
+                ActiveLoop(None),
+            ],
+        ),
     ],
 )
 async def test_validate_slots(


### PR DESCRIPTION
**Proposed changes**:
- forms are now correctly disabled when a custom validation action sets the next requested slot to `None`
- form can now be disabled during validation by setting the currently `active_loop` to None

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
