### PR TITLE
Wait for `rasa --help` output for 20 seconds on Windows

### DIFF
--- a/changelog/6915.misc.md
+++ b/changelog/6915.misc.md
@@ -1,0 +1,1 @@
+Update `test_cli_start` to wait for `rasa --help` output for 20 seconds on Windows.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,7 +7,7 @@ import sys
 def test_cli_start(run: Callable[..., RunResult]):
     """
     Checks that a call to ``rasa --help`` does not take longer than 7 seconds
-    (10 seconds on Windows).
+    (20 seconds on Windows).
     """
     import time
 
@@ -18,7 +18,7 @@ def test_cli_start(run: Callable[..., RunResult]):
     duration = end - start
 
     # it sometimes takes a bit more time to start it on Windows
-    assert duration <= 10 if sys.platform == "win32" else 7
+    assert duration <= 20 if sys.platform == "win32" else 7
 
 
 def test_data_convert_help(run: Callable[..., RunResult]):


### PR DESCRIPTION
**Proposed changes**:
- increase the timeout for `test_cli_start` from 10 seconds to 20 seconds

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
