### PR TITLE
docs: conform nav-header contents/behavior

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -84,12 +84,13 @@ module.exports = {
           position: 'left',
         },
         {
+          target: '_self',
           label: 'Rasa X',
           position: 'left',
           href: `${SWAP_URL}/docs/rasa-x/`,
-          target: '_self',
         },
         {
+          target: '_self',
           label: 'Rasa Action Server',
           position: 'left',
           href: 'https://rasa.com/docs/action-server',


### PR DESCRIPTION
This just makes sure that the link to action-server opens in the same tab, like the one to rasa-x