### PR TITLE
Speed up LexicalSyntacticFeaturizer when using window features

### DIFF
--- a/changelog/6406.improvement.md
+++ b/changelog/6406.improvement.md
@@ -1,0 +1,1 @@
+Memoizes feature computations when window features are used are used in LexicalSyntacticFeaturizer. This results in some minor speedups since features are no longer computed repeatedly for each token.

--- a/tests/nlu/featurizers/test_lexical_syntactic_featurizer.py
+++ b/tests/nlu/featurizers/test_lexical_syntactic_featurizer.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import scipy.sparse
-from typing import Text
+from typing import Text, List
 
 from rasa.nlu.tokenizers.spacy_tokenizer import SpacyTokenizer
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
@@ -11,7 +11,7 @@ from rasa.nlu.featurizers.sparse_featurizer.lexical_syntactic_featurizer import 
 )
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.shared.nlu.training_data.message import Message
-from rasa.nlu.constants import SPACY_DOCS
+from rasa.nlu.constants import SPACY_DOCS, TOKENS_NAMES
 from rasa.shared.nlu.constants import TEXT, ACTION_TEXT
 
 
@@ -195,3 +195,93 @@ def test_text_featurizer_using_pos_with_action_text(
 
     assert seq_vec is None
     assert sen_vec is None
+
+
+@pytest.mark.parametrize(
+    "sentence, featurizer_config",
+    [
+        (
+            "At 0700 the SUN is shining",
+            [
+                ["prefix2", "suffix1", "suffix3", "pos", "upper"],
+                [
+                    "low",
+                    "title",
+                    "prefix2",
+                    "suffix1",
+                    "suffix3",
+                    "pos",
+                    "upper",
+                    "digit",
+                ],
+                ["prefix2", "suffix1", "suffix3", "pos", "upper"],
+            ],
+        )
+    ],
+)
+def test_text_featurizer_using_feature_to_idx_dict(
+    sentence: Text, featurizer_config: List[List[Text]], spacy_nlp
+):
+    featurizer = LexicalSyntacticFeaturizer({"features": featurizer_config})
+
+    train_message = Message(data={TEXT: sentence, ACTION_TEXT: sentence})
+    test_message = Message(data={TEXT: sentence, ACTION_TEXT: sentence})
+
+    train_message.set(SPACY_DOCS[TEXT], spacy_nlp(sentence))
+    train_message.set(SPACY_DOCS[ACTION_TEXT], spacy_nlp(sentence))
+    test_message.set(SPACY_DOCS[TEXT], spacy_nlp(sentence))
+    test_message.set(SPACY_DOCS[ACTION_TEXT], spacy_nlp(sentence))
+
+    SpacyTokenizer().process(train_message)
+    SpacyTokenizer().process(test_message)
+
+    featurizer.train(TrainingData([train_message]))
+    featurizer.process(test_message)
+
+    seq_vec, sen_vec = test_message.get_sparse_features(TEXT, [])
+    if seq_vec:
+        seq_vec = seq_vec.features
+    if sen_vec:
+        sen_vec = sen_vec.features
+
+    # Check that all requested features were indexed
+    window_center = len(featurizer_config) // 2
+    for index in range(len(featurizer_config)):
+        for feature in featurizer_config[index]:
+            assert (
+                f"{index - window_center}:{feature}" in featurizer.feature_to_idx_dict
+            )
+
+    # Check that all indexed features were requested
+    for feature in featurizer.feature_to_idx_dict.keys():
+        i, feature_function = feature.split(":")
+        index = int(i)
+        assert index + window_center < len(featurizer_config)
+        assert feature_function in featurizer_config[index + window_center]
+
+    feature_vec = seq_vec.toarray()
+    tokens = test_message.get(TOKENS_NAMES[TEXT])
+
+    assert len(tokens) == feature_vec.shape[0]
+
+    # For each word, check that the features we expect are the features we received
+    for i, _ in enumerate(tokens):
+        token_features = feature_vec[i, :]
+
+        # For each expected feature, check that it's 1, then zero it out
+        for j, position_features in enumerate(featurizer_config):
+            position = i + j - window_center
+            if position >= 0 and position < len(tokens):
+                for feature_function in position_features:
+                    feature_name = f"{j - window_center}:{feature_function}"
+                    feature_value_str = str(
+                        featurizer.function_dict[feature_function](tokens[position])
+                    )
+                    feature_idx = featurizer.feature_to_idx_dict[feature_name][
+                        feature_value_str
+                    ]
+                    assert token_features[feature_idx] == 1.0
+                    token_features[feature_idx] = 0.0
+
+        # Since all expected features were zeroed out, result should be all zeros
+        assert not np.any(token_features)


### PR DESCRIPTION
**Proposed changes**:
- Memoizes feature computations when window features are used are used in LexicalSyntacticFeaturizer. This results in some minor speedups since features are no longer computed repeatedly for each token., as noted by https://github.com/RasaHQ/rasa/issues/6406. It doesn't completely solve their problem, since more features still require more time to compute (e.g. since there are larger arrays in _features_to_onehot).

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
