### PR TITLE
Setting slots via API does not influence conversation

### DIFF
--- a/changelog/6721.bugfix.md
+++ b/changelog/6721.bugfix.md
@@ -1,0 +1,4 @@
+Fixed bug where slots with `influence_conversation=false` affected the action 
+prediction if they were set manually using the 
+`POST /conversations/<conversation_id/tracker/events` endpoint in the 
+[HTTP API](./http-api.mdx).

--- a/changelog/6721.removal.md
+++ b/changelog/6721.removal.md
@@ -1,0 +1,2 @@
+The `rasa.core.Processor` method `get_tracker_with_session_start()` is deprecated. 
+Please use `fetch_tracker_and_update_session()` instead.

--- a/changelog/6721.removal.md
+++ b/changelog/6721.removal.md
@@ -1,2 +1,0 @@
-The `rasa.core.Processor` method `get_tracker_with_session_start()` is deprecated. 
-Please use `fetch_tracker_and_update_session()` instead.

--- a/docs/static/spec/rasa.yml
+++ b/docs/static/spec/rasa.yml
@@ -155,6 +155,8 @@ paths:
         Appends one or multiple new events to the tracker state of the conversation.
         Any existing events will be kept and the new events will be appended,
         updating the existing state.
+        If events are appended to a new conversation ID, the tracker will be
+        initialised with a new session.
       parameters:
       - $ref: '#/components/parameters/conversation_id'
       - $ref: '#/components/parameters/include_events'

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -794,10 +794,9 @@ class Agent:
         should_merge_nodes: bool = True,
         fontsize: int = 12,
     ) -> None:
+        """Visualize the loaded training data from the resource."""
         from rasa.shared.core.training_data.visualization import visualize_stories
         from rasa.shared.core.training_data import loading
-
-        """Visualize the loaded training data from the resource."""
 
         # if the user doesn't provide a max history, we will use the
         # largest value from any policy

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -541,10 +541,10 @@ class Agent:
         message: UserMessage,
         message_preprocessor: Optional[Callable[[Text], Text]] = None,
         **kwargs: Any,
-    ) -> Optional[DialogueStateTracker]:
+    ) -> DialogueStateTracker:
         """Append a message to a dialogue - does not predict actions."""
-
         processor = self.create_processor(message_preprocessor)
+
         return await processor.log_message(message)
 
     async def execute_action(

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -178,7 +178,7 @@ class MessageProcessor:
         output_channel: Optional[OutputChannel] = None,
         metadata: Optional[Dict] = None,
     ) -> DialogueStateTracker:
-        """Get tracker for `sender_id` or create a new tracker for `sender_id`.
+        """Fetch tracker for `sender_id` and update its conversation session.
 
         If a new tracker is created, `action_session_start` is run.
 
@@ -188,7 +188,7 @@ class MessageProcessor:
             sender_id: Conversation ID for which to fetch the tracker.
 
         Returns:
-              Tracker for `sender_id` if available, `None` otherwise.
+              Tracker for `sender_id` if available.
         """
 
         tracker = self.get_tracker(sender_id)
@@ -211,9 +211,8 @@ class MessageProcessor:
             sender_id: Conversation ID for which to fetch the tracker.
 
         Returns:
-              Tracker for `sender_id` if available, `None` otherwise.
+              Tracker for `sender_id`.
         """
-
         tracker = self.get_tracker(sender_id)
 
         # run session start only if the tracker is empty
@@ -815,7 +814,6 @@ class MessageProcessor:
         Returns:
             `True` if the session in `tracker` has expired, `False` otherwise.
         """
-
         if not self.domain.session_config.are_sessions_enabled():
             # tracker has never expired if sessions are disabled
             return False

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -189,6 +189,36 @@ class MessageProcessor:
 
         return tracker
 
+    async def get_tracker_with_session_start(
+        self,
+        sender_id: Text,
+        output_channel: Optional[OutputChannel] = None,
+        metadata: Optional[Dict] = None,
+    ) -> DialogueStateTracker:
+        """Fetches tracker for `sender_id` and updates its conversation session.
+
+        If a new tracker is created, `action_session_start` is run.
+
+        Args:
+            metadata: Data sent from client associated with the incoming user message.
+            output_channel: Output channel associated with the incoming user message.
+            sender_id: Conversation ID for which to fetch the tracker.
+
+        Returns:
+              Tracker for `sender_id`.
+        """
+        # TODO: Remove in Rasa Open Source 3.0
+        rasa.shared.utils.io.raise_warning(
+            "`get_tracker_with_session_start()` is deprecated and will be removed "
+            "in Rasa Open Source version 3.0. Please use "
+            "`fetch_tracker_and_update_session()` instead.",
+            category=DeprecationWarning,
+        )
+
+        return await self.fetch_tracker_and_update_session(
+            sender_id, output_channel, metadata
+        )
+
     async def fetch_tracker_with_initial_session(
         self,
         sender_id: Text,

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -189,36 +189,6 @@ class MessageProcessor:
 
         return tracker
 
-    async def get_tracker_with_session_start(
-        self,
-        sender_id: Text,
-        output_channel: Optional[OutputChannel] = None,
-        metadata: Optional[Dict] = None,
-    ) -> DialogueStateTracker:
-        """Fetches tracker for `sender_id` and updates its conversation session.
-
-        If a new tracker is created, `action_session_start` is run.
-
-        Args:
-            metadata: Data sent from client associated with the incoming user message.
-            output_channel: Output channel associated with the incoming user message.
-            sender_id: Conversation ID for which to fetch the tracker.
-
-        Returns:
-              Tracker for `sender_id`.
-        """
-        # TODO: Remove in Rasa Open Source 3.0
-        rasa.shared.utils.io.raise_warning(
-            "`get_tracker_with_session_start()` is deprecated and will be removed "
-            "in Rasa Open Source version 3.0. Please use "
-            "`fetch_tracker_and_update_session()` instead.",
-            category=DeprecationWarning,
-        )
-
-        return await self.fetch_tracker_and_update_session(
-            sender_id, output_channel, metadata
-        )
-
     async def fetch_tracker_with_initial_session(
         self,
         sender_id: Text,

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -111,7 +111,7 @@ class MessageProcessor:
 
         # we have a Tracker instance for each user
         # which maintains conversation state
-        tracker = await self.get_tracker_with_session_start(sender_id)
+        tracker = await self.fetch_tracker_and_update_session(sender_id)
         if not tracker:
             logger.warning(
                 f"Failed to retrieve or create tracker for sender '{sender_id}'."
@@ -172,7 +172,7 @@ class MessageProcessor:
                 metadata=metadata,
             )
 
-    async def get_tracker_with_session_start(
+    async def fetch_tracker_and_update_session(
         self,
         sender_id: Text,
         output_channel: Optional[OutputChannel] = None,
@@ -197,10 +197,35 @@ class MessageProcessor:
 
         return tracker
 
+    async def fetch_tracker_with_initial_session(
+        self,
+        sender_id: Text,
+        output_channel: Optional[OutputChannel] = None,
+        metadata: Optional[Dict] = None,
+    ) -> DialogueStateTracker:
+        """Fetch tracker for `sender_id` and run a session start if it's a new tracker.
+
+        Args:
+            metadata: Data sent from client associated with the incoming user message.
+            output_channel: Output channel associated with the incoming user message.
+            sender_id: Conversation ID for which to fetch the tracker.
+
+        Returns:
+              Tracker for `sender_id` if available, `None` otherwise.
+        """
+
+        tracker = self.get_tracker(sender_id)
+
+        # run session start only if the tracker is empty
+        if not tracker.events:
+            await self._update_tracker_session(tracker, output_channel, metadata)
+
+        return tracker
+
     def get_tracker(self, conversation_id: Text) -> DialogueStateTracker:
         """Get the tracker for a conversation.
 
-        In contrast to `get_tracker_with_session_start` this does not add any
+        In contrast to `fetch_tracker_and_update_session` this does not add any
         `action_session_start` or `session_start` events at the beginning of a
         conversation.
 
@@ -256,7 +281,7 @@ class MessageProcessor:
 
         # we have a Tracker instance for each user
         # which maintains conversation state
-        tracker = await self.get_tracker_with_session_start(
+        tracker = await self.fetch_tracker_and_update_session(
             message.sender_id, message.output_channel, message.metadata
         )
 
@@ -285,7 +310,7 @@ class MessageProcessor:
 
         # we have a Tracker instance for each user
         # which maintains conversation state
-        tracker = await self.get_tracker_with_session_start(sender_id, output_channel)
+        tracker = await self.fetch_tracker_and_update_session(sender_id, output_channel)
         if tracker:
             action = self._get_action(action_name)
             await self._run_action(
@@ -359,7 +384,7 @@ class MessageProcessor:
     ) -> None:
         """Handle a reminder that is triggered asynchronously."""
 
-        tracker = await self.get_tracker_with_session_start(sender_id, output_channel)
+        tracker = await self.fetch_tracker_and_update_session(sender_id, output_channel)
 
         if not tracker:
             logger.warning(

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -181,9 +181,8 @@ class MessageProcessor:
             sender_id: Conversation ID for which to fetch the tracker.
 
         Returns:
-              Tracker for `sender_id` if available.
+              Tracker for `sender_id`.
         """
-
         tracker = self.get_tracker(sender_id)
 
         await self._update_tracker_session(tracker, output_channel, metadata)
@@ -266,7 +265,6 @@ class MessageProcessor:
         can be skipped if the tracker returned by this method is used for further
         processing and saved at a later stage.
         """
-
         # we have a Tracker instance for each user
         # which maintains conversation state
         tracker = await self.fetch_tracker_and_update_session(

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -125,12 +125,15 @@ class TrackerStore:
             max_event_history: Value to update the tracker store's max event history to.
             append_action_listen: Whether or not to append an initial `action_listen`.
         """
-        tracker = self.retrieve(sender_id)
         self.max_event_history = max_event_history
+
+        tracker = self.retrieve(sender_id)
+
         if tracker is None:
             tracker = self.create_tracker(
                 sender_id, append_action_listen=append_action_listen
             )
+
         return tracker
 
     def init_tracker(self, sender_id: Text) -> "DialogueStateTracker":
@@ -154,16 +157,13 @@ class TrackerStore:
 
         Returns:
             The newly created tracker for `sender_id`.
-
         """
-
         tracker = self.init_tracker(sender_id)
 
-        if tracker:
-            if append_action_listen:
-                tracker.update(ActionExecuted(ACTION_LISTEN_NAME))
+        if append_action_listen:
+            tracker.update(ActionExecuted(ACTION_LISTEN_NAME))
 
-            self.save(tracker)
+        self.save(tracker)
 
         return tracker
 
@@ -212,6 +212,7 @@ class TrackerStore:
     def number_of_existing_events(self, sender_id: Text) -> int:
         """Return number of stored events for a given sender id."""
         old_tracker = self.retrieve(sender_id)
+
         return len(old_tracker.events) if old_tracker else 0
 
     def keys(self) -> Iterable[Text]:
@@ -229,13 +230,13 @@ class TrackerStore:
     def _deserialise_dialogue_from_pickle(
         sender_id: Text, serialised_tracker: bytes
     ) -> Dialogue:
-
         rasa.shared.utils.io.raise_deprecation_warning(
             f"Found pickled tracker for "
             f"conversation ID '{sender_id}'. Deserialisation of pickled "
             f"trackers is deprecated. Rasa will perform any "
             f"future save operations of this tracker using json serialisation."
         )
+
         return pickle.loads(serialised_tracker)
 
     def deserialise_tracker(
@@ -244,8 +245,6 @@ class TrackerStore:
         """Deserializes the tracker and returns it."""
 
         tracker = self.init_tracker(sender_id)
-        if not tracker:
-            return None
 
         try:
             dialogue = Dialogue.from_parameters(json.loads(serialised_tracker))
@@ -282,9 +281,9 @@ class InMemoryTrackerStore(TrackerStore):
         if sender_id in self.store:
             logger.debug(f"Recreating tracker for id '{sender_id}'")
             return self.deserialise_tracker(sender_id, self.store[sender_id])
-        else:
-            logger.debug(f"Creating a new tracker for id '{sender_id}'.")
-            return None
+
+        logger.debug(f"Creating a new tracker for id '{sender_id}'.")
+        return None
 
     def keys(self) -> Iterable[Text]:
         """Returns sender_ids of the Tracker Store in memory"""

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -227,14 +227,16 @@ class TrackerStore:
         return json.dumps(dialogue.as_dict())
 
     @staticmethod
-    def _deserialise_dialogue_from_pickle(
+    def _deserialize_dialogue_from_pickle(
         sender_id: Text, serialised_tracker: bytes
     ) -> Dialogue:
+        # TODO: Remove in Rasa Open Source 3.0
         rasa.shared.utils.io.raise_deprecation_warning(
             f"Found pickled tracker for "
-            f"conversation ID '{sender_id}'. Deserialisation of pickled "
-            f"trackers is deprecated. Rasa will perform any "
-            f"future save operations of this tracker using json serialisation."
+            f"conversation ID '{sender_id}'. Deserialization of pickled "
+            f"trackers is deprecated and will be removed in Rasa Open Source 3.0. Rasa "
+            f"will perform any future save operations of this tracker using json "
+            f"serialisation."
         )
 
         return pickle.loads(serialised_tracker)
@@ -249,7 +251,7 @@ class TrackerStore:
         try:
             dialogue = Dialogue.from_parameters(json.loads(serialised_tracker))
         except UnicodeDecodeError:
-            dialogue = self._deserialise_dialogue_from_pickle(
+            dialogue = self._deserialize_dialogue_from_pickle(
                 sender_id, serialised_tracker
             )
 
@@ -282,7 +284,8 @@ class InMemoryTrackerStore(TrackerStore):
             logger.debug(f"Recreating tracker for id '{sender_id}'")
             return self.deserialise_tracker(sender_id, self.store[sender_id])
 
-        logger.debug(f"Creating a new tracker for id '{sender_id}'.")
+        logger.debug(f"Could not find tracker for conversation ID '{sender_id}'.")
+
         return None
 
     def keys(self) -> Iterable[Text]:

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -5,11 +5,10 @@ import multiprocessing
 import os
 import tempfile
 import traceback
-import typing
 from functools import reduce, wraps
 from inspect import isawaitable
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Text, Union, Dict
+from typing import Any, Callable, List, Optional, Text, Union, Dict, TYPE_CHECKING
 
 from sanic import Sanic, response
 from sanic.request import Request
@@ -27,7 +26,6 @@ from rasa.shared.core.training_data.story_writer.yaml_story_writer import (
     YAMLStoryWriter,
 )
 from rasa.shared.nlu.training_data.formats import RasaYAMLReader
-from rasa.utils import common as common_utils
 from rasa import model
 from rasa.constants import DEFAULT_RESPONSE_TIMEOUT, MINIMUM_COMPATIBLE_VERSION
 from rasa.shared.constants import (
@@ -55,7 +53,7 @@ from rasa.nlu.emulators.no_emulator import NoEmulator
 from rasa.nlu.test import run_evaluation
 from rasa.utils.endpoints import EndpointConfig
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from ssl import SSLContext
     from rasa.core.processor import MessageProcessor
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -796,6 +796,7 @@ def create_app(
         try:
             async with app.agent.lock_store.lock(conversation_id):
                 tracker = await app.agent.log_message(user_message)
+
             return response.json(tracker.current_state(verbosity))
         except Exception as e:
             logger.debug(traceback.format_exc())

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -285,7 +285,7 @@ def get_test_stories(
     return YAMLStoryWriter().dumps(story_steps, is_test_story=True)
 
 
-async def fetch_tracker_and_update_with_events(
+async def update_conversation_with_events(
     conversation_id: Text,
     processor: "MessageProcessor",
     domain: Domain,
@@ -571,7 +571,7 @@ def create_app(
                 processor = app.agent.create_processor()
                 events = _get_events_from_request_body(request)
 
-                tracker = await fetch_tracker_and_update_with_events(
+                tracker = await update_conversation_with_events(
                     conversation_id, processor, app.agent.domain, events
                 )
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -967,7 +967,7 @@ def create_app(
     @requires_auth(app, auth_token)
     @ensure_loaded_agent(app, require_core_is_ready=True)
     async def tracker_predict(request: Request) -> HTTPResponse:
-        """ Given a list of events, predicts the next action"""
+        """Given a list of events, predicts the next action."""
         validate_request_body(
             request,
             "No events defined in request_body. Add events to request body in order to "

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -256,9 +256,7 @@ def get_test_stories(
         The stories for `conversation_id` in test format.
     """
     if fetch_all_sessions:
-        trackers: List[
-            DialogueStateTracker
-        ] = processor.get_trackers_for_all_conversation_sessions(conversation_id)
+        trackers = processor.get_trackers_for_all_conversation_sessions(conversation_id)
     else:
         trackers = [processor.get_tracker(conversation_id)]
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -254,7 +254,7 @@ async def get_tracker_with_session_start(
     Returns:
         The tracker for `conversation_id` with an updated conversation session.
     """
-    return await processor.get_tracker_with_session_start(conversation_id)
+    return await processor.fetch_tracker_and_update_session(conversation_id)
 
 
 def get_test_stories(
@@ -564,7 +564,9 @@ def create_app(
         try:
             async with app.agent.lock_store.lock(conversation_id):
                 processor = app.agent.create_processor()
-                tracker = processor.get_tracker(conversation_id)
+                tracker = await processor.fetch_tracker_with_initial_session(
+                    conversation_id
+                )
                 output_channel = _get_output_channel(request, tracker)
 
                 events = _get_events_from_request_body(request)

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -18,6 +18,8 @@ from rasa.shared.core.constants import (
     ACTION_NAME_SENDER_ID_CONNECTOR_STR,
     IS_EXTERNAL,
     LOOP_INTERRUPTED,
+    ACTION_SESSION_START_NAME,
+    ACTION_LISTEN_NAME,
 )
 from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_TYPE,
@@ -164,6 +166,24 @@ def split_events(
         sub_events.append(current)
 
     return sub_events
+
+
+def do_events_begin_with_session_start(events: List["Event"]) -> bool:
+    """Determines whether `events` begins with a session start sequence.
+
+    A session start sequence is a sequence of two events: an executed
+    `action_session_start` as well as a logged `session_started`.
+
+    Args:
+        events: The events to inspect.
+
+    Returns:
+        Whether or not `events` begins with a session start sequence.
+    """
+    return len(events) > 1 and events[:2] == [
+        ActionExecuted(ACTION_SESSION_START_NAME),
+        SessionStarted(),
+    ]
 
 
 # noinspection PyProtectedMember

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -673,8 +673,6 @@ class Restarted(Event):
         return self.type_name
 
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
-        from rasa.shared.core.constants import ACTION_LISTEN_NAME
-
         tracker._reset()
         tracker.trigger_followup_action(ACTION_LISTEN_NAME)
 

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -650,13 +650,17 @@ async def test_fetch_tracker_with_initial_session(
 
 
 async def test_fetch_tracker_with_initial_session_does_not_update_session(
-    default_channel: CollectingOutputChannel, default_processor: MessageProcessor,
+    default_channel: CollectingOutputChannel,
+    default_processor: MessageProcessor,
+    monkeypatch: MonkeyPatch,
 ):
     conversation_id = uuid.uuid4().hex
 
     # the domain has a session expiration time of one second
-    default_processor.tracker_store.domain.session_config = SessionConfig(
-        carry_over_slots=True, session_expiration_time=1 / 60
+    monkeypatch.setattr(
+        default_processor.tracker_store.domain,
+        "session_config",
+        SessionConfig(carry_over_slots=True, session_expiration_time=1 / 60),
     )
 
     now = time.time()

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -271,7 +271,7 @@ def test_deprecated_pickle_deserialisation():
         assert tracker == store.deserialise_tracker(DEFAULT_SENDER_ID, serialised)
     assert len(record) == 1
     assert (
-        "Deserialisation of pickled trackers is deprecated" in record[0].message.args[0]
+        "Deserialization of pickled trackers is deprecated" in record[0].message.args[0]
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -940,8 +940,7 @@ async def test_push_multiple_events(rasa_app: SanicASGITestClient):
 
 
 @pytest.mark.parametrize(
-    "params",
-    ["?execute_side_effects=true&output_channel=callback", ""],
+    "params", ["?execute_side_effects=true&output_channel=callback", ""],
 )
 async def test_pushing_event_while_executing_side_effects(
     rasa_server: Sanic, params: Text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -940,7 +940,8 @@ async def test_push_multiple_events(rasa_app: SanicASGITestClient):
 
 
 @pytest.mark.parametrize(
-    "params", ["?execute_side_effects=true&output_channel=callback", ""],
+    "params",
+    ["?execute_side_effects=true&output_channel=callback", ""],
 )
 async def test_pushing_event_while_executing_side_effects(
     rasa_server: Sanic, params: Text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -940,8 +940,7 @@ async def test_push_multiple_events(rasa_app: SanicASGITestClient):
 
 
 @pytest.mark.parametrize(
-    "params",
-    ["?execute_side_effects=true&output_channel=callback", ""],
+    "params", ["?execute_side_effects=true&output_channel=callback", ""],
 )
 async def test_pushing_event_while_executing_side_effects(
     rasa_server: Sanic, params: Text
@@ -1514,6 +1513,7 @@ async def test_get_story_does_not_update_conversation_session(
     domain.session_config = SessionConfig(
         session_expiration_time=1 / 60, carry_over_slots=True
     )
+    rasa_app.app.agent.domain = domain
 
     # conversation contains one session that has expired
     now = time.time()
@@ -1525,6 +1525,9 @@ async def test_get_story_does_not_update_conversation_session(
     ]
 
     tracker = DialogueStateTracker.from_events(conversation_id, conversation_events)
+
+    # the conversation session has expired
+    assert rasa_app.app.agent.create_processor()._has_session_expired(tracker)
 
     tracker_store = InMemoryTrackerStore(domain)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1487,7 +1487,7 @@ async def test_get_story(
 
     tracker_store.save(tracker)
 
-    monkeypatch.setattr(rasa_app.app.tracker_store, "tracker_store", tracker_store)
+    monkeypatch.setattr(rasa_app.app.agent, "tracker_store", tracker_store)
 
     url = f"/conversations/{conversation_id}/story?"
 
@@ -1610,7 +1610,7 @@ stories:
         ),
     ],
 )
-async def test_fetch_tracker_and_update_with_events(
+async def test_update_conversation_with_events(
     rasa_app: SanicASGITestClient,
     monkeypatch: MonkeyPatch,
     initial_tracker_events: List[Event],
@@ -1628,7 +1628,7 @@ async def test_fetch_tracker_and_update_with_events(
         )
         tracker_store.save(tracker)
 
-    fetched_tracker = await rasa.server.fetch_tracker_and_update_with_events(
+    fetched_tracker = await rasa.server.update_conversation_with_events(
         conversation_id,
         rasa_app.app.agent.create_processor(),
         domain,


### PR DESCRIPTION
**Proposed changes**:
- fixes #6721 
- the bug comes from the fact that previously no session start was run if slots were appended to a new tracker
- this manifests itself in different `prediction_states` depending on whether or not the session start sequence was run at the beginning of the tracker
- this leads to different policy behaviour - in the linked issue, it makes the difference between the memo policy kicking in or not
- this PR fixes this behaviour by making sure that when appending events to a new tracker, there is always a session start

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
