### PR TITLE
Add docs for the pipe symbol in YAML

### DIFF
--- a/docs/docs/training-data-format.mdx
+++ b/docs/docs/training-data-format.mdx
@@ -99,6 +99,13 @@ stories:
 [Test stories](#test-stories) use the same format as the story training data and should be placed
 in a separate file with the prefix `test_`.
 
+:::note The  `|` symbol
+As shown in the above examples, the `user` and `examples` keys are followed by `|`
+(pipe) symbol. In YAML `|` identifies multi-line strings with preserved indentation.
+This helps to keep special symbols like `"`, `'` and others still available in the
+training examples.
+:::
+
 ## NLU Training Data
 
 [NLU](glossary.mdx#nlu) training data consists of example user utterances categorized by


### PR DESCRIPTION
Closes #6734

**Proposed changes**:
- Added a doc entry for the `|` symbol

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
