### PR TITLE
pydocstyle only new changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ lint:
 
 BRANCH ?= master # Compare against `master` if no branch was provided
 lint-docstrings:
-	# Lint docstrings only against the diff to avoid too many errors.
+	# Lint docstrings only against the the diff to avoid too many errors.
 	# Check only production code. Ignore other flake errors which are captured by `lint`
 	# Diff of committed changes (shows only changes introduced by your branch)
-	if [[ -n $(BRANCH) ]]; then
+	if [[ -n "$(BRANCH)" ]]; then
 	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff
 	fi
 	# Diff of uncommitted changes for running locally

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint:
 
 BRANCH ?= master # Compare against `master` if no branch was provided
 lint-docstrings:
-	# Lint docstrings only against the the diff to avoid too many errors.
+	# Lint docstrings only against the diff to avoid too many errors.
 	# Check only production code. Ignore other flake errors which are captured by `lint`
 	# Diff of committed changes (shows only changes introduced by your branch)
 	if [[ -n $(BRANCH) ]]; then

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ lint-docstrings:
 	# Check only production code. Ignore other flake errors which are captured by `lint`
 	# Diff of committed changes (shows only changes introduced by your branch)
 	if [[ -n "$(BRANCH)" ]]; then \
-	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff \
+	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff; \
 	fi
 	# Diff of uncommitted changes for running locally
 	git diff HEAD -- rasa | poetry run flake8 --select D --diff

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,14 @@ lint:
 
 BRANCH ?= master # Compare against `master` if no branch was provided
 lint-docstrings:
-     # Lint docstrings only against the the diff to avoid too many errors.
-     # Check only production code. Ignore other flake errors which are captured by `lint`
-	git diff $(BRANCH) -- rasa | poetry run flake8 --select D --diff
+	# Lint docstrings only against the the diff to avoid too many errors.
+	# Check only production code. Ignore other flake errors which are captured by `lint`
+	# Diff of committed changes (shows only changes introduced by your branch)
+	if [[ -n $(BRANCH) ]]; then
+	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff
+	fi
+	# Diff of uncommitted changes for running locally
+	git diff HEAD -- rasa | poetry run flake8 --select D --diff
 
 types:
 	poetry run pytype --keep-going rasa -j 16

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ lint-docstrings:
 	# Lint docstrings only against the the diff to avoid too many errors.
 	# Check only production code. Ignore other flake errors which are captured by `lint`
 	# Diff of committed changes (shows only changes introduced by your branch)
-	if [[ -n "$(BRANCH)" ]]; then
-	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff
+	if [[ -n "$(BRANCH)" ]]; then \
+	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff \
 	fi
 	# Diff of uncommitted changes for running locally
 	git diff HEAD -- rasa | poetry run flake8 --select D --diff


### PR DESCRIPTION
**Proposed changes**:
- only use diff of new changes of the current PR. This avoids errors when running an outdated PR against a target branch. Previously this used the diff of the target branch for linting.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
