### PR TITLE
fix docstyle validations

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -99,8 +99,12 @@ jobs:
     - name: Checkout target branch to be able to diff
       if: github.event_name == 'pull_request'
       run: |
-        git fetch --depth=1 origin ${{ github.base_ref }}
+        git fetch origin ${{ github.base_ref }}
         echo "DOCSTRING_DIFF_BRANCH=origin/${{ github.base_ref }}" >> $GITHUB_ENV
+
+        # Fetch entire history for current branch so that `make lint-docstrings`
+        # can calculate the proper diff between the branches
+        git pull --ff-only --unshallow origin ${{ github.head_ref }}
 
     - name: Lint Code 🎎
       run: |

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,16 @@ lint:
 	poetry run black --check rasa tests
 	make lint-docstrings
 
-BRANCH ?= master # Compare against `master` if no branch was provided
+# Compare against `master` if no branch was provided
+BRANCH ?= master
 lint-docstrings:
-	# Lint docstrings only against the the diff to avoid too many errors.
-	# Check only production code. Ignore other flake errors which are captured by `lint`
-	# Diff of committed changes (shows only changes introduced by your branch)
-	if [[ -n "$(BRANCH)" ]]; then \
-	    git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff; \
-	fi
+# Lint docstrings only against the the diff to avoid too many errors.
+# Check only production code. Ignore other flake errors which are captured by `lint`
+# Diff of committed changes (shows only changes introduced by your branch
+ifneq ($(strip $(BRANCH)),)
+	git diff $(BRANCH)...HEAD -- rasa | poetry run flake8 --select D --diff
+endif
+
 	# Diff of uncommitted changes for running locally
 	git diff HEAD -- rasa | poetry run flake8 --select D --diff
 


### PR DESCRIPTION
**Proposed changes**:
- use `Make` conditions
- fix the following error (`sh` doesn't support `[[`)
```
make lint-docstrings
make[1]: Entering directory '/home/runner/work/rasa-sdk/rasa-sdk'
# Lint docstrings only against the the diff to avoid too many errors.
# Check only production code. Ignore other flake errors which are captured by `lint`
# Diff of committed changes (shows only changes introduced by your branch)
if [[ -n "origin/master" ]]; then \
    git diff origin/master...HEAD -- rasa-sdk | poetry run flake8 --select D --diff; \
fi
/bin/sh: 1: [[: not found
```

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
