### PR TITLE
Use context manager to auto-clean model tmp directory when pulling model from server

### DIFF
--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -152,25 +152,31 @@ async def _update_model_from_server(
     if not is_url(model_server.url):
         raise aiohttp.InvalidURL(model_server.url)
 
-    model_directory_and_fingerprint = await _pull_model_and_fingerprint(
-        model_server, agent.fingerprint
-    )
-    if model_directory_and_fingerprint:
-        model_directory, new_model_fingerprint = model_directory_and_fingerprint
-        _load_and_set_updated_model(agent, model_directory, new_model_fingerprint)
-    else:
-        logger.debug(f"No new model found at URL {model_server.url}")
+    with tempfile.TemporaryDirectory() as model_directory:
+        new_fingerprint = await _pull_model_and_fingerprint(
+            model_server, agent.fingerprint, model_directory
+        )
+
+        if new_fingerprint:
+            _load_and_set_updated_model(agent, model_directory, new_fingerprint)
+        else:
+            logger.debug(f"No new model found at URL {model_server.url}")
 
 
 async def _pull_model_and_fingerprint(
-    model_server: EndpointConfig, fingerprint: Optional[Text]
-) -> Optional[Tuple[Text, Text]]:
+        model_server: EndpointConfig, fingerprint: Optional[Text], model_directory: Text
+) -> Optional[Text]:
     """Queries the model server.
 
-    Returns the temporary model directory and value of the response's <ETag> header
-    which contains the model hash. Returns `None` if no new model is found.
-    """
+    Args:
+        model_server: Model server endpoint information.
+        fingerprint: Current model fingerprint.
+        model_directory: Directory where to download model to.
 
+    Returns:
+        Value of the response's <ETag> header which contains the model
+        hash. Returns `None` if no new model is found.
+    """
     headers = {"If-None-Match": fingerprint}
 
     logger.debug(f"Requesting model from server {model_server.url}...")
@@ -210,16 +216,13 @@ async def _pull_model_and_fingerprint(
                     )
                     return None
 
-                model_directory = tempfile.mkdtemp()
                 rasa.utils.io.unarchive(await resp.read(), model_directory)
                 logger.debug(
                     "Unzipped model to '{}'".format(os.path.abspath(model_directory))
                 )
 
-                # get the new fingerprint
-                new_fingerprint = resp.headers.get("ETag")
-                # return new tmp model directory and new fingerprint
-                return model_directory, new_fingerprint
+                # return the new fingerprint
+                return resp.headers.get("ETag")
 
         except aiohttp.ClientError as e:
             logger.debug(


### PR DESCRIPTION
**Proposed changes**:
When pulling a model from a remote server, use `with tempfile.TemporaryDirectory()` to automatically delete the temp directory created after the agent has been updated.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
