### PR TITLE
Fix `black` to be the same version in the pre-commit config as it's in the pyproject config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
 -   repo: https://github.com/thlorenz/doctoc


### PR DESCRIPTION
**Proposed changes**:
In `.pre-commit-config.yaml` we used `stable` version of `black` but in `pyproject.toml` we had a fixed major version. Now the version should is fixed inside `.pre-commit-config.yaml` as well.

I've checked locally and the updated config installs the right version of `black` into my pre-commit hook.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
