### PR TITLE
Update Rasa Playground "Download" button to work correctly depending on the current chat state 

### DIFF
--- a/changelog/7001.bugfix.md
+++ b/changelog/7001.bugfix.md
@@ -1,0 +1,1 @@
+Update Rasa Playground "Download" button to work correctly depending on the current chat state. 

--- a/docs/themes/theme-custom/theme/Prototyper/download-button.jsx
+++ b/docs/themes/theme-custom/theme/Prototyper/download-button.jsx
@@ -9,7 +9,7 @@ const DownloadButton = (props) => {
   return (
     <RasaButton
       onClick={prototyperContext.downloadProject}
-      disabled={!prototyperContext.hasTrained || !!prototyperContext.isTraining}
+      disabled={prototyperContext.chatState !== "ready" && prototyperContext.chatState !== "needs_to_be_retrained"}
       {...props}
     >
       Download project


### PR DESCRIPTION
**Proposed changes**:
- fix "Download" button

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
