### PR TITLE
add missing metadata key in rule schema

### DIFF
--- a/changelog/7090.misc.md
+++ b/changelog/7090.misc.md
@@ -1,0 +1,1 @@
+Amended the YAML schema for rules to allow for a metadata key. Previously only stories were allowed to have metadata.

--- a/rasa/utils/schemas/stories.yml
+++ b/rasa/utils/schemas/stories.yml
@@ -102,6 +102,9 @@ mapping:
         rule:
           type: "str"
           allowempty: False
+        metadata:
+          type: "any"
+          required: False
         steps:
           type: "seq"
           matching: "any"


### PR DESCRIPTION
**Proposed changes**:
Previously, stories allowed for a metadata key, but not rules.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
