### PR TITLE
Trigger session start action as follow up to restart action

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -104,7 +104,7 @@ jobs:
 
         # Fetch entire history for current branch so that `make lint-docstrings`
         # can calculate the proper diff between the branches
-        git pull --ff-only --unshallow origin ${{ github.head_ref }}
+        git pull --ff-only --unshallow origin "${{ github.head_ref }}"
 
     - name: Lint Code 🎎
       run: |

--- a/changelog/5974.bugfix.md
+++ b/changelog/5974.bugfix.md
@@ -1,0 +1,1 @@
+`ActionRestart` will now trigger `ActionSessionStart` as a followup action.

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -19,6 +19,7 @@ from rasa.shared.core.constants import (
     ACTION_NAME_SENDER_ID_CONNECTOR_STR,
     IS_EXTERNAL,
     LOOP_INTERRUPTED,
+    ACTION_SESSION_START_NAME,
 )
 from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_TYPE,
@@ -590,10 +591,9 @@ class Restarted(Event):
         return self.type_name
 
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
-        from rasa.shared.core.constants import ACTION_LISTEN_NAME
-
+        """Resets the tracker and triggers a followup `ActionSessionStart`."""
         tracker._reset()
-        tracker.trigger_followup_action(ACTION_LISTEN_NAME)
+        tracker.trigger_followup_action(ACTION_SESSION_START_NAME)
 
 
 # noinspection PyProtectedMember

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -9,6 +9,8 @@ from _pytest.monkeypatch import MonkeyPatch
 from aioresponses import aioresponses
 from typing import Optional, Text, List, Callable
 from unittest.mock import patch, Mock
+
+from rasa.core.policies.rule_policy import RulePolicy
 from tests.utilities import latest_request
 
 from rasa.core import jobs
@@ -27,7 +29,7 @@ from rasa.shared.core.events import (
     SlotSet,
 )
 from rasa.core.interpreter import RasaNLUHttpInterpreter
-from rasa.shared.nlu.interpreter import NaturalLanguageInterpreter
+from rasa.shared.nlu.interpreter import NaturalLanguageInterpreter, RegexInterpreter
 from rasa.core.policies import SimplePolicyEnsemble
 from rasa.core.policies.ted_policy import TEDPolicy
 from rasa.core.processor import MessageProcessor
@@ -37,6 +39,7 @@ from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.shared.nlu.constants import INTENT_NAME_KEY
 from rasa.utils.endpoints import EndpointConfig
 from rasa.shared.core.constants import (
+    ACTION_RESTART_NAME,
     DEFAULT_INTENTS,
     ACTION_LISTEN_NAME,
     ACTION_SESSION_START_NAME,
@@ -754,3 +757,61 @@ def test_get_next_action_probabilities_pass_policy_predictions_without_interpret
                 "lala", [ActionExecuted(ACTION_LISTEN_NAME)]
             )
         )
+
+
+async def test_restart_triggers_session_start(
+    default_channel: CollectingOutputChannel,
+    default_processor: MessageProcessor,
+    monkeypatch: MonkeyPatch,
+):
+    # The rule policy is trained and used so as to allow the default action ActionRestart to be predicted
+    rule_policy = RulePolicy()
+    rule_policy.train([], default_processor.domain, RegexInterpreter())
+    monkeypatch.setattr(
+        default_processor.policy_ensemble,
+        "policies",
+        [rule_policy, *default_processor.policy_ensemble.policies],
+    )
+
+    sender_id = uuid.uuid4().hex
+
+    entity = "name"
+    slot_1 = {entity: "name1"}
+    await default_processor.handle_message(
+        UserMessage(f"/greet{json.dumps(slot_1)}", default_channel, sender_id)
+    )
+
+    assert default_channel.latest_output() == {
+        "recipient_id": sender_id,
+        "text": "hey there name1!",
+    }
+
+    # This restarts the chat
+    await default_processor.handle_message(
+        UserMessage("/restart", default_channel, sender_id)
+    )
+
+    tracker = default_processor.tracker_store.get_or_create_tracker(sender_id)
+
+    expected = [
+        ActionExecuted(ACTION_SESSION_START_NAME),
+        SessionStarted(),
+        ActionExecuted(ACTION_LISTEN_NAME),
+        UserUttered(
+            f"/greet{json.dumps(slot_1)}",
+            {INTENT_NAME_KEY: "greet", "confidence": 1.0},
+            [{"entity": entity, "start": 6, "end": 23, "value": "name1"}],
+        ),
+        SlotSet(entity, slot_1[entity]),
+        ActionExecuted("utter_greet"),
+        BotUttered("hey there name1!", metadata={"template_name": "utter_greet"}),
+        ActionExecuted(ACTION_LISTEN_NAME),
+        UserUttered("/restart", {INTENT_NAME_KEY: "restart", "confidence": 1.0},),
+        ActionExecuted(ACTION_RESTART_NAME),
+        Restarted(),
+        ActionExecuted(ACTION_SESSION_START_NAME),
+        SessionStarted(),
+        # No previous slot is set due to restart.
+        ActionExecuted(ACTION_LISTEN_NAME),
+    ]
+    assert list(tracker.events) == expected

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -348,7 +348,10 @@ def test_restart_event(default_domain: Domain):
     tracker.update(Restarted())
 
     assert len(tracker.events) == 5
-    assert tracker.followup_action is not None
+    assert tracker.followup_action == ACTION_SESSION_START_NAME
+
+    tracker.update(SessionStarted())
+
     assert tracker.followup_action == ACTION_LISTEN_NAME
     assert tracker.latest_message.text is None
     assert len(list(tracker.generate_all_prior_trackers())) == 1
@@ -359,7 +362,7 @@ def test_restart_event(default_domain: Domain):
     recovered.recreate_from_dialogue(dialogue)
 
     assert recovered.current_state() == tracker.current_state()
-    assert len(recovered.events) == 5
+    assert len(recovered.events) == 6
     assert recovered.latest_message.text is None
     assert len(list(recovered.generate_all_prior_trackers())) == 1
 


### PR DESCRIPTION
Issue: https://github.com/RasaHQ/rasa/issues/5974
This PR adds `ActionSessionStart` as the followup action to `ActionRestart`.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
