### PR TITLE
Chunk TrainingData into smaller chunks

### DIFF
--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Tuple, Text, Dict, Set, List
 
 import typing
 import copy
-import sys
 
 import rasa.shared.utils.io
 from rasa.shared.exceptions import RasaException

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Tuple, Text, Dict, Set, List
 
 import typing
 import copy
+import sys
 
 import rasa.shared.utils.io
 from rasa.shared.exceptions import RasaException
@@ -50,6 +51,22 @@ class Message:
     def add_features(self, features: Optional["Features"]) -> None:
         if features is not None:
             self.features.append(features)
+
+    def __sizeof__(self) -> int:
+        """Determine size of the object by going over instance attributes"""
+
+        total_size = 0
+        if self.time:
+            total_size += sys.getsizeof(self.time)
+        print(total_size)
+        if self.data:
+            total_size += sys.getsizeof(self.data)
+        print(total_size)
+        if self.features:
+            total_size += sys.getsizeof(self.features)
+        print(total_size)
+
+        return total_size
 
     def set(self, prop, info, add_to_output=False) -> None:
         self.data[prop] = info

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -52,22 +52,6 @@ class Message:
         if features is not None:
             self.features.append(features)
 
-    def __sizeof__(self) -> int:
-        """Determine size of the object by going over instance attributes"""
-
-        total_size = 0
-        if self.time:
-            total_size += sys.getsizeof(self.time)
-        print(total_size)
-        if self.data:
-            total_size += sys.getsizeof(self.data)
-        print(total_size)
-        if self.features:
-            total_size += sys.getsizeof(self.features)
-        print(total_size)
-
-        return total_size
-
     def set(self, prop, info, add_to_output=False) -> None:
         self.data[prop] = info
         if add_to_output:

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -745,7 +745,6 @@ class TrainingDataChunk(TrainingData):
         responses: Optional[Dict[Text, List[Dict[Text, Any]]]] = None,
     ) -> None:
         """Initialize a training data chunk."""
-
         if entity_synonyms or regex_features or lookup_tables:
             raise RasaException(
                 f"{self.__class__} cannot have entity synonyms, "

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -744,6 +744,7 @@ class TrainingDataChunk(TrainingData):
         lookup_tables: Optional[List[Dict[Text, Any]]] = None,
         responses: Optional[Dict[Text, List[Dict[Text, Any]]]] = None,
     ) -> None:
+        """Initialize a training data chunk."""
 
         if entity_synonyms or regex_features or lookup_tables:
             raise RasaException(

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -678,8 +678,6 @@ class TrainingData:
         ]
         return not any([len(lst) > 0 for lst in lists_to_check])
 
-    # def _sizeof__(self):
-
     def divide_into_chunks(self, num_chunks: int) -> List["TrainingDataChunk"]:
         """Divides the training data into smaller chunks.
 

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -26,7 +26,7 @@ from rasa.shared.nlu.constants import (
 )
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data import util
-
+import sys
 
 DEFAULT_TRAINING_DATA_OUTPUT_PATH = "training_data.yml"
 
@@ -60,6 +60,13 @@ class TrainingData:
         self.responses = responses or {}
 
         self._fill_response_phrases()
+
+    def __sizeof__(self) -> int:
+        total_size = 0
+        if self.training_examples:
+            for message in self.training_examples:
+                total_size += sys.getsizeof(message)
+        return total_size
 
     def fingerprint(self) -> Text:
         """Fingerprint the training data.
@@ -679,7 +686,9 @@ class TrainingData:
         ]
         return not any([len(lst) > 0 for lst in lists_to_check])
 
-    def divide_into_chunks(self, max_size: int = 2) -> List["TrainingDataChunk"]:
+    # def _sizeof__(self):
+
+    def divide_into_chunks(self, num_chunks: int = 2) -> List["TrainingDataChunk"]:
         """Divides the training data into smaller chunks.
 
         Each chunk should be a good representation of the complete dataset. E.g. it
@@ -692,6 +701,7 @@ class TrainingData:
         Returns:
             A list of all training data chunks.
         """
+
         pass
 
 

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -26,7 +26,6 @@ from rasa.shared.nlu.constants import (
 )
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data import util
-import sys
 
 DEFAULT_TRAINING_DATA_OUTPUT_PATH = "training_data.yml"
 


### PR DESCRIPTION
**Proposed changes**:
- Closes https://github.com/RasaHQ/rasa/issues/7273
- Instead of chunk memory, the method receives number of chunks to be returned. Computing the total memory of a complex object like `TrainingData` is [tricky](https://stackoverflow.com/questions/449560/how-do-i-determine-the-size-of-an-object-in-python).
- Make `TrainingDataChunk` a sub-class of `TrainingData`

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
