### PR TITLE
Fix tracker init copy method

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -160,7 +160,7 @@ jobs:
 
         # Fetch entire history for current branch so that `make lint-docstrings`
         # can calculate the proper diff between the branches
-        git pull --ff-only --unshallow origin "${{ github.head_ref }}"
+        git fetch --unshallow origin "${{ github.ref }}"
 
     - name: Lint Code 🎎
       if: needs.changes.outputs.backend == 'true'

--- a/changelog/7338.bugfix.md
+++ b/changelog/7338.bugfix.md
@@ -1,0 +1,1 @@
+Sender id is correctly set when copying the tracker and sending it to the action server (instead of sending the `default` value)

--- a/changelog/7338.bugfix.md
+++ b/changelog/7338.bugfix.md
@@ -1,1 +1,1 @@
-Sender id is correctly set when copying the tracker and sending it to the action server (instead of sending the `default` value)
+Sender ID is correctly set when copying the tracker and sending it to the action server (instead of sending the `default` value). This fixes a problem where the action server would only retrieve trackers with a `sender_id` `default`.

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -387,7 +387,7 @@ class DialogueStateTracker:
         """Creates a new state tracker with the same initial values."""
 
         return DialogueStateTracker(
-            DEFAULT_SENDER_ID,
+            self.sender_id or DEFAULT_SENDER_ID,
             self.slots.values(),
             self._max_event_history,
             is_rule_tracker=self.is_rule_tracker,

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -385,7 +385,6 @@ class DialogueStateTracker:
 
     def init_copy(self) -> "DialogueStateTracker":
         """Creates a new state tracker with the same initial values."""
-
         return DialogueStateTracker(
             self.sender_id or DEFAULT_SENDER_ID,
             self.slots.values(),

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -68,10 +68,7 @@ from tests.core.utilities import (
 from rasa.shared.core.training_data.story_writer.markdown_story_writer import (
     MarkdownStoryWriter,
 )
-from rasa.shared.nlu.constants import (
-    ACTION_NAME,
-    PREDICTED_CONFIDENCE_KEY,
-)
+from rasa.shared.nlu.constants import ACTION_NAME, PREDICTED_CONFIDENCE_KEY
 
 domain = Domain.load("examples/moodbot/domain.yml")
 
@@ -501,6 +498,13 @@ def test_traveling_back_in_time(default_domain: Domain):
     assert len(list(tracker.generate_all_prior_trackers())) == 2
 
 
+def test_tracker_init_copy(default_domain: Domain):
+    sender_id = "some-id"
+    tracker = DialogueStateTracker(sender_id, default_domain.slots)
+    tracker_copy = tracker.init_copy()
+    assert tracker.sender_id == tracker_copy.sender_id
+
+
 async def test_dump_and_restore_as_json(default_agent: Agent, tmp_path: Path):
     trackers = await default_agent.load_data(DEFAULT_STORIES_FILE)
 
@@ -612,7 +616,7 @@ def test_session_started_not_part_of_applied_events(default_agent: Agent):
     tracker_dump = "data/test_trackers/tracker_moodbot.json"
     tracker_json = json.loads(rasa.shared.utils.io.read_file(tracker_dump))
     tracker_json["events"].insert(
-        4, {"event": ActionExecuted.type_name, "name": ACTION_SESSION_START_NAME},
+        4, {"event": ActionExecuted.type_name, "name": ACTION_SESSION_START_NAME}
     )
     tracker_json["events"].insert(5, {"event": SessionStarted.type_name})
 
@@ -1153,8 +1157,8 @@ def test_reading_of_trackers_with_legacy_form_validation_events():
     tracker = DialogueStateTracker.from_dict(
         "sender",
         events_as_dict=[
-            {"event": LegacyFormValidation.type_name, "name": None, "validate": True,},
-            {"event": LegacyFormValidation.type_name, "name": None, "validate": False,},
+            {"event": LegacyFormValidation.type_name, "name": None, "validate": True},
+            {"event": LegacyFormValidation.type_name, "name": None, "validate": False},
         ],
     )
 


### PR DESCRIPTION
**Proposed changes**:
- The `init_copy` function of `DialogStateTracker` now uses the `sender_id` of the tracker to be copied
- Fixes #7338 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
