### PR TITLE
#6926 Created a fix for --version on Windows

### DIFF
--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -76,7 +76,7 @@ def print_version() -> None:
     """Prints version information of rasa tooling and python."""
 
     info = sys.version.split("\n")
-    python_version, os_info = info if len(info) == 2 else info, ""
+    python_version, os_info = info if len(info) == 2 else info, ""  # noqa: F841
 
     try:
         from rasax.community.version import __version__  # pytype: disable=import-error

--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -75,7 +75,9 @@ def create_argument_parser() -> argparse.ArgumentParser:
 def print_version() -> None:
     """Prints version information of rasa tooling and python."""
 
-    python_version, os_info = sys.version.split("\n")
+    info = sys.version.split("\n")
+    python_version, os_info = info if len(info) == 2 else info, ""
+
     try:
         from rasax.community.version import __version__  # pytype: disable=import-error
 


### PR DESCRIPTION
While fixing https://github.com/RasaHQ/rasa/issues/5637 I accidentally broke the `rasa --version` command on some windows machines. It turns out that `sys.version` returns a single line of information in some older versions. It unfortunately passed our CI but there were people who got hit by it https://github.com/RasaHQ/rasa/issues/6926. 

In this PR I've written a small patch that should fix it. The only caveat is that I'm not sure how to add a test for this since the Windows CI doesn't seem to be able to pick this up. 