### PR TITLE
disable searchbox shortcut in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -61,7 +61,7 @@ module.exports = {
       // isCloseable: false, // Defaults to `true`.
     },
     algolia: {
-      disabled: !isDev, // FIXME: remove this when our index is good
+      disabled: true, // FIXME: remove this when our index is good
       apiKey: '25626fae796133dc1e734c6bcaaeac3c', // FIXME: replace with values from our own index
       indexName: 'docsearch', // FIXME: replace with values from our own index
       inputSelector: '.search-bar',

--- a/docs/themes/theme-custom/index.js
+++ b/docs/themes/theme-custom/index.js
@@ -11,6 +11,16 @@ module.exports = function() {
       return path.resolve(__dirname, './theme');
     },
 
+    // FIXME: this allows to disable searchbox shortcuts. It's a quickfix and shouldn't be located here,
+    //        but it's temporary and should be removed when we enable Algolia search
+    getClientModules() {
+      const modules = [
+        require.resolve('./styles.css')
+      ];
+
+      return modules;
+    },
+
     configureWebpack() {
       return {
         resolve: {

--- a/docs/themes/theme-custom/styles.css
+++ b/docs/themes/theme-custom/styles.css
@@ -1,0 +1,3 @@
+.DocSearch-Button-Key {
+    display: none !important;
+}

--- a/docs/themes/theme-custom/styles.css
+++ b/docs/themes/theme-custom/styles.css
@@ -1,3 +1,7 @@
 .DocSearch-Button-Key {
     display: none !important;
 }
+
+.DocSearch-Button-Placeholder::after {
+    content: " (coming soon)";
+}


### PR DESCRIPTION
**Proposed changes**:
- Temporarily disable search box shortcuts

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
