### PR TITLE
Return "Migrate from" entry to the docs sidebar

### DIFF
--- a/changelog/7313.doc.md
+++ b/changelog/7313.doc.md
@@ -1,0 +1,1 @@
+Return the "Migrate from" entry to the docs sidebar.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -8,16 +8,8 @@ module.exports = {
       collapsed: false,
       items: [
           'installation',
+          'migrate-from',
           'command-line-interface',
-//        {
-//          type: 'category',
-//          label: 'Getting Started',
-//          collapsed: true,
-//          items: [
-//            'installation',
-//            'migrate-from',
-//          ],
-//        },
         {
           type: 'category',
           label: 'Best Practices',


### PR DESCRIPTION
**Proposed changes**:
- Returns back the "Migrate from" entry to the docs sidebar
<img width="298" alt="Screenshot 2020-11-19 at 13 59 10" src="https://user-images.githubusercontent.com/911127/99669504-735ad080-2a6f-11eb-9ee7-6e19ce37e1ec.png">


**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
