### PR TITLE
Slack init message

### DIFF
--- a/changelog/7366.feature.md
+++ b/changelog/7366.feature.md
@@ -1,0 +1,2 @@
+Allow to reaction of rasa chatbot to slack opening / switching window of conversation. This allows the chatbot to provide 
+a "welcome message" to the user.

--- a/docs/docs/connectors/slack.mdx
+++ b/docs/docs/connectors/slack.mdx
@@ -143,7 +143,6 @@ your bot and tell you about new messages. If you are running locally, you can
    time).
 
 
-
 Your bot is now ready to go and will receive webhook notifications about new messages.
 ## Optional: Interactive Components
 After you've completed [Sending Messages](./slack.mdx#sending-messages) and

--- a/docs/docs/connectors/slack.mdx
+++ b/docs/docs/connectors/slack.mdx
@@ -136,6 +136,13 @@ your bot and tell you about new messages. If you are running locally, you can
    sending of messages, you'll be prompted to **reinstall your app** which you will
    need to do. Otherwise, Slack will confirm your change with a **Success!**)
 
+## Optional: Initial message
+   If you want to have the bot greet message appear every time when user opens its chat (e.g. for the first time) you want
+   to send some subscribe to `app_home_opened` event. This will automatically redirect to expected `init` intent in your 
+   domain.
+
+
+
 Your bot is now ready to go and will receive webhook notifications about new messages.
 ## Optional: Interactive Components
 After you've completed [Sending Messages](./slack.mdx#sending-messages) and

--- a/docs/docs/connectors/slack.mdx
+++ b/docs/docs/connectors/slack.mdx
@@ -139,7 +139,8 @@ your bot and tell you about new messages. If you are running locally, you can
 ## Optional: Initial message
    If you want to have the bot greet message appear every time when user opens its chat (e.g. for the first time) you want
    to send some subscribe to `app_home_opened` event. This will automatically redirect to expected `init` intent in your 
-   domain.
+   domain (it might be smart to handle if a user has already encountered a chatbot and not react to this event every single
+   time).
 
 
 

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -570,6 +570,7 @@ class SlackInput(InputChannel):
             self._is_direct_message(slack_event)
             or self._is_app_mention(slack_event)
             or metadata["out_channel"] == self.slack_channel
+            
             or self._is_init_message(slack_event)
         )
 

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -228,14 +228,14 @@ class SlackInput(InputChannel):
     @staticmethod
     def _is_user_message(slack_event: Dict[Text, Any]) -> bool:
         return (
-            slack_event.get("event") is not None
+            (slack_event.get("event") is not None
             and (
                 slack_event.get("event", {}).get("type") == "message"
                 or slack_event.get("event", {}).get("type") == "app_mention"
-                or SlackInput._is_init_message(slack_event)
             )
             and slack_event.get("event", {}).get("text")
-            and not slack_event.get("event", {}).get("bot_id")
+            and not slack_event.get("event", {}).get("bot_id"))
+            or SlackInput._is_init_message(slack_event)
         )
     @staticmethod
     def _is_init_message(slack_event: Dict[Text, Any]) -> bool:
@@ -570,6 +570,7 @@ class SlackInput(InputChannel):
             self._is_direct_message(slack_event)
             or self._is_app_mention(slack_event)
             or metadata["out_channel"] == self.slack_channel
+            or self._is_init_message(slack_event)
         )
 
     def get_output_channel(

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -228,21 +228,22 @@ class SlackInput(InputChannel):
     @staticmethod
     def _is_user_message(slack_event: Dict[Text, Any]) -> bool:
         return (
-            (slack_event.get("event") is not None
+            slack_event.get("event") is not None
             and (
                 slack_event.get("event", {}).get("type") == "message"
                 or slack_event.get("event", {}).get("type") == "app_mention"
             )
             and slack_event.get("event", {}).get("text")
-            and not slack_event.get("event", {}).get("bot_id"))
-            or SlackInput._is_init_message(slack_event)
-        )
+            and not slack_event.get("event", {}).get("bot_id")
+        ) or SlackInput._is_init_message(slack_event)
+
     @staticmethod
     def _is_init_message(slack_event: Dict[Text, Any]) -> bool:
         return (
             slack_event.get("event") is not None
             and slack_event.get("event", {}).get("type") == "app_home_opened"
         )
+
     @staticmethod
     def _sanitize_user_message(
         text: Text, uids_to_remove: Optional[List[Text]]
@@ -523,9 +524,7 @@ class SlackInput(InputChannel):
                     )
                     return response.text("Bot message delivered.")
                 if self._is_init_message(output):
-                    logger.debug(
-                        "Init message recieved - sending to /init intent"
-                    )
+                    logger.debug("Init message recieved - sending to /init intent")
                     user_message = "/init"
                 if not self._is_supported_channel(output, metadata):
                     logger.warning(
@@ -570,7 +569,6 @@ class SlackInput(InputChannel):
             self._is_direct_message(slack_event)
             or self._is_app_mention(slack_event)
             or metadata["out_channel"] == self.slack_channel
-            
             or self._is_init_message(slack_event)
         )
 


### PR DESCRIPTION
**Proposed changes**:
- Allow slack channel to support welcome message pattern by forwarding to _init_ intent automatically when a user interaction with chatbot starts

**Status (please check what you already did)**:
- [] added some tests for the functionality
- [✅] updated the documentation
- [✅ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [✅] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
