### PR TITLE
Two stage fallback fix

### DIFF
--- a/changelog/7176.bugfix.md
+++ b/changelog/7176.bugfix.md
@@ -1,2 +1,2 @@
-Fixed a bug in the [`TwoStageFallback`](fallback-handoff.mdx#two-stage-fallback) which
+Fixed a bug in the [`TwoStageFallback`](fallback-handoff.mdx#two-stage-fallback) action which
 reverted too many events after the user successfully rephrased.

--- a/changelog/7176.bugfix.md
+++ b/changelog/7176.bugfix.md
@@ -1,0 +1,2 @@
+Fixed a bug in the [`TwoStageFallback`](fallback-handoff.mdx#two-stage-fallback) which
+reverted too many events after the user successfully rephrased.

--- a/rasa/core/actions/two_stage_fallback.py
+++ b/rasa/core/actions/two_stage_fallback.py
@@ -141,9 +141,7 @@ def _last_n_intent_names(
 ) -> List[Text]:
     intent_names = []
     for i in range(number_of_last_intent_names):
-        message = tracker.get_last_event_for(
-            UserUttered, skip=i, event_verbosity=EventVerbosity.AFTER_RESTART
-        )
+        message = tracker.get_last_event_for(UserUttered, skip=i)
         if isinstance(message, UserUttered):
             intent_names.append(message.intent.get("name"))
 

--- a/rasa/core/actions/two_stage_fallback.py
+++ b/rasa/core/actions/two_stage_fallback.py
@@ -141,7 +141,11 @@ def _last_n_intent_names(
 ) -> List[Text]:
     intent_names = []
     for i in range(number_of_last_intent_names):
-        message = tracker.get_last_event_for(UserUttered, skip=i)
+        message = tracker.get_last_event_for(
+            (UserUttered, UserUtteranceReverted),
+            skip=i,
+            event_verbosity=EventVerbosity.AFTER_RESTART,
+        )
         if isinstance(message, UserUttered):
             intent_names.append(message.intent.get("name"))
 

--- a/rasa/core/actions/two_stage_fallback.py
+++ b/rasa/core/actions/two_stage_fallback.py
@@ -104,31 +104,8 @@ class TwoStageFallbackAction(LoopAction):
         if _two_fallbacks_in_a_row(tracker) or _second_affirmation_failed(tracker):
             return await self._give_up(output_channel, nlg, tracker, domain)
 
-        return await self._revert_fallback_events(
-            output_channel, nlg, tracker, domain, events_so_far
-        )
-
-    async def _revert_fallback_events(
-        self,
-        output_channel: OutputChannel,
-        nlg: NaturalLanguageGenerator,
-        tracker: DialogueStateTracker,
-        domain: Domain,
-        events_so_far: List[Event],
-    ) -> List[Event]:
-        revert_events = [UserUtteranceReverted(), UserUtteranceReverted()]
-
-        temp_tracker = DialogueStateTracker.from_events(
-            tracker.sender_id, tracker.applied_events() + events_so_far + revert_events
-        )
-
-        while temp_tracker.latest_message and not await self.is_done(
-            output_channel, nlg, temp_tracker, domain, []
-        ):
-            temp_tracker.update(UserUtteranceReverted())
-            revert_events.append(UserUtteranceReverted())
-
-        return revert_events + _message_clarification(tracker)
+        # revert fallback events
+        return [UserUtteranceReverted()] + _message_clarification(tracker)
 
     async def _give_up(
         self,

--- a/rasa/core/actions/two_stage_fallback.py
+++ b/rasa/core/actions/two_stage_fallback.py
@@ -106,7 +106,7 @@ class TwoStageFallbackAction(LoopAction):
 
         return await self._revert_fallback_events(
             output_channel, nlg, tracker, domain, events_so_far
-        ) + _message_clarification(tracker)
+        )
 
     async def _revert_fallback_events(
         self,
@@ -125,10 +125,10 @@ class TwoStageFallbackAction(LoopAction):
         while temp_tracker.latest_message and not await self.is_done(
             output_channel, nlg, temp_tracker, domain, []
         ):
-            temp_tracker.update(revert_events[-1])
+            temp_tracker.update(UserUtteranceReverted())
             revert_events.append(UserUtteranceReverted())
 
-        return revert_events
+        return revert_events + _message_clarification(tracker)
 
     async def _give_up(
         self,

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -635,7 +635,7 @@ class DialogueStateTracker:
 
     def get_last_event_for(
         self,
-        event_type: Type[Event],
+        event_type: Union[Type[Event], Tuple[Type, ...]],
         action_names_to_exclude: List[Text] = None,
         skip: int = 0,
         event_verbosity: EventVerbosity = EventVerbosity.APPLIED,

--- a/tests/core/actions/test_two_stage_fallback.py
+++ b/tests/core/actions/test_two_stage_fallback.py
@@ -47,10 +47,17 @@ def _two_stage_clarification_request() -> List[Event]:
     return [ActionExecuted(ACTION_TWO_STAGE_FALLBACK_NAME), BotUttered("please affirm")]
 
 
-async def test_ask_affirmation():
-    tracker = DialogueStateTracker.from_events(
-        "some-sender", evts=_message_requiring_fallback()
-    )
+@pytest.mark.parametrize(
+    "events",
+    [
+        _message_requiring_fallback(),
+        _message_requiring_fallback()
+        + [UserUtteranceReverted()]
+        + _message_requiring_fallback(),
+    ],
+)
+async def test_ask_affirmation(events: List[Event]):
+    tracker = DialogueStateTracker.from_events("some-sender", evts=events)
     domain = Domain.empty()
     action = TwoStageFallbackAction()
 

--- a/tests/core/actions/test_two_stage_fallback.py
+++ b/tests/core/actions/test_two_stage_fallback.py
@@ -9,6 +9,7 @@ from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
     ActionExecuted,
     UserUttered,
+    SlotSet,
     ActiveLoop,
     BotUttered,
     UserUtteranceReverted,
@@ -68,6 +69,9 @@ async def test_1st_affirmation_is_successful():
     tracker = DialogueStateTracker.from_events(
         "some-sender",
         evts=[
+            ActionExecuted(ACTION_LISTEN_NAME),
+            UserUttered("my name is John", {"name": "say_name", "confidence": 1.0}),
+            SlotSet("some_slot", "example_value"),
             # User sends message with low NLU confidence
             *_message_requiring_fallback(),
             ActiveLoop(ACTION_TWO_STAGE_FALLBACK_NAME),
@@ -93,6 +97,9 @@ async def test_1st_affirmation_is_successful():
 
     applied_events = tracker.applied_events()
     assert applied_events == [
+        ActionExecuted(ACTION_LISTEN_NAME),
+        UserUttered("my name is John", {"name": "say_name", "confidence": 1.0}),
+        SlotSet("some_slot", "example_value"),
         ActionExecuted(ACTION_LISTEN_NAME),
         UserUttered("hi", {"name": "greet", "confidence": 1.0}),
     ]
@@ -168,6 +175,9 @@ async def test_ask_rephrasing_successful():
     tracker = DialogueStateTracker.from_events(
         "some-sender",
         evts=[
+            ActionExecuted(ACTION_LISTEN_NAME),
+            UserUttered("my name is John", {"name": "say_name", "confidence": 1.0}),
+            SlotSet("some_slot", "example_value"),
             # User sends message with low NLU confidence
             *_message_requiring_fallback(),
             ActiveLoop(ACTION_TWO_STAGE_FALLBACK_NAME),
@@ -198,6 +208,9 @@ async def test_ask_rephrasing_successful():
 
     applied_events = tracker.applied_events()
     assert applied_events == [
+        ActionExecuted(ACTION_LISTEN_NAME),
+        UserUttered("my name is John", {"name": "say_name", "confidence": 1.0}),
+        SlotSet("some_slot", "example_value"),
         ActionExecuted(ACTION_LISTEN_NAME),
         UserUttered("hi", {"name": "greet"}),
     ]


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/7176
- `TwoStageFallbackAction` has only to revert once as `applied_events` reverts the events within the loop itself. Means we only have to revert the low confidence message with triggered the fallback. 
- fixed the tests which were missing the logging of the `ActionExecuted(ACTION_TWO_STAGE_FALLBACK_NAME)`. As this was missing, the `applied_events` logic didn't work for the tests
- fix an error which happened during interactive learning and led to a bug in the `TwoStageFallbackAction`: As the verbosity was `AfterRestart` and it didn't consider `UserUtteranceReverted` messages in between, the `TwoStageFallbackAction` though that we had two `nlu_fallback` messages in a row. We now consider `UserUtteredReverts` events as well

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
