### PR TITLE
Fix DynamoDB TrackerStore

### DIFF
--- a/changelog/7340.bugfix.md
+++ b/changelog/7340.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issues with the DynamoDB TrackerStore creating a new table entry/object for each TrackerStore update. The column `session_date` has been deprecated and should be removed manually in existing DynamoDB tables. 

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -357,19 +357,16 @@ class DynamoTrackerStore(TrackerStore):
         if self.table_name not in self.client.list_tables()["TableNames"]:
             table = dynamo.create_table(
                 TableName=self.table_name,
-                KeySchema=[
-                    {"AttributeName": "sender_id", "KeyType": "HASH"},
-                    {"AttributeName": "session_date", "KeyType": "RANGE"},
-                ],
+                KeySchema=[{"AttributeName": "sender_id", "KeyType": "HASH"},],
                 AttributeDefinitions=[
                     {"AttributeName": "sender_id", "AttributeType": "S"},
-                    {"AttributeName": "session_date", "AttributeType": "N"},
                 ],
                 ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
             )
 
             # Wait until the table exists.
             table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
+            table.meta
         return dynamo.Table(table_name)
 
     def save(self, tracker):
@@ -382,10 +379,7 @@ class DynamoTrackerStore(TrackerStore):
         """Serializes the tracker, returns object with decimal types"""
         d = tracker.as_dialogue().as_dict()
         d.update(
-            {
-                "sender_id": tracker.sender_id,
-                "session_date": int(datetime.now(tz=timezone.utc).timestamp()),
-            }
+            {"sender_id": tracker.sender_id,}
         )
         # DynamoDB cannot store `float`s, so we'll convert them to `Decimal`s
         return core_utils.replace_floats_with_decimals(d)

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -359,9 +359,7 @@ class DynamoTrackerStore(TrackerStore):
         if self.table_name not in self.client.list_tables()["TableNames"]:
             table = dynamo.create_table(
                 TableName=self.table_name,
-                KeySchema=[
-                    {"AttributeName": "sender_id", "KeyType": "HASH"},
-                ],
+                KeySchema=[{"AttributeName": "sender_id", "KeyType": "HASH"},],
                 AttributeDefinitions=[
                     {"AttributeName": "sender_id", "AttributeType": "S"},
                 ],
@@ -421,9 +419,7 @@ class DynamoTrackerStore(TrackerStore):
         """Serializes the tracker, returns object with decimal types"""
         d = tracker.as_dialogue().as_dict()
         d.update(
-            {
-                "sender_id": tracker.sender_id,
-            }
+            {"sender_id": tracker.sender_id,}
         )
         # DynamoDB cannot store `float`s, so we'll convert them to `Decimal`s
         return core_utils.replace_floats_with_decimals(d)

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -19,8 +19,9 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from boto.dynamodb2.exceptions import ValidationException
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
 import rasa.core.utils as core_utils
 from rasa.core.actions.action import ACTION_LISTEN_NAME
 from rasa.core.brokers.broker import EventBroker
@@ -376,8 +377,8 @@ class DynamoTrackerStore(TrackerStore):
         serialized = self.serialise_tracker(tracker)
         try:
             self.db.put_item(Item=serialized)
-        except ValidationException as e:
-            if "Missing the key session_date" in e.message:
+        except ClientError as e:
+            if "Missing the key session_date" in str(e):
                 legacy_date = self._retrieve_latest_session_date(tracker.sender_id)
                 if not legacy_date:
                     raise


### PR DESCRIPTION
**Proposed changes**:
- The "old" DynamoDB TrackerStore implementation created one table entry per Tracker update resulting in many objects/rows per user and session. This was caused because of the use of a timestamp (`session_date`) as part of the table's index. This fix drops the index `session_date` and only uses the `sender_id` when creating/updating DB entries. 

- The PR includes a backward compatibility check to continue usage for DynamoDBs tables with the old schema. It also introduces a deprecation warning for these kind of tables.

- Changes we tested together with @tmbo on a private project connecting to DynamoDB.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
