### PR TITLE
Amend response schema to support missing top-level keys

### DIFF
--- a/changelog/7232.improvement.md
+++ b/changelog/7232.improvement.md
@@ -1,0 +1,1 @@
+Add support for the top-level response keys `quick_replies`, `attachment` and `elements` refered to in `rasa.core.channels.OutputChannel.send_reponse`, as well as `metadata`.

--- a/rasa/shared/nlu/training_data/schemas/responses.yml
+++ b/rasa/shared/nlu/training_data/schemas/responses.yml
@@ -29,5 +29,25 @@ schema;responses:
                   type: "str"
                 payload:
                   type: "str"
+          quick_replies:
+            type: "seq"
+            sequence:
+            - type: "map"
+              allowempty: True
+              mapping:
+                title:
+                  type: "str"
+                payload:
+                  type: "str"
+          attachment:
+            type: "map"
+            allowempty: True
+          elements:
+            type: "seq"
+            sequence:
+            - type: "map"
+              allowempty: True
           channel:
             type: "str"
+          metadata:
+            type: "any"


### PR DESCRIPTION
**Proposed changes**:
Add support for the top-level response keys `quick_replies`, `attachment` and `elements` refered to in `rasa.core.channels.OutputChannel.send_reponse`, as well as `metadata`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
