### PR TITLE
Bump theme to 0.8.2, configure `rootEditUrl`

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -25,7 +25,10 @@ const versionLabels = {
 
 module.exports = {
   customFields: {
-    rootEditUrl: 'https://github.com/rasahq/rasa/', // NOTE: this could be directed to a specfic README or a heading within a README
+    // FIXME: this is a simplistic solution to https://github.com/RasaHQ/rasa/issues/7011
+    // either (A): create a more sophisticated solution to link the precise branch and doc to be edited, according to branch settings
+    // or (B): create a README document (or a section in the main README) which explains how to contribute docs fixes, and link all edit links to this
+    rootEditUrl: 'https://github.com/rasahq/rasa/',
     productLogo: '/img/logo-rasa-oss.png',
     versionLabels,
     legacyVersions: [{

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -25,6 +25,7 @@ const versionLabels = {
 
 module.exports = {
   customFields: {
+    rootEditUrl: 'https://github.com/rasahq/rasa/', // NOTE: this could be directed to a specfic README or a heading within a README
     productLogo: '/img/logo-rasa-oss.png',
     versionLabels,
     legacyVersions: [{

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,7 +43,7 @@
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
     "@philpl/buble": "^0.19.7",
-    "@rasahq/docusaurus-theme-tabula": "^0.8.1",
+    "@rasahq/docusaurus-theme-tabula": "^0.8.2",
     "classnames": "^2.2.6",
     "clsx": "^1.1.1",
     "core-js": "^3.6.5",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2246,10 +2246,10 @@
     os-homedir "^1.0.1"
     regexpu-core "^4.5.4"
 
-"@rasahq/docusaurus-theme-tabula@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@rasahq/docusaurus-theme-tabula/-/docusaurus-theme-tabula-0.8.1.tgz#27723ef68e6a3a27e92f5150bf68e663b2549221"
-  integrity sha512-533IiB5WLtDgjOIorZ+CKCcspCjP0RLUwo7p5yyDrSccr2x39xxpj8Imz6F5vE9H6efIDN1gL4tdD/C+jp5V1w==
+"@rasahq/docusaurus-theme-tabula@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@rasahq/docusaurus-theme-tabula/-/docusaurus-theme-tabula-0.8.2.tgz#ea92e1fd08678fe83dda2e701c7589acc25a7a0a"
+  integrity sha512-N159DCmpJhECZogIcndscPoBV8hhFPkRZcMOi9iZZ0EXyJXUDdOkdBikNlFgWssV/EVGemPQsCfOGSHflYJJgg==
   dependencies:
     clsx "^1.1.1"
     copy-text-to-clipboard "^2.2.0"


### PR DESCRIPTION
This is a patch theme update to support a `customFields.rootEditUrl` property, as a quick fix for [404 errors on "Edit This Page" links](https://github.com/RasaHQ/rasa/issues/7011). 

[Theme changes can be seen here](https://github.com/RasaHQ/tabula/commit/1feccb59e035563ffabf726163fcf975e1519857)

My suggestion for this property is to create a section in the README which explains how to submit PRs for docs fixes, including which branches/versions will be allowed, and put that anchor link in.

Closes https://github.com/RasaHQ/tabula/issues/49