### PR TITLE
Add option "featurizers" to TEDPolicy

### DIFF
--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -276,6 +276,10 @@ However, additional parameters exist that can be adapted.
 |                                 |                  | Requires `evaluate_on_number_of_examples > 0` and            |
 |                                 |                  | `evaluate_every_number_of_epochs > 0`                        |
 +---------------------------------+------------------+--------------------------------------------------------------+
+| featurizers                     | []               | List of featurizer names (alias names). Only features        |
+|                                 |                  | coming from the listed names are used. If list is empty      |
+|                                 |                  | all available features are used.                             |
++---------------------------------+------------------+--------------------------------------------------------------+
 ```
 
 :::note

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -75,6 +75,7 @@ from rasa.utils.tensorflow.constants import (
     DENSE_DIMENSION,
     E2E_CONFIDENCE_THRESHOLD,
     MASK,
+    FEATURIZERS,
 )
 
 
@@ -208,6 +209,9 @@ class TEDPolicy(Policy):
         CHECKPOINT_MODEL: False,
         # Only pick e2e prediction if the policy is confident enough
         E2E_CONFIDENCE_THRESHOLD: 0.5,
+        # Specify what features to use as sequence and sentence features.
+        # By default all features in the pipeline are used.
+        FEATURIZERS: [],
     }
 
     @staticmethod
@@ -261,7 +265,9 @@ class TEDPolicy(Policy):
         state_featurizer = self.featurizer.state_featurizer
         encoded_all_labels = state_featurizer.encode_all_actions(domain, interpreter)
 
-        attribute_data, _ = convert_to_data_format(encoded_all_labels)
+        attribute_data, _ = convert_to_data_format(
+            encoded_all_labels, featurizers=self.config[FEATURIZERS]
+        )
 
         label_data = RasaModelData()
         label_data.add_data(attribute_data, key_prefix=f"{LABEL_KEY}_")
@@ -308,12 +314,14 @@ class TEDPolicy(Policy):
             )
 
             attribute_data, self.zero_state_features = convert_to_data_format(
-                tracker_state_features
+                tracker_state_features, featurizers=self.config[FEATURIZERS]
             )
         else:
             # method is called during prediction
             attribute_data, _ = convert_to_data_format(
-                tracker_state_features, self.zero_state_features
+                tracker_state_features,
+                self.zero_state_features,
+                featurizers=self.config[FEATURIZERS],
             )
 
         model_data.add_data(attribute_data)

--- a/rasa/utils/tensorflow/model_data_utils.py
+++ b/rasa/utils/tensorflow/model_data_utils.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
     from rasa.nlu.classifiers.diet_classifier import EntityTagSpec
 
 
-ENTITY_TAG_ORIGIN = "origin_entity_tag_ids"
+TAG_ID_ORIGIN = "tag_id_origin"
 
 
 def convert_training_examples(
@@ -88,7 +88,7 @@ def _get_tag_ids(
 
     # transpose to have seq_len x 1
     return Features(
-        np.array([_tags]).T, FEATURE_TYPE_SEQUENCE, tag_spec.tag_name, ENTITY_TAG_ORIGIN
+        np.array([_tags]).T, FEATURE_TYPE_SEQUENCE, tag_spec.tag_name, TAG_ID_ORIGIN
     )
 
 
@@ -155,11 +155,11 @@ def _filter_features(features: Optional[List["Features"]], featurizers: List[Tex
     if features is None or not featurizers:
         return features
 
-    # it might be that the list of features also contains the tag_ids
-    # the origin of the tag_ids is set to ENTITY_TAG_ORIGIN
-    # add ENTITY_TAG_ORIGIN to the list of featurizers to make sure that we keep the
+    # it might be that the list of features also contains some tag_ids
+    # the origin of the tag_ids is set to TAG_ID_ORIGIN
+    # add TAG_ID_ORIGIN to the list of featurizers to make sure that we keep the
     # tag_ids
-    featurizers.append(ENTITY_TAG_ORIGIN)
+    featurizers.append(TAG_ID_ORIGIN)
 
     # filter the features
     return [f for f in features if f.origin in featurizers]

--- a/tests/utils/tensorflow/test_model_data_utils.py
+++ b/tests/utils/tensorflow/test_model_data_utils.py
@@ -25,7 +25,7 @@ from rasa.shared.nlu.constants import (
 from rasa.utils.tensorflow.constants import SENTENCE
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data.training_data import TrainingData
-from utils.tensorflow.model_data_utils import ENTITY_TAG_ORIGIN
+from utils.tensorflow.model_data_utils import TAG_ID_ORIGIN
 
 shape = 100
 
@@ -66,8 +66,14 @@ def test_surface_attributes():
                 features=np.random.rand(shape),
                 attribute=INTENT,
                 feature_type=SENTENCE,
-                origin=[],
-            )
+                origin="featuirzer-a",
+            ),
+            Features(
+                features=np.random.rand(shape),
+                attribute=INTENT,
+                feature_type=SENTENCE,
+                origin="featurizer-b",
+            ),
         ]
     }
 
@@ -78,7 +84,7 @@ def test_surface_attributes():
                 features=action_name_features,
                 attribute=ACTION_NAME,
                 feature_type=SENTENCE,
-                origin=[],
+                origin="featurizer-c",
             )
         ]
     }
@@ -86,7 +92,9 @@ def test_surface_attributes():
     state_features.update(copy.deepcopy(action_name_features))
     # test on 2 dialogs -- one with dialog length 3 the other one with dialog length 2
     dialogs = [[state_features, intent_features, {}], [{}, action_name_features]]
-    surfaced_features = model_data_utils._surface_attributes(dialogs)
+    surfaced_features = model_data_utils._surface_attributes(
+        dialogs, featurizers=["featurizer-a", "featurizer-c"]
+    )
     assert INTENT in surfaced_features and ACTION_NAME in surfaced_features
     # check that number of lists corresponds to number of dialogs
     assert (
@@ -279,10 +287,7 @@ def test_convert_training_examples(
         (
             [
                 Features(
-                    np.random.rand(5, 14),
-                    FEATURE_TYPE_SEQUENCE,
-                    "role",
-                    ENTITY_TAG_ORIGIN,
+                    np.random.rand(5, 14), FEATURE_TYPE_SEQUENCE, "role", TAG_ID_ORIGIN
                 ),
                 Features(
                     np.random.rand(5, 14),
@@ -294,10 +299,7 @@ def test_convert_training_examples(
             ["featurizer-b"],
             [
                 Features(
-                    np.random.rand(5, 14),
-                    FEATURE_TYPE_SEQUENCE,
-                    "role",
-                    ENTITY_TAG_ORIGIN,
+                    np.random.rand(5, 14), FEATURE_TYPE_SEQUENCE, "role", TAG_ID_ORIGIN
                 ),
                 Features(
                     np.random.rand(5, 14),

--- a/tests/utils/tensorflow/test_model_data_utils.py
+++ b/tests/utils/tensorflow/test_model_data_utils.py
@@ -25,7 +25,7 @@ from rasa.shared.nlu.constants import (
 from rasa.utils.tensorflow.constants import SENTENCE
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data.training_data import TrainingData
-from utils.tensorflow.model_data_utils import TAG_ID_ORIGIN
+from rasa.utils.tensorflow.model_data_utils import TAG_ID_ORIGIN
 
 shape = 100
 


### PR DESCRIPTION
**Proposed changes**:
`TEDPolicy` now has the option `featurizers`. It can be set to a list of featurizer names (name of `alias`). Only the given featurizers will be considers when the dialogues are featurized.

related to https://github.com/RasaHQ/rasa/issues/6670

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
