### PR TITLE
spaCy 3.0 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ install-mitie:
 
 install-full: install install-mitie
 	poetry install -E full
+	pip uninstall spacy
+	pip install spacy-nightly
 
 install-docs:
 	cd docs/ && yarn install

--- a/poetry.lock
+++ b/poetry.lock
@@ -2605,10 +2605,10 @@ version = "2.3.0"
 [[package]]
 category = "main"
 description = "Industrial-strength Natural Language Processing (NLP) in Python"
-name = "spacy"
+name = "spacy-nightly"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "2.2.4"
+version = "3.0.0rc2"
 
 [package.dependencies]
 blis = ">=0.4.0,<0.5.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2605,7 +2605,7 @@ version = "2.3.0"
 [[package]]
 category = "main"
 description = "Industrial-strength Natural Language Processing (NLP) in Python"
-name = "spacy-nightly"
+name = "spacy"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 version = "3.0.0rc2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2608,7 +2608,7 @@ description = "Industrial-strength Natural Language Processing (NLP) in Python"
 name = "spacy"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.0.0rc2"
+version = "2.2.4"
 
 [package.dependencies]
 blis = ">=0.4.0,<0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ exclude = "((.eggs | .git | .pytest_cache | build | dist))"
 
 [tool.poetry]
 name = "rasa"
-version = "2.1.0"
+version = "2.1.1"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 authors = [ "Rasa Technologies GmbH <hi@rasa.com>",]
 maintainers = [ "Tom Bocklisch <tom@rasa.com>",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ pytest-timeout = "^1.4.2"
 mypy = "^0.790"
 
 [tool.poetry.extras]
-spacy = [ "spacy",]
+spacy = [ "spacy-nightly",]
 jieba = [ "jieba",]
 transformers = [ "transformers",]
 full = [ "spacy", "transformers", "jieba",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ pytest-timeout = "^1.4.2"
 mypy = "^0.790"
 
 [tool.poetry.extras]
-spacy = [ "spacy-nightly",]
+spacy = [ "spacy",]
 jieba = [ "jieba",]
 transformers = [ "transformers",]
 full = [ "spacy", "transformers", "jieba",]

--- a/tests/nlu/tokenizers/test_spacy_tokenizer.py
+++ b/tests/nlu/tokenizers/test_spacy_tokenizer.py
@@ -55,7 +55,8 @@ def test_spacy_pos_tags(text, expected_pos_tags, spacy_nlp):
 
 @pytest.mark.parametrize(
     "text, expected_tokens, expected_indices",
-    [("Forecast for lunch", ["Forecast", "for", "lunch"], [(0, 8), (9, 12), (13, 18)])],
+    [("Forecast for lunch", ["Forecast", "for", "lunch"], [(0, 8), (9, 12), (13, 18)]),
+     ("Forecast for launch", ["Forecast", "for", "launch"], [(0, 8), (9, 12), (13, 19)])],
 )
 def test_train_tokenizer(text, expected_tokens, expected_indices, spacy_nlp):
     tk = SpacyTokenizer()


### PR DESCRIPTION
This is a work in progress PR. The idea is to see what breaks if we switch to the nightly version of spaCy. 

The docs for this version can be found [here](https://nightly.spacy.io/usage/v3) and the pypi can be found [here](https://pypi.org/project/spacy-nightly/#history).

The main reason for adding this is to keep things maintainable but also because there's support for even more languages *and* new transformer-based models. 