### PR TITLE
Fix deleted code block backticks in the rasa data validate docs part.

### DIFF
--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -310,6 +310,7 @@ To validate your data, run this command:
 
 ```bash
 rasa data validate
+```
 
 By default, the validator searches only for errors in the data, e.g. the same training
 example being listed as an example for two intents.
@@ -320,6 +321,8 @@ You can also validate the story structure by running this command:
 
 ```bash
 rasa data validate stories
+```
+
 This validator checks if you have any stories where different assistant actions follow from the same 
 dialogue history. Conflicts between stories will prevent a model from learning the correct
 pattern for a dialogue. 


### PR DESCRIPTION
**Proposed changes**:
- Fix overflowing code blocks due to accidentally deleted "```" in `rasa data validate` docs.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
