### PR TITLE
Update to PR [#6926]

### DIFF
--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -75,7 +75,6 @@ def create_argument_parser() -> argparse.ArgumentParser:
 def print_version() -> None:
     """Prints version information of rasa tooling and python."""
 
-    python_version, os_info = sys.version.split("\n")
     try:
         from rasax.community.version import __version__
 
@@ -86,7 +85,7 @@ def print_version() -> None:
     print(f"Rasa Version     : {version.__version__}")
     print(f"Rasa SDK Version : {rasa_sdk_version}")
     print(f"Rasa X Version   : {rasa_x_info}")
-    print(f"Python Version   : {python_version}")
+    print(f"Python Version   : {platform.python_version()}")
     print(f"Operating System : {platform.platform()}")
     print(f"Python Path      : {sys.executable}")
 


### PR DESCRIPTION
The original issue was [#6496], where the --version command breaks in windows.
Eventhough the PR[#6926] solved the problem, it looked a bit complicated of parsing twice.

**Proposed changes**:
- In this fix, I used platform.python_version() to solve the issue.  Totally removed the sys.version function.
- Working both in windows and linux.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
