### PR TITLE
utter end-to-end responses

### DIFF
--- a/changelog/6410.removal.md
+++ b/changelog/6410.removal.md
@@ -1,0 +1,2 @@
+`Domain.random_template_for` is deprecated and will be removed in Rasa Open Source 
+3.0.0. You can alternatively use the `TemplatedNaturalLanguageGenerator`.

--- a/changelog/6410.removal.md
+++ b/changelog/6410.removal.md
@@ -1,2 +1,5 @@
 `Domain.random_template_for` is deprecated and will be removed in Rasa Open Source 
 3.0.0. You can alternatively use the `TemplatedNaturalLanguageGenerator`.
+
+`Domain.action_names` is deprecated and will be removed in Rasa Open Source 
+3.0.0. Please use `Domain.action_names_or_texts` instead.

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -102,7 +102,9 @@ def action_for_index(
             f"Domain has {domain.num_actions} actions."
         )
 
-    return action_for_name_or_text(domain.action_names[index], domain, action_endpoint)
+    return action_for_name_or_text(
+        domain.action_names_or_texts[index], domain, action_endpoint
+    )
 
 
 def is_retrieval_action(action_name: Text, retrieval_intents: List[Text]) -> bool:
@@ -141,7 +143,7 @@ def action_for_name_or_text(
     Returns:
         The instantiated action.
     """
-    if action_name_or_text not in domain.action_names:
+    if action_name_or_text not in domain.action_names_or_texts:
         domain.raise_action_not_found_exception(action_name_or_text)
 
     defaults = {a.name(): a for a in default_actions(action_endpoint)}

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -158,7 +158,7 @@ def action_for_name_or_text(
         return ActionRetrieveResponse(action_name_or_text)
 
     if action_name_or_text in domain.action_texts:
-        return EndToEndAction(action_name_or_text)
+        return ActionEndToEndResponse(action_name_or_text)
 
     if action_name_or_text.startswith(UTTER_PREFIX):
         return ActionUtterTemplate(action_name_or_text)
@@ -288,7 +288,7 @@ class ActionUtterTemplate(Action):
         return "ActionUtterTemplate('{}')".format(self.name())
 
 
-class EndToEndAction(Action):
+class ActionEndToEndResponse(Action):
     """Action to utter end-to-end responses to the user."""
 
     def __init__(self, action_text: Text) -> None:

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -301,7 +301,8 @@ class EndToEndAction(Action):
 
     def name(self) -> Text:
         """Returns action name."""
-
+        # In case of an end-to-end action there is no label (aka name) for the action.
+        # We fake a name by returning the text which we respond to the user.
         return self.action_text
 
     async def run(

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -170,7 +170,7 @@ def action_from_name(
     ):
         return ActionRetrieveResponse(name)
 
-    if name.startswith(UTTER_PREFIX):
+    if name.startswith(UTTER_PREFIX) or name in domain.action_texts:
         return ActionUtterTemplate(name)
 
     is_form = name in domain.form_names

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -137,10 +137,10 @@ def action_for_name_or_text(
 
     Raises:
         ActionNotFoundException: If action not in current domain.
+
     Returns:
         The instantiated action.
     """
-
     if action_name_or_text not in domain.action_names:
         domain.raise_action_not_found_exception(action_name_or_text)
 
@@ -232,7 +232,8 @@ class Action:
         raise NotImplementedError
 
     def __str__(self) -> Text:
-        return "Action('{}')".format(self.name())
+        """Returns text representation of form."""
+        return f"{self.__class__.__name__}('{self.name()}')"
 
     def event_for_successful_execution(
         self, prediction: PolicyPrediction
@@ -254,9 +255,17 @@ class ActionUtterTemplate(Action):
     """An action which only effect is to utter a template when it is run.
 
     Both, name and utter template, need to be specified using
-    the `name` method."""
+    the `name` method.
+    """
 
     def __init__(self, name: Text, silent_fail: Optional[bool] = False):
+        """Creates action.
+
+        Args:
+            name: Name of the action.
+            silent_fail: `True` if the action should fail silently in case no response
+                was defined for this action.
+        """
         self.template_name = name
         self.silent_fail = silent_fail
 
@@ -282,10 +291,8 @@ class ActionUtterTemplate(Action):
         return [create_bot_utterance(message)]
 
     def name(self) -> Text:
+        """Returns action name."""
         return self.template_name
-
-    def __str__(self) -> Text:
-        return "ActionUtterTemplate('{}')".format(self.name())
 
 
 class ActionEndToEndResponse(Action):
@@ -338,6 +345,7 @@ class ActionRetrieveResponse(ActionUtterTemplate):
     """An action which queries the Response Selector for the appropriate response."""
 
     def __init__(self, name: Text, silent_fail: Optional[bool] = False):
+        """Creates action. See docstring of parent class."""
         super().__init__(name, silent_fail)
         self.action_name = name
         self.silent_fail = silent_fail
@@ -393,10 +401,8 @@ class ActionRetrieveResponse(ActionUtterTemplate):
         return await super().run(output_channel, nlg, tracker, domain)
 
     def name(self) -> Text:
+        """Returns action name."""
         return self.action_name
-
-    def __str__(self) -> Text:
-        return "ActionRetrieveResponse('{}')".format(self.name())
 
 
 class ActionBack(ActionUtterTemplate):

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -128,7 +128,7 @@ def is_retrieval_action(action_name: Text, retrieval_intents: List[Text]) -> boo
 def action_for_name_or_text(
     action_name_or_text: Text, domain: Domain, action_endpoint: Optional[EndpointConfig]
 ) -> "Action":
-    """Retrieves an action by its name.
+    """Retrieves an action by its name or by its text in case it's an end-to-end action.
 
     Args:
         action_name_or_text: The name of the action.
@@ -241,7 +241,7 @@ class Action:
         """Event which should be logged for the successful execution of this action.
 
         Args:
-            prediction: Prediction which led to the execution for this event.
+            prediction: Prediction which led to the execution of this event.
 
         Returns:
             Event which should be logged onto the tracker.
@@ -258,7 +258,7 @@ class ActionUtterTemplate(Action):
     the `name` method.
     """
 
-    def __init__(self, name: Text, silent_fail: Optional[bool] = False):
+    def __init__(self, name: Text, silent_fail: Optional[bool] = False) -> None:
         """Creates action.
 
         Args:
@@ -309,7 +309,7 @@ class ActionEndToEndResponse(Action):
     def name(self) -> Text:
         """Returns action name."""
         # In case of an end-to-end action there is no label (aka name) for the action.
-        # We fake a name by returning the text which we respond to the user.
+        # We fake a name by returning the text which the bot sends back to the user.
         return self.action_text
 
     async def run(
@@ -329,7 +329,7 @@ class ActionEndToEndResponse(Action):
         """Event which should be logged for the successful execution of this action.
 
         Args:
-            prediction: Prediction which led to the execution for this event.
+            prediction: Prediction which led to the execution of this event.
 
         Returns:
             Event which should be logged onto the tracker.
@@ -344,7 +344,7 @@ class ActionEndToEndResponse(Action):
 class ActionRetrieveResponse(ActionUtterTemplate):
     """An action which queries the Response Selector for the appropriate response."""
 
-    def __init__(self, name: Text, silent_fail: Optional[bool] = False):
+    def __init__(self, name: Text, silent_fail: Optional[bool] = False) -> None:
         """Creates action. See docstring of parent class."""
         super().__init__(name, silent_fail)
         self.action_name = name

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -552,15 +552,20 @@ class FormAction(LoopAction):
         logger.debug(f"Request next slot '{slot_name}'")
 
         action_to_ask_for_next_slot = self._name_of_utterance(domain, slot_name)
+        if not action_to_ask_for_next_slot:
+            # Use a debug log as the user might have asked as part of a custom action
+            logger.debug(
+                f"There was no action found to ask for slot '{slot_name}' "
+                f"name to be filled."
+            )
+            return []
 
-        if action_to_ask_for_next_slot:
-            action_to_ask_for_next_slot = action.action_for_name_or_text(
-                action_to_ask_for_next_slot, domain, self.action_endpoint
-            )
-            return await action_to_ask_for_next_slot.run(
-                output_channel, nlg, tracker, domain
-            )
-        return []
+        action_to_ask_for_next_slot = action.action_for_name_or_text(
+            action_to_ask_for_next_slot, domain, self.action_endpoint
+        )
+        return await action_to_ask_for_next_slot.run(
+            output_channel, nlg, tracker, domain
+        )
 
     # helpers
     @staticmethod

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -550,7 +550,7 @@ class FormAction(LoopAction):
     ) -> List[Event]:
         logger.debug(f"Request next slot '{slot_name}'")
 
-        action_to_ask_for_next_slot = action.action_from_name(
+        action_to_ask_for_next_slot = action.action_for_name_or_text(
             self._name_of_utterance(domain, slot_name), domain, self.action_endpoint
         )
         events_to_ask_for_next_slot = await action_to_ask_for_next_slot.run(

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -395,7 +395,7 @@ class FormAction(LoopAction):
 
         validate_name = f"validate_{self.name()}"
 
-        if validate_name not in domain.action_names:
+        if validate_name not in domain.action_names_or_texts:
             return events
 
         _tracker = self._temporary_tracker(tracker, events, domain)
@@ -536,7 +536,7 @@ class FormAction(LoopAction):
         found_actions = (
             action_name
             for action_name in search_path
-            if action_name in domain.action_names
+            if action_name in domain.action_names_or_texts
         )
 
         return next(found_actions, None)

--- a/rasa/core/actions/two_stage_fallback.py
+++ b/rasa/core/actions/two_stage_fallback.py
@@ -54,7 +54,7 @@ class TwoStageFallbackAction(LoopAction):
         tracker: DialogueStateTracker,
         domain: Domain,
     ) -> List[Event]:
-        affirm_action = action.action_from_name(
+        affirm_action = action.action_for_name_or_text(
             ACTION_DEFAULT_ASK_AFFIRMATION_NAME, domain, self._action_endpoint
         )
 
@@ -67,7 +67,7 @@ class TwoStageFallbackAction(LoopAction):
         tracker: DialogueStateTracker,
         domain: Domain,
     ) -> List[Event]:
-        rephrase = action.action_from_name(
+        rephrase = action.action_for_name_or_text(
             ACTION_DEFAULT_ASK_REPHRASE_NAME, domain, self._action_endpoint
         )
 
@@ -112,7 +112,7 @@ class TwoStageFallbackAction(LoopAction):
         tracker: DialogueStateTracker,
         domain: Domain,
     ) -> List[Event]:
-        fallback = action.action_from_name(
+        fallback = action.action_for_name_or_text(
             ACTION_DEFAULT_FALLBACK_NAME, domain, self._action_endpoint
         )
 

--- a/rasa/core/featurizers/single_state_featurizer.py
+++ b/rasa/core/featurizers/single_state_featurizer.py
@@ -74,7 +74,9 @@ class SingleStateFeaturizer:
             }
 
         self._default_feature_states[INTENT] = convert_to_dict(domain.intents)
-        self._default_feature_states[ACTION_NAME] = convert_to_dict(domain.action_names)
+        self._default_feature_states[ACTION_NAME] = convert_to_dict(
+            domain.action_names_or_texts
+        )
         self._default_feature_states[ENTITIES] = convert_to_dict(domain.entity_states)
         self._default_feature_states[SLOTS] = convert_to_dict(domain.slot_states)
         self._default_feature_states[ACTIVE_LOOP] = convert_to_dict(domain.form_names)
@@ -281,7 +283,7 @@ class SingleStateFeaturizer:
         # transpose to have seq_len x 1
         return {
             ENTITY_TAGS: [
-                Features(np.array([_tags]).T, IDS, ENTITY_TAGS, TAG_ID_ORIGIN,)
+                Features(np.array([_tags]).T, IDS, ENTITY_TAGS, TAG_ID_ORIGIN)
             ]
         }
 
@@ -309,7 +311,8 @@ class SingleStateFeaturizer:
         """
 
         return [
-            self._encode_action(action, interpreter) for action in domain.action_names
+            self._encode_action(action, interpreter)
+            for action in domain.action_names_or_texts
         ]
 
 

--- a/rasa/core/policies/policy.py
+++ b/rasa/core/policies/policy.py
@@ -16,7 +16,7 @@ from typing import (
     TYPE_CHECKING,
 )
 import numpy as np
-from rasa.shared.core.events import Event
+from rasa.shared.core.events import Event, ActionExecuted
 
 import rasa.shared.utils.common
 import rasa.utils.common
@@ -459,6 +459,30 @@ class PolicyPrediction:
             The highest predicted probability.
         """
         return max(self.probabilities, default=0.0)
+
+    def events_for_prediction(self, action_name: Text) -> List[Event]:
+        """Returns events which should be logged on the tracker for this prediction.
+
+        Args:
+            action_name: The name of the predicted action. If it was an end-to-end
+                prediction the `action_name` is actually the predicted text.
+
+        Returns:
+            The events which should be logged.
+        """
+        action_text = None
+        if self.is_end_to_end_prediction:
+            action_text = action_name
+            action_name = None
+
+        return self.events + [
+            ActionExecuted(
+                action_name,
+                action_text=action_text,
+                policy=self.policy_name,
+                confidence=self.max_confidence,
+            )
+        ]
 
 
 def confidence_scores_for(

--- a/rasa/core/policies/policy.py
+++ b/rasa/core/policies/policy.py
@@ -460,30 +460,6 @@ class PolicyPrediction:
         """
         return max(self.probabilities, default=0.0)
 
-    def events_for_prediction(self, action_name: Text) -> List[Event]:
-        """Returns events which should be logged on the tracker for this prediction.
-
-        Args:
-            action_name: The name of the predicted action. If it was an end-to-end
-                prediction the `action_name` is actually the predicted text.
-
-        Returns:
-            The events which should be logged.
-        """
-        action_text = None
-        if self.is_end_to_end_prediction:
-            action_text = action_name
-            action_name = None
-
-        return self.events + [
-            ActionExecuted(
-                action_name,
-                action_text=action_text,
-                policy=self.policy_name,
-                confidence=self.max_confidence,
-            )
-        ]
-
 
 def confidence_scores_for(
     action_name: Text, value: float, domain: Domain

--- a/rasa/core/policies/policy.py
+++ b/rasa/core/policies/policy.py
@@ -16,7 +16,7 @@ from typing import (
     TYPE_CHECKING,
 )
 import numpy as np
-from rasa.shared.core.events import Event, ActionExecuted
+from rasa.shared.core.events import Event
 
 import rasa.shared.utils.common
 import rasa.utils.common

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -756,8 +756,8 @@ class RulePolicy(MemoizationPolicy):
                 whether to use intent or text.
 
         Returns:
-            A tuple of the predicted action name (or `None` if no matching rule was
-            found), a description of the matching rule, and `True` if a loop action
+            A tuple of the predicted action name or text (or `None` if no matching rule
+            was found), a description of the matching rule, and `True` if a loop action
             was predicted after the loop has been in an unhappy path before.
         """
         if (

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -155,7 +155,7 @@ class RulePolicy(MemoizationPolicy):
 
         if (
             domain is None
-            or rule_policy._fallback_action_name not in domain.action_names
+            or rule_policy._fallback_action_name not in domain.action_names_or_texts
         ):
             raise InvalidDomain(
                 f"The fallback action '{rule_policy._fallback_action_name}' which was "
@@ -415,7 +415,9 @@ class RulePolicy(MemoizationPolicy):
             probabilities != self._default_predictions(domain)
             or tracker.is_rule_tracker
         ):
-            predicted_action_name = domain.action_names[np.argmax(probabilities)]
+            predicted_action_name = domain.action_names_or_texts[
+                np.argmax(probabilities)
+            ]
 
         return predicted_action_name
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -354,8 +354,8 @@ class MessageProcessor:
         """
         prediction = self._get_next_action_probabilities(tracker)
 
-        action = rasa.core.actions.action.action_for_prediction(
-            prediction, self.domain, self.action_endpoint
+        action = rasa.core.actions.action.action_for_index(
+            prediction.max_confidence_index, self.domain, self.action_endpoint
         )
 
         logger.debug(

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -152,7 +152,7 @@ class MessageProcessor:
 
         scores = [
             {"action": a, "score": p}
-            for a, p in zip(self.domain.action_names, prediction.probabilities)
+            for a, p in zip(self.domain.action_names_or_texts, prediction.probabilities)
         ]
         return {
             "scores": scores,
@@ -880,7 +880,7 @@ class MessageProcessor:
         followup_action = tracker.followup_action
         if followup_action:
             tracker.clear_followup_action()
-            if followup_action in self.domain.action_names:
+            if followup_action in self.domain.action_names_or_texts:
                 return PolicyPrediction.for_action_name(
                     self.domain, followup_action, FOLLOWUP_ACTION
                 )

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -354,8 +354,8 @@ class MessageProcessor:
         """
         prediction = self._get_next_action_probabilities(tracker)
 
-        action = rasa.core.actions.action.action_for_index(
-            prediction.max_confidence_index, self.domain, self.action_endpoint
+        action = rasa.core.actions.action.action_for_prediction(
+            prediction, self.domain, self.action_endpoint
         )
 
         logger.debug(

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -826,13 +826,9 @@ class MessageProcessor:
         )
         if action_name is not None and not action_was_rejected_manually:
             logger.debug(f"Policy prediction ended with events '{prediction.events}'.")
-            tracker.update_with_events(prediction.events, self.domain)
 
-            # log the action and its produced events
-            tracker.update(
-                ActionExecuted(
-                    action_name, prediction.policy_name, prediction.max_confidence
-                )
+            tracker.update_with_events(
+                prediction.events_for_prediction(action_name), self.domain
             )
 
         logger.debug(f"Action '{action_name}' ended with events '{events}'.")

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -511,7 +511,7 @@ class MessageProcessor:
                 )
 
     def _get_action(self, action_name) -> Optional[rasa.core.actions.action.Action]:
-        return rasa.core.actions.action.action_for_name(
+        return rasa.core.actions.action.action_for_name_or_text(
             action_name, self.domain, self.action_endpoint
         )
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -835,21 +835,6 @@ class MessageProcessor:
         logger.debug(f"Action '{action.name()}' ended with events '{events}'.")
         tracker.update_with_events(events, self.domain)
 
-    def _action_event_for_prediction(
-        self, action_name: Text, prediction: PolicyPrediction
-    ) -> ActionExecuted:
-        action_text = None
-        if action_name in self.domain.action_texts:
-            action_text = action_name
-            action_name = None
-
-        return ActionExecuted(
-            action_name,
-            prediction.policy_name,
-            prediction.max_confidence,
-            action_text=action_text,
-        )
-
     def _has_session_expired(self, tracker: DialogueStateTracker) -> bool:
         """Determine whether the latest session in `tracker` has expired.
 

--- a/rasa/core/training/training.py
+++ b/rasa/core/training/training.py
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
 def _find_events_after_actions(
     trackers: List["DialogueStateTracker"],
 ) -> Dict[Text, Set["Event"]]:
-    """Creates a dictionary of action names and events that follow these actions.
+    """Creates a mapping of action names / texts and events that follow these actions.
 
     Args:
         trackers: the list of trackers
 
     Returns:
-        a dictionary of action names and events that follow these actions
+        A mapping of action names / texts and events that follow these actions.
     """
     events_after_actions = defaultdict(set)
 

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -504,10 +504,25 @@ class Domain:
         store_entities_as_slots: bool = True,
         session_config: SessionConfig = SessionConfig.default(),
     ) -> None:
+        """Creates a `Domain`.
+
+        Args:
+            intents: Intent labels.
+            entities: The name of the entities which might be present in user messages.
+            slots: Slots to store information during the conversation.
+            templates: Bot responses. If an action with the same name is executed, it
+                will send the matching response to the user.
+            action_names: Names of custom actions.
+            forms: Form names and their slot mappings.
+            action_texts: End-to-End bot utterances from end-to-end stories.
+            store_entities_as_slots: If `True` Rasa will automatically create `SlotSet`
+                events for entities if there are slots with the same name as the entity.
+            session_config: Configuration for conversation sessions. Conversation are
+                restarted at the end of a session.
+        """
         self.entities, self.roles, self.groups = self.collect_entity_properties(
             entities
         )
-
         self.intent_properties = self.collect_intent_properties(
             intents, self.entities, self.roles, self.groups
         )
@@ -769,6 +784,14 @@ class Domain:
         )
 
     def random_template_for(self, utter_action: Text) -> Optional[Dict[Text, Any]]:
+        """Returns a random response for an action name.
+
+        Args:
+            utter_action: The name of the utter action.
+
+        Returns:
+            A response for an utter action.
+        """
         import numpy as np
 
         if utter_action in self.templates:

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -668,6 +668,7 @@ class Domain:
 
     @rasa.shared.utils.common.lazy_property
     def action_names(self) -> List[Text]:
+        """Returns action names or texts."""
         rasa.shared.utils.io.raise_warning(
             f"{Domain.__name__}.{Domain.action_names.__name__} "
             f"is deprecated and will be removed version 3.0.0.",
@@ -676,9 +677,8 @@ class Domain:
         return self.action_names_or_texts
 
     @rasa.shared.utils.common.lazy_property
-    def num_actions(self):
+    def num_actions(self) -> int:
         """Returns the number of available actions."""
-
         # noinspection PyTypeChecker
         return len(self.action_names_or_texts)
 
@@ -762,17 +762,26 @@ class Domain:
                     self.slots.append(TextSlot(s, influence_conversation=False))
 
     def index_for_action(self, action_name: Text) -> Optional[int]:
-        """Look up which action index corresponds to this action name."""
-
+        """Looks up which action index corresponds to this action."""
         try:
             return self.action_names_or_texts.index(action_name)
         except ValueError:
             self.raise_action_not_found_exception(action_name)
 
-    def raise_action_not_found_exception(self, action_name) -> NoReturn:
+    def raise_action_not_found_exception(self, action_name_or_text: Text) -> NoReturn:
+        """Raises exception if action name or text not part of the domain.
+
+        Args:
+            action_name_or_text: Name of an action or its text in case it's an
+                end-to-end bot utterance.
+
+        Raises:
+            ActionNotFoundException: If `action_name_or_text` are not part of this
+                domain.
+        """
         action_names = "\n".join([f"\t - {a}" for a in self.action_names_or_texts])
         raise ActionNotFoundException(
-            f"Cannot access action '{action_name}', "
+            f"Cannot access action '{action_name_or_text}', "
             f"as that name is not a registered "
             f"action for this domain. "
             f"Available actions are: \n{action_names}"
@@ -860,7 +869,6 @@ class Domain:
     @rasa.shared.utils.common.lazy_property
     def input_states(self) -> List[Text]:
         """Returns all available states."""
-
         return (
             self.intents
             + self.entity_states
@@ -1074,6 +1082,7 @@ class Domain:
         return {slot.name: slot.persistence_info() for slot in self.slots}
 
     def as_dict(self) -> Dict[Text, Any]:
+        """Return serialized `Domain`."""
         return {
             "config": {"store_entities_as_slots": self.store_entities_as_slots},
             SESSION_CONFIG_KEY: {
@@ -1364,8 +1373,7 @@ class Domain:
         def check_mappings(
             intent_properties: Dict[Text, Dict[Text, Union[bool, List]]]
         ) -> List[Tuple[Text, Text]]:
-            """Check whether intent-action mappings use proper action names."""
-
+            """Checks whether intent-action mappings use valid action names or texts."""
             incorrect = []
             for intent, properties in intent_properties.items():
                 if "triggers" in properties:

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -536,15 +536,12 @@ class Domain:
         action_names += overridden_form_actions
 
         self.slots = slots
+        self.templates = templates
+        self.action_texts = action_texts or []
         self.session_config = session_config
 
         self._custom_actions = action_names
 
-        self.action_texts = action_texts or []
-        self._responses_from_domain = templates
-        self.templates = self._combine_domain_responses_with_end_to_end_responses(
-            templates, self.action_texts
-        )
         # only includes custom actions and utterance actions
         self.user_actions = self._combine_with_templates(action_names, templates)
 
@@ -642,18 +639,6 @@ class Domain:
         )
 
         return [], {}, []
-
-    @classmethod
-    def _combine_domain_responses_with_end_to_end_responses(
-        cls,
-        user_responses: Dict[Text, List[Dict[Text, Any]]],
-        end_to_end_responses: List[Text],
-    ) -> Dict[Text, List[Dict[Text, Any]]]:
-        end_to_end_responses = {
-            end_to_end_response: [{"text": end_to_end_response}]
-            for end_to_end_response in end_to_end_responses
-        }
-        return {**user_responses, **end_to_end_responses}
 
     def __hash__(self) -> int:
         """Returns a unique hash for the domain."""
@@ -1087,7 +1072,7 @@ class Domain:
             KEY_INTENTS: self._transform_intents_for_file(),
             KEY_ENTITIES: self._transform_entities_for_file(),
             KEY_SLOTS: self._slot_definitions(),
-            KEY_RESPONSES: self._responses_from_domain,
+            KEY_RESPONSES: self.templates,
             KEY_ACTIONS: self._custom_actions,
             KEY_FORMS: self.forms,
             KEY_E2E_ACTIONS: self.action_texts,

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -794,6 +794,10 @@ class Domain:
         """
         import numpy as np
 
+        rasa.shared.utils.io.raise_warning(
+            "This method is deprecated and will be removed version 3.0.0.",
+            category=DeprecationWarning,
+        )
         if utter_action in self.templates:
             return np.random.choice(self.templates[utter_action])
         else:

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -301,8 +301,12 @@ class DialogueStateTracker:
             self.active_loop[LOOP_REJECTED] = True
 
     def set_latest_action(self, action: Dict[Text, Text]) -> None:
-        """Set latest action name
-        and reset form validation and rejection parameters
+        """Sets latest action name or text.
+
+        Resets loop validation and rejection parameters.
+
+        Args:
+            action: Serialized action event.
         """
         self.latest_action = action
         if self.active_loop_name:

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -13,7 +13,7 @@ from rasa.shared.nlu.interpreter import NaturalLanguageInterpreter, RegexInterpr
 from rasa.shared.core.training_data.structures import StoryGraph
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data.training_data import TrainingData
-from rasa.shared.nlu.constants import INTENT, TEXT, ENTITIES, ACTION_NAME
+from rasa.shared.nlu.constants import ENTITIES, ACTION_NAME
 from rasa.shared.importers.autoconfig import TrainingType
 from rasa.shared.core.domain import IS_RETRIEVAL_INTENT_KEY
 
@@ -464,7 +464,7 @@ class E2EImporter(TrainingDataImporter):
             [],
             {},
             action_names=[],
-            forms=[],
+            forms={},
             action_texts=additional_e2e_action_names,
         )
 

--- a/rasa/telemetry.py
+++ b/rasa/telemetry.py
@@ -693,7 +693,7 @@ async def track_model_training(
             "policies": config.get("policies"),
             "num_intent_examples": len(nlu_data.intent_examples),
             "num_entity_examples": len(nlu_data.entity_examples),
-            "num_actions": len(domain.action_names),
+            "num_actions": len(domain.action_names_or_texts),
             # Old nomenclature from when 'responses' were still called
             # 'templates' in the domain
             "num_templates": len(domain.templates),
@@ -870,7 +870,7 @@ def track_project_init(path: Text) -> None:
         path: Location of the project
     """
     _track(
-        TELEMETRY_PROJECT_CREATED_EVENT, {"init_directory": _hash_directory_path(path)},
+        TELEMETRY_PROJECT_CREATED_EVENT, {"init_directory": _hash_directory_path(path)}
     )
 
 

--- a/rasa/validator.py
+++ b/rasa/validator.py
@@ -143,7 +143,6 @@ class Validator:
 
     def verify_utterances(self, ignore_warnings: bool = True) -> bool:
         """Compares list of utterances in actions with utterances in responses."""
-
         actions = self.domain.action_names_or_texts
         utterance_templates = set(self.domain.templates)
         everything_is_alright = True

--- a/rasa/validator.py
+++ b/rasa/validator.py
@@ -138,13 +138,13 @@ class Validator:
         return responses | {
             utterance
             for utterance in self.domain.templates.keys()
-            if utterance in self.domain.action_names
+            if utterance in self.domain.action_names_or_texts
         }
 
     def verify_utterances(self, ignore_warnings: bool = True) -> bool:
         """Compares list of utterances in actions with utterances in responses."""
 
-        actions = self.domain.action_names
+        actions = self.domain.action_names_or_texts
         utterance_templates = set(self.domain.templates)
         everything_is_alright = True
 

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -1082,7 +1082,9 @@ async def test_ask_for_slot(
 
     action_from_name = Mock(return_value=action.ActionListen())
     endpoint_config = Mock()
-    monkeypatch.setattr(action, action.action_from_name.__name__, action_from_name)
+    monkeypatch.setattr(
+        action, action.action_for_name_or_text.__name__, action_from_name
+    )
 
     form = FormAction("my_form", endpoint_config)
     domain = Domain.from_dict(domain)

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -446,10 +446,16 @@ async def test_validate_slots_on_activation_with_other_action_after_user_utteran
     ]
 
 
-def test_name_of_utterance():
-    form_name = "another_form"
+@pytest.mark.parametrize(
+    "utterance_name, expected",
+    [
+        ("utter_ask_my_form_num_people", "utter_ask_my_form_num_people"),
+        ("utter_ask_num_people", "utter_ask_num_people"),
+    ],
+)
+def test_name_of_utterance(utterance_name: Text, expected: Optional[Text]):
+    form_name = "my_form"
     slot_name = "num_people"
-    full_utterance_name = f"utter_ask_{form_name}_{slot_name}"
 
     domain = f"""
     forms:
@@ -457,22 +463,14 @@ def test_name_of_utterance():
         {slot_name}:
         - type: from_text
     responses:
-        {full_utterance_name}:
+        {utterance_name}:
         - text: "How many people?"
     """
     domain = Domain.from_yaml(domain)
 
-    action_server_url = "http:/my-action-server:5055/webhook"
+    action = FormAction(form_name, None)
 
-    with aioresponses():
-        action_server = EndpointConfig(action_server_url)
-        action = FormAction(form_name, action_server)
-
-        assert action._name_of_utterance(domain, slot_name) == full_utterance_name
-        assert (
-            action._name_of_utterance(domain, "another_slot")
-            == "utter_ask_another_slot"
-        )
+    assert action._name_of_utterance(domain, slot_name) == utterance_name
 
 
 def test_temporary_tracker():
@@ -1044,7 +1042,6 @@ def test_extract_other_slots_with_entity(
 @pytest.mark.parametrize(
     "domain, expected_action",
     [
-        ({}, "utter_ask_sun"),
         (
             {
                 "actions": ["action_ask_my_form_sun", "action_ask_sun"],
@@ -1093,3 +1090,22 @@ async def test_ask_for_slot(
     )
 
     action_from_name.assert_called_once_with(expected_action, domain, endpoint_config)
+
+
+async def test_ask_for_slot_if_not_utter_ask(monkeypatch: MonkeyPatch):
+    action_from_name = Mock(return_value=action.ActionListen())
+    endpoint_config = Mock()
+    monkeypatch.setattr(
+        action, action.action_for_name_or_text.__name__, action_from_name
+    )
+
+    form = FormAction("my_form", endpoint_config)
+    await form._ask_for_slot(
+        Domain.empty(),
+        None,
+        None,
+        "some slot",
+        DialogueStateTracker.from_events("dasd", []),
+    )
+
+    action_from_name.assert_not_called()

--- a/tests/core/featurizers/test_single_state_featurizers.py
+++ b/tests/core/featurizers/test_single_state_featurizers.py
@@ -172,7 +172,7 @@ def test_single_state_featurizer_creates_encoded_all_actions():
     f.prepare_from_domain(domain)
     encoded_actions = f.encode_all_actions(domain, RegexInterpreter())
 
-    assert len(encoded_actions) == len(domain.action_names)
+    assert len(encoded_actions) == len(domain.action_names_or_texts)
     assert all(
         [
             ACTION_NAME in encoded_action and ACTION_TEXT not in encoded_action

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -442,7 +442,7 @@ def assert_predicted_action(
 ) -> None:
     assert prediction.max_confidence == confidence
     index_of_predicted_action = prediction.max_confidence_index
-    prediction_action_name = domain.action_names[index_of_predicted_action]
+    prediction_action_name = domain.action_names_or_texts[index_of_predicted_action]
     assert prediction_action_name == expected_action_name
 
 

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -17,6 +17,7 @@ from rasa.core.actions.action import (
     ActionRetrieveResponse,
     RemoteAction,
     ActionSessionStart,
+    EndToEndAction,
 )
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel
@@ -785,7 +786,7 @@ def test_get_end_to_end_utterance_action():
 
     actual = action.action_for_name("Hi", domain, None)
 
-    assert isinstance(actual, ActionUtterTemplate)
+    assert isinstance(actual, EndToEndAction)
     assert actual.name() == end_to_end_utterance
 
 
@@ -821,6 +822,6 @@ async def test_run_end_to_end_utterance_action():
                 "image": None,
                 "custom": None,
             },
-            {"template_name": "Hi"},
+            {},
         )
     ]

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -98,7 +98,7 @@ def test_domain_action_instantiation():
 
     instantiated_actions = [
         action.action_for_name_or_text(action_name, domain, None)
-        for action_name in domain.action_names
+        for action_name in domain.action_names_or_texts
     ]
 
     assert len(instantiated_actions) == 14

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -17,7 +17,7 @@ from rasa.core.actions.action import (
     ActionRetrieveResponse,
     RemoteAction,
     ActionSessionStart,
-    EndToEndAction,
+    ActionEndToEndResponse,
 )
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel
@@ -786,7 +786,7 @@ def test_get_end_to_end_utterance_action():
 
     actual = action.action_for_name_or_text("Hi", domain, None)
 
-    assert isinstance(actual, EndToEndAction)
+    assert isinstance(actual, ActionEndToEndResponse)
     assert actual.name() == end_to_end_utterance
 
 

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -61,7 +61,7 @@ from tests.utilities import json_of_latest_request, latest_request
 
 
 @pytest.fixture(scope="module")
-def template_nlg():
+def template_nlg() -> TemplatedNaturalLanguageGenerator:
     templates = {
         "utter_ask_rephrase": [{"text": "can you rephrase that?"}],
         "utter_restart": [{"text": "congrats, you've restarted me!"}],
@@ -81,20 +81,8 @@ def template_nlg():
 
 
 @pytest.fixture(scope="module")
-def template_sender_tracker(default_domain):
+def template_sender_tracker(default_domain: Domain):
     return DialogueStateTracker("template-sender", default_domain.slots)
-
-
-def test_text_format():
-    assert "{}".format(ActionListen()) == "Action('action_listen')"
-    assert (
-        "{}".format(ActionUtterTemplate("my_action_name"))
-        == "ActionUtterTemplate('my_action_name')"
-    )
-    assert (
-        "{}".format(ActionRetrieveResponse("utter_test"))
-        == "ActionRetrieveResponse('utter_test')"
-    )
 
 
 def test_domain_action_instantiation():

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -21,6 +21,7 @@ from rasa.core.actions.action import (
 )
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel
+from rasa.shared.constants import UTTER_PREFIX
 from rasa.shared.core.domain import (
     ActionNotFoundException,
     SessionConfig,
@@ -759,9 +760,10 @@ def test_get_form_action_if_not_in_forms():
         assert not action.action_for_name_or_text(form_action_name, domain, None)
 
 
-def test_get_end_to_end_utterance_action():
-    end_to_end_utterance = "Hi"
-
+@pytest.mark.parametrize(
+    "end_to_end_utterance", ["Hi", f"{UTTER_PREFIX} is a dangerous start"]
+)
+def test_get_end_to_end_utterance_action(end_to_end_utterance: Text):
     domain = Domain.from_yaml(
         f"""
     actions:
@@ -772,7 +774,7 @@ def test_get_end_to_end_utterance_action():
 """
     )
 
-    actual = action.action_for_name_or_text("Hi", domain, None)
+    actual = action.action_for_name_or_text(end_to_end_utterance, domain, None)
 
     assert isinstance(actual, ActionEndToEndResponse)
     assert actual.name() == end_to_end_utterance

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -108,7 +108,7 @@ def test_domain_action_instantiation():
     )
 
     instantiated_actions = [
-        action.action_for_name(action_name, domain, None)
+        action.action_for_name_or_text(action_name, domain, None)
         for action_name in domain.action_names
     ]
 
@@ -722,7 +722,7 @@ def test_get_form_action(slot_mapping: Text):
     """
     )
 
-    actual = action.action_for_name(form_action_name, domain, None)
+    actual = action.action_for_name_or_text(form_action_name, domain, None)
     assert isinstance(actual, FormAction)
 
 
@@ -738,7 +738,7 @@ def test_get_form_action_with_rasa_open_source_1_forms():
         """
         )
 
-    actual = action.action_for_name(form_action_name, domain, None)
+    actual = action.action_for_name_or_text(form_action_name, domain, None)
     assert isinstance(actual, RemoteAction)
 
 
@@ -754,7 +754,7 @@ def test_overridden_form_action():
     """
     )
 
-    actual = action.action_for_name(form_action_name, domain, None)
+    actual = action.action_for_name_or_text(form_action_name, domain, None)
     assert isinstance(actual, RemoteAction)
 
 
@@ -768,7 +768,7 @@ def test_get_form_action_if_not_in_forms():
     )
 
     with pytest.raises(ActionNotFoundException):
-        assert not action.action_for_name(form_action_name, domain, None)
+        assert not action.action_for_name_or_text(form_action_name, domain, None)
 
 
 def test_get_end_to_end_utterance_action():
@@ -784,7 +784,7 @@ def test_get_end_to_end_utterance_action():
 """
     )
 
-    actual = action.action_for_name("Hi", domain, None)
+    actual = action.action_for_name_or_text("Hi", domain, None)
 
     assert isinstance(actual, EndToEndAction)
     assert actual.name() == end_to_end_utterance
@@ -803,7 +803,7 @@ async def test_run_end_to_end_utterance_action():
 """
     )
 
-    e2e_action = action.action_for_name("Hi", domain, None)
+    e2e_action = action.action_for_name_or_text("Hi", domain, None)
     events = await e2e_action.run(
         CollectingOutputChannel(),
         TemplatedNaturalLanguageGenerator(domain.templates),

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -78,7 +78,7 @@ async def test_agent_train(trained_moodbot_path: Text):
     loaded = Agent.load(trained_moodbot_path)
 
     # test domain
-    assert loaded.domain.action_names == moodbot_domain.action_names
+    assert loaded.domain.action_names_or_texts == moodbot_domain.action_names_or_texts
     assert loaded.domain.intents == moodbot_domain.intents
     assert loaded.domain.entities == moodbot_domain.entities
     assert loaded.domain.templates == moodbot_domain.templates

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -177,8 +177,8 @@ def test_fallback_mapping_restart():
         tracker, domain, RegexInterpreter()
     )
     index_of_mapping_policy = 1
-    next_action = rasa.core.actions.action.action_for_index(
-        prediction.max_confidence_index, domain, None
+    next_action = rasa.core.actions.action.action_for_prediction(
+        prediction, domain, None
     )
 
     assert (
@@ -222,8 +222,8 @@ def test_mapping_wins_over_form(events: List[Event]):
         tracker, domain, RegexInterpreter()
     )
 
-    next_action = rasa.core.actions.action.action_for_index(
-        prediction.max_confidence_index, domain, None
+    next_action = rasa.core.actions.action.action_for_prediction(
+        prediction, domain, None
     )
 
     index_of_mapping_policy = 0
@@ -265,8 +265,8 @@ def test_form_wins_over_everything_else(ensemble: SimplePolicyEnsemble):
         tracker, domain, RegexInterpreter()
     )
 
-    next_action = rasa.core.actions.action.action_for_index(
-        prediction.max_confidence_index, domain, None
+    next_action = rasa.core.actions.action.action_for_prediction(
+        prediction, domain, None
     )
 
     index_of_form_policy = 0
@@ -291,8 +291,8 @@ def test_fallback_wins_over_mapping():
         tracker, domain, RegexInterpreter()
     )
     index_of_fallback_policy = 0
-    next_action = rasa.core.actions.action.action_for_index(
-        prediction.max_confidence_index, domain, None
+    next_action = rasa.core.actions.action.action_for_prediction(
+        prediction, domain, None
     )
 
     assert (

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -177,8 +177,8 @@ def test_fallback_mapping_restart():
         tracker, domain, RegexInterpreter()
     )
     index_of_mapping_policy = 1
-    next_action = rasa.core.actions.action.action_for_prediction(
-        prediction, domain, None
+    next_action = rasa.core.actions.action.action_for_index(
+        prediction.max_confidence_index, domain, None
     )
 
     assert (
@@ -222,8 +222,8 @@ def test_mapping_wins_over_form(events: List[Event]):
         tracker, domain, RegexInterpreter()
     )
 
-    next_action = rasa.core.actions.action.action_for_prediction(
-        prediction, domain, None
+    next_action = rasa.core.actions.action.action_for_index(
+        prediction.max_confidence_index, domain, None
     )
 
     index_of_mapping_policy = 0
@@ -265,8 +265,8 @@ def test_form_wins_over_everything_else(ensemble: SimplePolicyEnsemble):
         tracker, domain, RegexInterpreter()
     )
 
-    next_action = rasa.core.actions.action.action_for_prediction(
-        prediction, domain, None
+    next_action = rasa.core.actions.action.action_for_index(
+        prediction.max_confidence_index, domain, None
     )
 
     index_of_form_policy = 0
@@ -291,8 +291,8 @@ def test_fallback_wins_over_mapping():
         tracker, domain, RegexInterpreter()
     )
     index_of_fallback_policy = 0
-    next_action = rasa.core.actions.action.action_for_prediction(
-        prediction, domain, None
+    next_action = rasa.core.actions.action.action_for_index(
+        prediction.max_confidence_index, domain, None
     )
 
     assert (

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -286,7 +286,9 @@ class TestSklearnPolicy(PolicyTestCollection):
             new_tracker = DialogueStateTracker(DEFAULT_SENDER_ID, default_domain.slots)
             for e in tr.applied_events():
                 if isinstance(e, ActionExecuted):
-                    new_action = default_domain.action_names[np.random.choice(classes)]
+                    new_action = rasa.core.actions.action.action_for_index(
+                        np.random.choice(classes), default_domain, action_endpoint=None
+                    ).name()
                     new_tracker.update(ActionExecuted(new_action))
                 else:
                     new_tracker.update(e)

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -181,7 +181,7 @@ class PolicyTestCollection:
             tracker, domain, RegexInterpreter()
         ).probabilities
         index = scores.index(max(scores))
-        return domain.action_names[index]
+        return domain.action_names_or_texts[index]
 
 
 class TestSklearnPolicy(PolicyTestCollection):
@@ -941,7 +941,7 @@ class TestMappingPolicy(PolicyTestCollection):
             tracker, domain_with_mapping, RegexInterpreter()
         )
         index = prediction.probabilities.index(max(prediction.probabilities))
-        action_planned = domain_with_mapping.action_names[index]
+        action_planned = domain_with_mapping.action_names_or_texts[index]
         assert not prediction.is_end_to_end_prediction
         assert action_planned == ACTION_LISTEN_NAME
         assert prediction.probabilities != [0] * domain_with_mapping.num_actions

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -286,9 +286,7 @@ class TestSklearnPolicy(PolicyTestCollection):
             new_tracker = DialogueStateTracker(DEFAULT_SENDER_ID, default_domain.slots)
             for e in tr.applied_events():
                 if isinstance(e, ActionExecuted):
-                    new_action = rasa.core.actions.action.action_for_index(
-                        np.random.choice(classes), default_domain, action_endpoint=None
-                    ).name()
+                    new_action = default_domain.action_names[np.random.choice(classes)]
                     new_tracker.update(ActionExecuted(new_action))
                 else:
                     new_tracker.update(e)

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1086,7 +1086,7 @@ async def test_logging_of_end_to_end_action():
     await processor.handle_message(UserMessage(user_message, sender_id=conversation_id))
 
     tracker = tracker_store.retrieve(conversation_id)
-    assert list(tracker.events) == [
+    expected_events = [
         ActionExecuted(ACTION_SESSION_START_NAME),
         SessionStarted(),
         ActionExecuted(ACTION_LISTEN_NAME),
@@ -1095,3 +1095,5 @@ async def test_logging_of_end_to_end_action():
         BotUttered("hi, how are you?", {}, {"template_name": end_to_end_action}, 123),
         ActionExecuted(ACTION_LISTEN_NAME),
     ]
+    for event, expected in zip(tracker.events, expected_events):
+        assert event == expected

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -43,7 +43,7 @@ from rasa.shared.core.events import (
     LoopInterrupted,
 )
 from rasa.core.interpreter import RasaNLUHttpInterpreter
-from rasa.shared.nlu.interpreter import NaturalLanguageInterpreter
+from rasa.shared.nlu.interpreter import NaturalLanguageInterpreter, RegexInterpreter
 from rasa.core.policies import SimplePolicyEnsemble, PolicyEnsemble
 from rasa.core.policies.ted_policy import TEDPolicy
 from rasa.core.processor import MessageProcessor
@@ -1035,3 +1035,63 @@ async def test_policy_events_not_applied_if_rejected(
     ]
     for event, expected in zip(tracker.events, expected_events):
         assert event == expected
+
+
+async def test_logging_of_end_to_end_action():
+    end_to_end_action = "hi, how are you?"
+    domain = Domain(
+        intents=["greet"],
+        entities=[],
+        slots=[],
+        templates={},
+        action_names=[],
+        forms={},
+        action_texts=[end_to_end_action],
+    )
+
+    conversation_id = "test_logging_of_end_to_end_action"
+    user_message = "/greet"
+
+    class ConstantEnsemble(PolicyEnsemble):
+        def __init__(self) -> None:
+            super().__init__([])
+            self.number_of_calls = 0
+
+        def probabilities_using_best_policy(
+            self,
+            tracker: DialogueStateTracker,
+            domain: Domain,
+            interpreter: NaturalLanguageInterpreter,
+            **kwargs: Any,
+        ) -> PolicyPrediction:
+            if self.number_of_calls == 0:
+                prediction = PolicyPrediction.for_action_name(
+                    domain, end_to_end_action, "some policy"
+                )
+                prediction.is_end_to_end_prediction = True
+                self.number_of_calls += 1
+                return prediction
+            else:
+                return PolicyPrediction.for_action_name(domain, ACTION_LISTEN_NAME)
+
+    tracker_store = InMemoryTrackerStore(domain)
+    processor = MessageProcessor(
+        RegexInterpreter(),
+        ConstantEnsemble(),
+        domain,
+        tracker_store,
+        NaturalLanguageGenerator.create(None, domain),
+    )
+
+    await processor.handle_message(UserMessage(user_message, sender_id=conversation_id))
+
+    tracker = tracker_store.retrieve(conversation_id)
+    assert list(tracker.events) == [
+        ActionExecuted(ACTION_SESSION_START_NAME),
+        SessionStarted(),
+        ActionExecuted(ACTION_LISTEN_NAME),
+        UserUttered(user_message, intent={"name": "greet"}),
+        ActionExecuted(action_text=end_to_end_action),
+        BotUttered("hi, how are you?", {}, {"template_name": end_to_end_action}, 123),
+        ActionExecuted(ACTION_LISTEN_NAME),
+    ]

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1092,7 +1092,7 @@ async def test_logging_of_end_to_end_action():
         ActionExecuted(ACTION_LISTEN_NAME),
         UserUttered(user_message, intent={"name": "greet"}),
         ActionExecuted(action_text=end_to_end_action),
-        BotUttered("hi, how are you?", {}, {"template_name": end_to_end_action}, 123),
+        BotUttered("hi, how are you?", {}, {}, 123),
         ActionExecuted(ACTION_LISTEN_NAME),
     ]
     for event, expected in zip(tracker.events, expected_events):

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -597,8 +597,8 @@ async def test_write_domain_to_file_with_form(tmp_path: Path):
 
     interactive._write_domain_to_file(domain_path, events, old_domain)
 
-    assert set(Domain.from_path(domain_path).action_names) == set(
-        old_domain.action_names
+    assert set(Domain.from_path(domain_path).action_names_or_texts) == set(
+        old_domain.action_names_or_texts
     )
 
 

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -180,7 +180,7 @@ def test_domain_from_template():
 
     assert not domain.is_empty()
     assert len(domain.intents) == 10 + len(DEFAULT_INTENTS)
-    assert len(domain.action_names) == 15
+    assert len(domain.action_names_or_texts) == 15
 
 
 def test_avoid_action_repetition():
@@ -189,7 +189,9 @@ def test_avoid_action_repetition():
 
     assert not domain.is_empty() and not domain_with_no_actions.is_empty()
     assert len(domain.intents) == len(domain_with_no_actions.intents)
-    assert len(domain.action_names) == len(domain_with_no_actions.action_names)
+    assert len(domain.action_names_or_texts) == len(
+        domain_with_no_actions.action_names_or_texts
+    )
 
 
 def test_utter_templates():
@@ -885,7 +887,7 @@ def test_add_knowledge_base_slots(default_domain: Domain):
     # don't modify default domain as it is used in other tests
     test_domain = copy.deepcopy(default_domain)
 
-    test_domain.action_names.append(DEFAULT_KNOWLEDGE_BASE_ACTION)
+    test_domain.action_names_or_texts.append(DEFAULT_KNOWLEDGE_BASE_ACTION)
 
     slot_names = [s.name for s in test_domain.slots]
 
@@ -1017,7 +1019,7 @@ def test_domain_deepcopy():
     assert new_domain.session_config == domain.session_config
     assert new_domain._custom_actions == domain._custom_actions
     assert new_domain.user_actions == domain.user_actions
-    assert new_domain.action_names == domain.action_names
+    assert new_domain.action_names_or_texts == domain.action_names_or_texts
     assert new_domain.store_entities_as_slots == domain.store_entities_as_slots
 
     # not the same objects
@@ -1035,7 +1037,7 @@ def test_domain_deepcopy():
     assert new_domain.session_config is not domain.session_config
     assert new_domain._custom_actions is not domain._custom_actions
     assert new_domain.user_actions is not domain.user_actions
-    assert new_domain.action_names is not domain.action_names
+    assert new_domain.action_names_or_texts is not domain.action_names_or_texts
 
 
 @pytest.mark.parametrize(

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -359,8 +359,6 @@ responses:
     assert domain.templates == {
         "utter_greet": [{"text": "hey there!"}],
         "utter_goodbye": [{"text": "bye!"}],
-        "Bye": [{"text": "Bye"}],
-        "Hi": [{"text": "Hi"}],
     }
     # lists should be deduplicated and merged
     assert domain.intents == sorted(["greet", *DEFAULT_INTENTS])
@@ -377,8 +375,6 @@ responses:
     assert domain.templates == {
         "utter_greet": [{"text": "hey you!"}],
         "utter_goodbye": [{"text": "bye!"}],
-        "Bye": [{"text": "Bye"}],
-        "Hi": [{"text": "Hi"}],
     }
     assert domain.session_config == SessionConfig(20, True)
     assert domain.action_texts == ["Bye", "Hi"]

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -335,7 +335,10 @@ async def test_adding_e2e_actions_to_domain(default_importer: E2EImporter):
 
     domain = await default_importer.get_domain()
 
-    assert all(action_name in domain.action_names for action_name in additional_actions)
+    assert all(
+        action_name in domain.action_names_or_texts
+        for action_name in additional_actions
+    )
 
 
 async def test_nlu_data_domain_sync_with_retrieval_intents(project: Text):
@@ -362,4 +365,4 @@ async def test_nlu_data_domain_sync_with_retrieval_intents(project: Text):
     assert domain.intent_properties["chitchat"].get("is_retrieval_intent")
     assert domain.retrieval_intent_templates == nlu_data.responses
     assert domain.templates != nlu_data.responses
-    assert "utter_chitchat" in domain.action_names
+    assert "utter_chitchat" in domain.action_names_or_texts

--- a/tests/shared/importers/test_multi_project.py
+++ b/tests/shared/importers/test_multi_project.py
@@ -364,4 +364,4 @@ async def test_multi_project_training(trained_async):
         "utter_goodbye",
     ]
 
-    assert all([a in domain.action_names for a in expected_actions])
+    assert all([a in domain.action_names_or_texts for a in expected_actions])

--- a/tests/shared/importers/test_rasa.py
+++ b/tests/shared/importers/test_rasa.py
@@ -24,7 +24,7 @@ async def test_rasa_file_importer(project: Text):
     assert len(domain.intents) == 7 + len(DEFAULT_INTENTS)
     assert domain.slots == []
     assert domain.entities == []
-    assert len(domain.action_names) == 17
+    assert len(domain.action_names_or_texts) == 17
     assert len(domain.templates) == 6
 
     stories = await importer.get_stories()


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/6410
- deprecate `random_template_for` as it's unused
- rename `Domain.action_names` to `Domain.action_names_or_texts`. Added a property with deprecation message for `Domain.action_names`
- add docstrings
- utter end-to-end bot responses if predicted
- log end-to-end action correctly (`action_text` property is set)
- added method `event_for_successful_execution` to `Action` to encapsulate action event with the action which ran it

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
