### PR TITLE
Add TED link for Youtube.

### DIFF
--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -81,7 +81,8 @@ Doing so can lead to unexpected and undesired bot behavior.
 ### TED Policy
 
 The Transformer Embedding Dialogue (TED) Policy is described in
-[our paper](https://arxiv.org/abs/1910.00486).
+[our paper](https://arxiv.org/abs/1910.00486) and on our
+[youtube channel](https://www.youtube.com/watch?v=j90NvurJI4I&list=PL75e0qA87dlG-za8eLI6t0_Pbxafk-cxb&index=14&ab_channel=Rasa).
 
 This policy has a pre-defined architecture, which comprises the
 following steps:


### PR DESCRIPTION
I've noticed that our DIET section links to the algorithm whiteboard while the TED section does not. Figured I'd add a link. 