### PR TITLE
Fix incorrect attribute for key prefix in RedisTrackerStore

### DIFF
--- a/changelog/7306.bugfix.md
+++ b/changelog/7306.bugfix.md
@@ -1,0 +1,1 @@
+Fix an erroneous attribute for Redis key prefix in `rasa.core.tracker_store.RedisTrackerStore`: 'RedisTrackerStore' object has no attribute 'prefix'.

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -351,6 +351,16 @@ class RedisTrackerStore(TrackerStore):
         )
 
     def retrieve(self, sender_id: Text) -> Optional[DialogueStateTracker]:
+        """Retrieves tracker for the latest conversation session.
+
+        The Redis key is formed by appending a prefix to sender_id.
+
+        Args:
+            sender_id: Conversation ID to fetch the tracker for.
+
+        Returns:
+            Tracker containing events from the latest conversation sessions.
+        """
         stored = self.red.get(self.key_prefix + sender_id)
         if stored is not None:
             return self.deserialise_tracker(sender_id, stored)
@@ -358,7 +368,7 @@ class RedisTrackerStore(TrackerStore):
             return None
 
     def keys(self) -> Iterable[Text]:
-        """Returns keys of the Redis Tracker Store"""
+        """Returns keys of the Redis Tracker Store."""
         return self.red.keys(self.key_prefix + "*")
 
 

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -346,10 +346,12 @@ class RedisTrackerStore(TrackerStore):
             timeout = self.record_exp
 
         serialised_tracker = self.serialise_tracker(tracker)
-        self.red.set(self.prefix + tracker.sender_id, serialised_tracker, ex=timeout)
+        self.red.set(
+            self.key_prefix + tracker.sender_id, serialised_tracker, ex=timeout
+        )
 
     def retrieve(self, sender_id: Text) -> Optional[DialogueStateTracker]:
-        stored = self.red.get(self.prefix + sender_id)
+        stored = self.red.get(self.key_prefix + sender_id)
         if stored is not None:
             return self.deserialise_tracker(sender_id, stored)
         else:
@@ -357,7 +359,7 @@ class RedisTrackerStore(TrackerStore):
 
     def keys(self) -> Iterable[Text]:
         """Returns keys of the Redis Tracker Store"""
-        return self.red.keys(self.prefix + "*")
+        return self.red.keys(self.key_prefix + "*")
 
 
 class DynamoTrackerStore(TrackerStore):

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -77,19 +77,14 @@ domain = Domain.load("examples/moodbot/domain.yml")
 
 
 class MockRedisTrackerStore(RedisTrackerStore):
-    # skipcq:PYL-W0231
-    # can't call call super init since it would init a redis connection
     def __init__(self, _domain: Domain) -> None:
+        super().__init__(_domain)
+
+        # Patch the Redis connection in RedisTrackerStore using fakeredis
         self.red = fakeredis.FakeStrictRedis()
-        self.record_exp = None
 
         # added in redis==3.3.0, but not yet in fakeredis
         self.red.connection_pool.connection_class.health_check_interval = 0
-
-        # Defined in RedisTrackerStore but needs to be added for the MockRedisTrackerStore
-        self.prefix = "tracker:"
-
-        TrackerStore.__init__(self, _domain)
 
 
 def stores_to_be_tested():


### PR DESCRIPTION
Fix #7306

**Proposed changes**:
- Use `self.key_prefix` instead of the erroneous `self.prefix` in `rasa.core.tracker_store.RedisTrackerStore`.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
