### PR TITLE
fixed cmdline coloring on windows

### DIFF
--- a/changelog/7053.bugfix.md
+++ b/changelog/7053.bugfix.md
@@ -1,0 +1,1 @@
+Fixed command line coloring for windows command lines running an encoding other than `utf-8`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -366,13 +366,13 @@ python-versions = ">=3.5"
 version = "1.4.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
+marker = "sys_platform == \"windows\" or sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
+version = "0.4.4"
 
 [[package]]
 category = "main"
@@ -3315,8 +3315,8 @@ cloudpickle = [
     {file = "cloudpickle-1.4.1.tar.gz", hash = "sha256:0b6258a20a143603d53b037a20983016d4e978f554ec4f36b3d0895b947099ae"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 colorclass = [
     {file = "colorclass-2.2.0.tar.gz", hash = "sha256:b05c2a348dfc1aff2d502527d78a5b7b7e2f85da94a96c5081210d8e9ee8e18b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ oauth2client = "4.1.3"
 regex = ">=2020.6,<2020.10"
 joblib = "^0.15.1"
 sentry-sdk = ">=0.17.0,<0.20.0"
+colorama = {version = "^0.4.4", markers = "sys_platform == 'win32'"}
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.10.0"

--- a/rasa/shared/utils/cli.py
+++ b/rasa/shared/utils/cli.py
@@ -4,8 +4,17 @@ from typing import Any, Text, NoReturn
 import rasa.shared.utils.io
 
 
-def print_color(*args: Any, color: Text):
-    print(rasa.shared.utils.io.wrap_with_color(*args, color=color))
+def print_color(*args: Any, color: Text) -> None:
+    output = rasa.shared.utils.io.wrap_with_color(*args, color=color)
+    try:
+        # colorama is used to fix a regression where colors can not be printed on
+        # windows. https://github.com/RasaHQ/rasa/issues/7053
+        from colorama import AnsiToWin32  # type:ignore
+
+        stream = AnsiToWin32(sys.stdout).stream
+        print(output, file=stream)
+    except ImportError:
+        print(output)
 
 
 def print_success(*args: Any):

--- a/tests/cli/test_rasa_init.py
+++ b/tests/cli/test_rasa_init.py
@@ -30,10 +30,7 @@ def test_init_using_init_dir_option(run_with_stdin: Callable[..., RunResult]):
 def test_not_found_init_path(run: Callable[..., RunResult]):
     output = run("init", "--no-prompt", "--quiet", "--init-dir", "./workspace")
 
-    assert (
-        output.outlines[-1]
-        == "\033[91mProject init path './workspace' not found.\033[0m"
-    )
+    assert "Project init path './workspace' not found" in output.outlines[-1]
 
 
 def test_init_help(run: Callable[..., RunResult]):


### PR DESCRIPTION
**Proposed changes**:
- fixed cmdline coloring on windows. fixes #7053 
- adds `colorama` as a windows only dependency (was already a dependency for development) 

**Status (please check what you already did)**:
- [x] ~added some tests for the functionality~
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
