### PR TITLE
Minor Language Tweak for Memoization Policy

### DIFF
--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -291,9 +291,9 @@ for details.
 ### Memoization Policy
 
 The `MemoizationPolicy` remembers the stories from your
-training data. It checks if the current conversation matches a story
-in the training data. If so, it will predict the next action from the matching
-story of your training data with a confidence of `1.0`. If no matching conversation
+training data. It checks if the current conversation matches the stories in your
+`stories.yml` file. If so, it will predict the next action from the matching
+stories of your training data with a confidence of `1.0`. If no matching conversation
 is found, the policy predicts `None` with confidence `0.0`.
 
 When looking for a match in your training data, the policy will take the last


### PR DESCRIPTION
There's a slight mis-interpretation possible when reading the docs on the `MemoizationPolicy`. 

## Before 

> It checks if the current conversation matches a story in the training data. If so, it will predict the next action from the matching story of your training data with a confidence of 1.0

## After 

> It checks if the current conversation matches the stories in your training data. If so, it will predict the next action from the matching story of your training data with a confidence of 1.0

## Why? 

The idea is that "matches a story in the training data" suggests that we only are matching if there is *any* story that matches. We also expect the stories to be consistent. This prompted a question in me so I figured this small change would be good. I discussed the change with @Ghostvv and @JEM-Mosig on slack. 