### PR TITLE
E2e story printing

### DIFF
--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -312,6 +312,7 @@ class WronglyClassifiedUserUtterance(UserUttered):
         return f"predicted: {self.predicted_intent}: {predicted_message}"
 
     def as_story_string(self, e2e: bool = True) -> Text:
+        """Returns text representation of event."""
         from rasa.shared.core.events import format_message
 
         correct_message = format_message(

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -304,17 +304,17 @@ class WronglyClassifiedUserUtterance(UserUttered):
 
     def inline_comment(self) -> Text:
         """A comment attached to this event. Used during dumping."""
-        from rasa.shared.core.events import md_format_message
+        from rasa.shared.core.events import format_message
 
-        predicted_message = md_format_message(
+        predicted_message = format_message(
             self.text, self.predicted_intent, self.predicted_entities
         )
         return f"predicted: {self.predicted_intent}: {predicted_message}"
 
     def as_story_string(self, e2e: bool = True) -> Text:
-        from rasa.shared.core.events import md_format_message
+        from rasa.shared.core.events import format_message
 
-        correct_message = md_format_message(
+        correct_message = format_message(
             self.text, self.intent.get("name"), self.entities
         )
         return (

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -534,7 +534,7 @@ def _chat_history_table(events: List[Dict[Text, Any]]) -> Text:
 
     for idx, event in enumerate(applied_events):
         if isinstance(event, ActionExecuted):
-            bot_column.append(colored(event.action_name, "autocyan"))
+            bot_column.append(colored(str(event), "autocyan"))
             if event.confidence is not None:
                 bot_column[-1] += colored(f" {event.confidence:03.2f}", "autowhite")
 

--- a/rasa/core/training/story_conflict.py
+++ b/rasa/core/training/story_conflict.py
@@ -196,6 +196,7 @@ def _find_conflicting_states(
     # represented by its hash
     state_action_mapping = defaultdict(list)
     for element in _sliced_states_iterator(trackers, domain, max_history):
+        # TODO: Hash or just store as dict
         hashed_state = element.sliced_states_hash
         if element.event.as_story_string() not in state_action_mapping[hashed_state]:
             state_action_mapping[hashed_state] += [element.event.as_story_string()]

--- a/rasa/core/training/story_conflict.py
+++ b/rasa/core/training/story_conflict.py
@@ -196,10 +196,10 @@ def _find_conflicting_states(
     # represented by its hash
     state_action_mapping = defaultdict(list)
     for element in _sliced_states_iterator(trackers, domain, max_history):
-        # TODO: Hash or just store as dict
         hashed_state = element.sliced_states_hash
-        if element.event.as_story_string() not in state_action_mapping[hashed_state]:
-            state_action_mapping[hashed_state] += [element.event.as_story_string()]
+        current_hash = hash(element.event)
+        if current_hash not in state_action_mapping[hashed_state]:
+            state_action_mapping[hashed_state] += [current_hash]
 
     # Keep only conflicting `state_action_mapping`s
     return {
@@ -239,8 +239,7 @@ def _build_conflicts_from_states(
                 conflicts[hashed_state] = StoryConflict(element.sliced_states)
 
             conflicts[hashed_state].add_conflicting_action(
-                action=element.event.as_story_string(),
-                story_name=element.tracker.sender_id,
+                action=str(element.event), story_name=element.tracker.sender_id,
             )
 
     # Return list of conflicts that arise from unpredictable actions

--- a/rasa/exceptions.py
+++ b/rasa/exceptions.py
@@ -37,7 +37,3 @@ class PublishingError(RasaException):
     def __str__(self) -> Text:
         """Returns string representation of exception."""
         return str(self.timestamp)
-
-
-class UnsupportedFeatureException(RasaException):
-    """Raised if a certain feature is not supported."""

--- a/rasa/exceptions.py
+++ b/rasa/exceptions.py
@@ -35,4 +35,9 @@ class PublishingError(RasaException):
         super(PublishingError, self).__init__()
 
     def __str__(self) -> Text:
+        """Returns string representation of exception."""
         return str(self.timestamp)
+
+
+class UnsupportedFeatureException(RasaException):
+    """Raised if a certain feature is not supported."""

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -410,7 +410,7 @@ class UserUttered(Event):
 
     def __hash__(self) -> int:
         """Returns unique hash of object."""
-        return hash((self.text, self.intent_name, jsonpickle.encode(self.entities)))
+        return hash(json.dumps(self.as_sub_state()))
 
     @property
     def intent_name(self) -> Optional[Text]:

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -434,9 +434,19 @@ class UserUttered(Event):
 
     def __str__(self) -> Text:
         """Returns text representation of event."""
+        entities = ""
+        if self.entities:
+            entities = [
+                f"{entity[ENTITY_ATTRIBUTE_VALUE]} "
+                f"(Type: {entity[ENTITY_ATTRIBUTE_TYPE]}, "
+                f"Role: {entity.get(ENTITY_ATTRIBUTE_ROLE)}, "
+                f"Group: {entity.get(ENTITY_ATTRIBUTE_GROUP)}"
+                for entity in self.entities
+            ]
+            entities = f", entities: {', '.join(entities)}"
+
         return (
-            f"UserUttered(text: {self.text}, intent: {self.intent}, "
-            f"entities: {self.entities})"
+            f"UserUttered(text: {self.text}, intent: {self.intent_name}" f"{entities}))"
         )
 
     @staticmethod
@@ -513,7 +523,7 @@ class UserUttered(Event):
         except KeyError as e:
             raise ValueError(f"Failed to parse bot uttered event. {e}")
 
-    def _entity_string(self):
+    def _entity_string(self) -> Text:
         if self.entities:
             return json.dumps(
                 {

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -515,6 +515,7 @@ class UserUttered(Event):
         return f"{self.intent_name or ''}{self._entity_string()}"
 
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
+        """Applies event to tracker. See docstring of `Event`."""
         tracker.latest_message = self
         tracker.clear_followup_action()
 
@@ -1220,10 +1221,15 @@ class ActionExecuted(Event):
 
         super().__init__(timestamp, metadata)
 
-    def __str__(self) -> Text:
+    def __repr__(self) -> Text:
+        """Returns event as string for debugging."""
         return "ActionExecuted(action: {}, policy: {}, confidence: {})".format(
             self.action_name, self.policy, self.confidence
         )
+
+    def __str__(self) -> Text:
+        """Returns event as human readable string."""
+        return self.action_name or self.action_text
 
     def __hash__(self) -> int:
         """Returns unique hash for action event."""
@@ -1241,6 +1247,7 @@ class ActionExecuted(Event):
             return equal
 
     def as_story_string(self) -> Text:
+        """Returns event in Markdown format."""
         if self.action_text:
             raise UnsupportedFeatureException(
                 "Printing end-to-end bot utterances is not supported in the "

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -433,6 +433,7 @@ class UserUttered(Event):
         )
 
     def __str__(self) -> Text:
+        """Returns text representation of event."""
         return (
             f"UserUttered(text: {self.text}, intent: {self.intent}, "
             f"entities: {self.entities})"
@@ -653,29 +654,34 @@ class BotUttered(Event):
         )
 
     def __hash__(self) -> int:
+        """Returns unique hash for event."""
         return hash(self.__members())
 
     def __eq__(self, other) -> bool:
+        """Compares object with other object."""
         if not isinstance(other, BotUttered):
             return NotImplemented
 
         return self.__members() == other.__members()
 
     def __str__(self) -> Text:
+        """Returns text representation of event."""
         return "BotUttered(text: {}, data: {}, metadata: {})".format(
             self.text, json.dumps(self.data), json.dumps(self.metadata)
         )
 
     def __repr__(self) -> Text:
+        """Returns text representation of event for debugging."""
         return "BotUttered('{}', {}, {}, {})".format(
             self.text, json.dumps(self.data), json.dumps(self.metadata), self.timestamp
         )
 
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
-
+        """Applies event to current conversation state."""
         tracker.latest_bot_utterance = self
 
     def as_story_string(self) -> None:
+        """Skips representing the event in stories."""
         return None
 
     def message(self) -> Dict[Text, Any]:
@@ -697,6 +703,7 @@ class BotUttered(Event):
 
     @staticmethod
     def empty() -> "BotUttered":
+        """Creates an empty bot utterance."""
         return BotUttered()
 
     def as_dict(self) -> Dict[Text, Any]:
@@ -766,6 +773,7 @@ class SlotSet(Event):
         return (self.key, self.value) == (other.key, other.value)
 
     def as_story_string(self) -> Text:
+        """Returns text representation of event."""
         props = json.dumps({self.key: self.value}, ensure_ascii=False)
         return f"{self.type_name}{props}"
 
@@ -929,13 +937,15 @@ class ReminderScheduled(Event):
             )
         )
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
+        """Compares object with other object."""
         if not isinstance(other, ReminderScheduled):
             return NotImplemented
 
         return self.name == other.name
 
     def __str__(self) -> Text:
+        """Returns text representation of event."""
         return (
             f"ReminderScheduled(intent: {self.intent}, trigger_date: {self.trigger_date_time}, "
             f"entities: {self.entities}, name: {self.name})"
@@ -1018,15 +1028,18 @@ class ReminderCancelled(Event):
         super().__init__(timestamp, metadata)
 
     def __hash__(self) -> int:
+        """Returns unique hash for event."""
         return hash((self.name, self.intent, str(self.entities)))
 
     def __eq__(self, other: Any) -> bool:
+        """Compares object with other object."""
         if not isinstance(other, ReminderCancelled):
             return NotImplemented
 
         return hash(self) == hash(other)
 
     def __str__(self) -> Text:
+        """Returns text representation of event."""
         return f"ReminderCancelled(name: {self.name}, intent: {self.intent}, entities: {self.entities})"
 
     def cancels_job_with_name(self, job_name: Text, sender_id: Text) -> bool:
@@ -1558,6 +1571,17 @@ class LoopInterrupted(Event):
         timestamp: Optional[float] = None,
         metadata: Optional[Dict[Text, Any]] = None,
     ) -> None:
+        """Event to notify that loop was interrupted.
+
+        This e.g. happens when a user is within a form, and is de-railing the
+        form-filling by asking FAQs.
+
+        Args:
+            is_interrupted: `True` if the loop execution was interrupted, and ML
+                policies had to take over the last prediction.
+            timestamp: When the event was created.
+            metadata: Additional event metadata.
+        """
         super().__init__(timestamp, metadata)
         self.is_interrupted = is_interrupted
 
@@ -1638,7 +1662,7 @@ class LegacyFormValidation(LoopInterrupted):
 
 
 class ActionExecutionRejected(Event):
-    """Notify Core that the execution of the action has been rejected"""
+    """Notify Core that the execution of the action has been rejected."""
 
     type_name = "action_execution_rejected"
 
@@ -1710,6 +1734,7 @@ class ActionExecutionRejected(Event):
         return d
 
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
+        """Applies event to current conversation state."""
         tracker.reject_action(self.action_name)
 
 

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -504,15 +504,15 @@ class UserUttered(Event):
                 "Markdown training format. Please use the YAML training data instead."
             )
 
+        if self.intent_name:
+            return f"{self.intent_name or ''}{self._entity_string()}"
+
         text_with_entities = md_format_message(
             self.text or "", self.intent_name, self.entities
         )
         if e2e:
             intent_prefix = f"{self.intent_name}: " if self.intent_name else ""
             return f"{intent_prefix}{text_with_entities}"
-
-        if self.intent_name:
-            return f"{self.intent_name or ''}{self._entity_string()}"
 
         if self.text:
             return text_with_entities

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -12,6 +12,7 @@ from typing import List, Dict, Text, Any, Type, Optional, TYPE_CHECKING, Iterabl
 import rasa.shared.utils.common
 from typing import Union
 
+from rasa.shared.constants import DOCS_URL_TRAINING_DATA
 from rasa.shared.core.constants import (
     LOOP_NAME,
     EXTERNAL_MESSAGE_PREFIX,
@@ -500,8 +501,9 @@ class UserUttered(Event):
         """
         if self.use_text_for_featurization and not e2e:
             raise UnsupportedFeatureException(
-                "Printing end-to-end user utterances is not supported in the "
-                "Markdown training format. Please use the YAML training data instead."
+                f"Printing end-to-end user utterances is not supported in the "
+                f"Markdown training format. Please use the YAML training data format "
+                f"instead. Please see {DOCS_URL_TRAINING_DATA} for more information."
             )
 
         if e2e:
@@ -1250,8 +1252,9 @@ class ActionExecuted(Event):
         """Returns event in Markdown format."""
         if self.action_text:
             raise UnsupportedFeatureException(
-                "Printing end-to-end bot utterances is not supported in the "
-                "Markdown training format. Please use the YAML training data instead."
+                f"Printing end-to-end bot utterances is not supported in the "
+                f"Markdown training format. Please use the YAML training data format "
+                f"instead. Please see {DOCS_URL_TRAINING_DATA} for more information."
             )
 
         return self.action_name

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -306,6 +306,12 @@ class Event:
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
         pass
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        return True
+
 
 # noinspection PyProtectedMember
 class UserUttered(Event):
@@ -386,17 +392,17 @@ class UserUttered(Event):
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, UserUttered):
-            return False
-        else:
-            return (
-                self.text,
-                self.intent_name,
-                [jsonpickle.encode(ent) for ent in self.entities],
-            ) == (
-                other.text,
-                other.intent_name,
-                [jsonpickle.encode(ent) for ent in other.entities],
-            )
+            return NotImplemented
+
+        return (
+            self.text,
+            self.intent_name,
+            [jsonpickle.encode(ent) for ent in self.entities],
+        ) == (
+            other.text,
+            other.intent_name,
+            [jsonpickle.encode(ent) for ent in other.entities],
+        )
 
     def __str__(self) -> Text:
         return (
@@ -556,9 +562,6 @@ class DefinePrevUserUtteredFeaturization(Event):
     def __hash__(self) -> int:
         return hash(self.use_text_for_featurization)
 
-    def __eq__(self, other) -> bool:
-        return isinstance(other, DefinePrevUserUtteredFeaturization)
-
     def as_story_string(self) -> None:
         return None
 
@@ -605,9 +608,9 @@ class BotUttered(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, BotUttered):
-            return False
-        else:
-            return self.__members() == other.__members()
+            return NotImplemented
+
+        return self.__members() == other.__members()
 
     def __str__(self) -> Text:
         return "BotUttered(text: {}, data: {}, metadata: {})".format(
@@ -696,9 +699,9 @@ class SlotSet(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, SlotSet):
-            return False
-        else:
-            return (self.key, self.value) == (other.key, other.value)
+            return NotImplemented
+
+        return (self.key, self.value) == (other.key, other.value)
 
     def as_story_string(self) -> Text:
         props = json.dumps({self.key: self.value}, ensure_ascii=False)
@@ -750,9 +753,6 @@ class Restarted(Event):
     def __hash__(self) -> int:
         return hash(32143124312)
 
-    def __eq__(self, other) -> bool:
-        return isinstance(other, Restarted)
-
     def __str__(self) -> Text:
         return "Restarted()"
 
@@ -778,9 +778,6 @@ class UserUtteranceReverted(Event):
     def __hash__(self) -> int:
         return hash(32143124315)
 
-    def __eq__(self, other) -> bool:
-        return isinstance(other, UserUtteranceReverted)
-
     def __str__(self) -> Text:
         return "UserUtteranceReverted()"
 
@@ -804,9 +801,6 @@ class AllSlotsReset(Event):
 
     def __hash__(self) -> int:
         return hash(32143124316)
-
-    def __eq__(self, other) -> bool:
-        return isinstance(other, AllSlotsReset)
 
     def __str__(self) -> Text:
         return "AllSlotsReset()"
@@ -870,9 +864,9 @@ class ReminderScheduled(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, ReminderScheduled):
-            return False
-        else:
-            return self.name == other.name
+            return NotImplemented
+
+        return self.name == other.name
 
     def __str__(self) -> Text:
         return (
@@ -960,9 +954,9 @@ class ReminderCancelled(Event):
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ReminderCancelled):
-            return False
-        else:
-            return hash(self) == hash(other)
+            return NotImplemented
+
+        return hash(self) == hash(other)
 
     def __str__(self) -> Text:
         return f"ReminderCancelled(name: {self.name}, intent: {self.intent}, entities: {self.entities})"
@@ -1039,9 +1033,6 @@ class ActionReverted(Event):
     def __hash__(self) -> int:
         return hash(32143124318)
 
-    def __eq__(self, other) -> bool:
-        return isinstance(other, ActionReverted)
-
     def __str__(self) -> Text:
         return "ActionReverted()"
 
@@ -1070,9 +1061,6 @@ class StoryExported(Event):
 
     def __hash__(self) -> int:
         return hash(32143124319)
-
-    def __eq__(self, other) -> bool:
-        return isinstance(other, StoryExported)
 
     def __str__(self) -> Text:
         return "StoryExported()"
@@ -1115,9 +1103,9 @@ class FollowupAction(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, FollowupAction):
-            return False
-        else:
-            return self.action_name == other.action_name
+            return NotImplemented
+
+        return self.action_name == other.action_name
 
     def __str__(self) -> Text:
         return f"FollowupAction(action: {self.action_name})"
@@ -1158,9 +1146,6 @@ class ConversationPaused(Event):
     def __hash__(self) -> int:
         return hash(32143124313)
 
-    def __eq__(self, other) -> bool:
-        return isinstance(other, ConversationPaused)
-
     def __str__(self) -> Text:
         return "ConversationPaused()"
 
@@ -1182,9 +1167,6 @@ class ConversationResumed(Event):
 
     def __hash__(self) -> int:
         return hash(32143124314)
-
-    def __eq__(self, other) -> bool:
-        return isinstance(other, ConversationResumed)
 
     def __str__(self) -> Text:
         return "ConversationResumed()"
@@ -1240,13 +1222,13 @@ class ActionExecuted(Event):
     def __eq__(self, other: Any) -> bool:
         """Checks if object is equal to another."""
         if not isinstance(other, ActionExecuted):
-            return False
-        else:
-            equal = self.action_name == other.action_name
-            if hasattr(self, "action_text") and hasattr(other, "action_text"):
-                equal = equal and self.action_text == other.action_text
+            return NotImplemented
 
-            return equal
+        equal = self.action_name == other.action_name
+        if hasattr(self, "action_text") and hasattr(other, "action_text"):
+            equal = equal and self.action_text == other.action_text
+
+        return equal
 
     def as_story_string(self) -> Text:
         """Returns event in Markdown format."""
@@ -1332,12 +1314,12 @@ class AgentUttered(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, AgentUttered):
-            return False
-        else:
-            return (self.text, jsonpickle.encode(self.data)) == (
-                other.text,
-                jsonpickle.encode(other.data),
-            )
+            return NotImplemented
+
+        return (self.text, jsonpickle.encode(self.data)) == (
+            other.text,
+            jsonpickle.encode(other.data),
+        )
 
     def __str__(self) -> Text:
         return "AgentUttered(text: {}, data: {})".format(
@@ -1395,9 +1377,9 @@ class ActiveLoop(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, ActiveLoop):
-            return False
-        else:
-            return self.name == other.name
+            return NotImplemented
+
+        return self.name == other.name
 
     def as_story_string(self) -> Text:
         props = json.dumps({LOOP_NAME: self.name})
@@ -1462,10 +1444,10 @@ class LoopInterrupted(Event):
         return hash(self.is_interrupted)
 
     def __eq__(self, other) -> bool:
-        return (
-            isinstance(other, LoopInterrupted)
-            and self.is_interrupted == other.is_interrupted
-        )
+        if not isinstance(other, LoopInterrupted):
+            return NotImplemented
+
+        return self.is_interrupted == other.is_interrupted
 
     def as_story_string(self) -> None:
         return None
@@ -1553,9 +1535,9 @@ class ActionExecutionRejected(Event):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, ActionExecutionRejected):
-            return False
-        else:
-            return self.action_name == other.action_name
+            return NotImplemented
+
+        return self.action_name == other.action_name
 
     @classmethod
     def _from_parameters(cls, parameters) -> "ActionExecutionRejected":
@@ -1592,9 +1574,6 @@ class SessionStarted(Event):
 
     def __hash__(self) -> int:
         return hash(32143124320)
-
-    def __eq__(self, other: Any) -> bool:
-        return isinstance(other, SessionStarted)
 
     def __str__(self) -> Text:
         return "SessionStarted()"

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -73,7 +73,7 @@ def deserialise_entities(entities: Union[Text, List[Any]]) -> List[Dict[Text, An
     return [e for e in entities if isinstance(e, dict)]
 
 
-def md_format_message(
+def format_message(
     text: Text, intent: Optional[Text], entities: Union[Text, List[Any]]
 ) -> Text:
     """Uses NLU parser information to generate a message with inline entity annotations.
@@ -513,7 +513,7 @@ class UserUttered(Event):
             )
 
         if e2e:
-            text_with_entities = md_format_message(
+            text_with_entities = format_message(
                 self.text or "", self.intent_name, self.entities
             )
 

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -498,27 +498,21 @@ class UserUttered(Event):
         Returns:
             Event as string.
         """
-        if self.use_text_for_featurization:
+        if self.use_text_for_featurization and not e2e:
             raise UnsupportedFeatureException(
                 "Printing end-to-end user utterances is not supported in the "
                 "Markdown training format. Please use the YAML training data instead."
             )
 
-        if self.intent_name:
-            return f"{self.intent_name or ''}{self._entity_string()}"
-
-        text_with_entities = md_format_message(
-            self.text or "", self.intent_name, self.entities
-        )
         if e2e:
+            text_with_entities = md_format_message(
+                self.text or "", self.intent_name, self.entities
+            )
+
             intent_prefix = f"{self.intent_name}: " if self.intent_name else ""
             return f"{intent_prefix}{text_with_entities}"
 
-        if self.text:
-            return text_with_entities
-
-        # UserUttered is empty
-        return ""
+        return f"{self.intent_name or ''}{self._entity_string()}"
 
     def apply_to(self, tracker: "DialogueStateTracker") -> None:
         tracker.latest_message = self

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -12,7 +12,6 @@ from typing import List, Dict, Text, Any, Type, Optional, TYPE_CHECKING, Iterabl
 import rasa.shared.utils.common
 from typing import Union
 
-from rasa.exceptions import UnsupportedFeatureException
 from rasa.shared.core.constants import (
     LOOP_NAME,
     EXTERNAL_MESSAGE_PREFIX,
@@ -23,6 +22,7 @@ from rasa.shared.core.constants import (
     ENTITY_LABEL_SEPARATOR,
     ACTION_SESSION_START_NAME,
 )
+from rasa.shared.exceptions import UnsupportedFeatureException
 from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_TYPE,
     INTENT,

--- a/rasa/shared/core/training_data/story_reader/markdown_story_reader.py
+++ b/rasa/shared/core/training_data/story_reader/markdown_story_reader.py
@@ -203,8 +203,9 @@ class MarkdownStoryReader(StoryReader):
             parsed_messages.append(parsed)
         self.current_step_builder.add_user_messages(parsed_messages)
 
-    @staticmethod
-    def parse_e2e_message(line: Text, is_used_for_training: bool = True) -> Message:
+    def parse_e2e_message(
+        self, line: Text, is_used_for_training: bool = True
+    ) -> Message:
         """Parses an md list item line based on the current section type.
 
         Matches expressions of the form `<intent>:<example>`. For the
@@ -231,7 +232,7 @@ class MarkdownStoryReader(StoryReader):
         intent = match.group(2)
         message = match.group(4)
         example = entities_parser.parse_training_example(message, intent)
-        if not is_used_for_training:
+        if not is_used_for_training and not self.use_e2e:
             # In case this is a simple conversion from Markdown we should copy over
             # the original text and not parse the entities
             example.data[rasa.shared.nlu.constants.TEXT] = message

--- a/rasa/shared/core/training_data/story_reader/markdown_story_reader.py
+++ b/rasa/shared/core/training_data/story_reader/markdown_story_reader.py
@@ -209,8 +209,8 @@ class MarkdownStoryReader(StoryReader):
         """Parses an md list item line based on the current section type.
 
         Matches expressions of the form `<intent>:<example>`. For the
-        syntax of `<example>` see the Rasa docs on NLU training data."""
-
+        syntax of `<example>` see the Rasa docs on NLU training data.
+        """
         # Match three groups:
         # 1) Potential "form" annotation
         # 2) The correct intent

--- a/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
+++ b/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
@@ -372,7 +372,7 @@ class YAMLStoryReader(StoryReader):
     ) -> Tuple[Text, Optional[Text]]:
         user_intent = step.get(KEY_USER_INTENT, "").strip()
 
-        if not user_intent:
+        if not user_intent and KEY_USER_MESSAGE not in step:
             rasa.shared.utils.io.raise_warning(
                 f"Issue found in '{self.source_name}':\n"
                 f"User utterance cannot be empty. "

--- a/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
+++ b/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
@@ -318,14 +318,13 @@ class YAMLStoryReader(StoryReader):
 
         is_end_to_end_utterance = KEY_USER_INTENT not in step
         if is_end_to_end_utterance:
-            utterance.intent = {"name": None}
+            utterance.intent = {INTENT_NAME_KEY: None}
         else:
             self._validate_that_utterance_is_in_domain(utterance)
 
         self.current_step_builder.add_user_messages([utterance])
 
     def _validate_that_utterance_is_in_domain(self, utterance: UserUttered) -> None:
-
         intent_name = utterance.intent.get(INTENT_NAME_KEY)
 
         # check if this is a retrieval intent

--- a/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
+++ b/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Text, Union, Optional
 
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedMap
-from ruamel.yaml.scalarstring import DoubleQuotedScalarString, LiteralScalarString
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 import rasa.shared.utils.io
 import rasa.shared.core.constants

--- a/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
+++ b/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
@@ -217,7 +217,7 @@ class YAMLStoryWriter(StoryWriter):
             or is_test_story
         ):
             result[KEY_USER_MESSAGE] = LiteralScalarString(
-                rasa.shared.core.events.md_format_message(
+                rasa.shared.core.events.format_message(
                     user_utterance.text,
                     user_utterance.intent_name,
                     user_utterance.entities,

--- a/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
+++ b/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
@@ -188,13 +188,6 @@ class YAMLStoryWriter(StoryWriter):
         )
 
     @staticmethod
-    def _text_is_real_message(user_utterance: UserUttered) -> bool:
-        return (
-            not user_utterance.intent
-            or user_utterance.text != user_utterance.as_story_string()
-        )
-
-    @staticmethod
     def process_user_utterance(
         user_utterance: UserUttered, is_test_story: bool = False
     ) -> OrderedDict:

--- a/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
+++ b/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
@@ -213,7 +213,6 @@ class YAMLStoryWriter(StoryWriter):
         if user_utterance.text and (
             # We only print the utterance text if it was an end-to-end prediction
             user_utterance.use_text_for_featurization
-            or user_utterance.use_text_for_featurization is None
             # or if we want to print a conversation test story.
             or is_test_story
         ):

--- a/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
+++ b/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
@@ -104,6 +104,7 @@ class YAMLStoryWriter(StoryWriter):
 
         Args:
             story_steps: Original story steps to be converted to the YAML.
+            is_test_story: `True` if the story is an end-to-end conversation test story.
         """
         from rasa.shared.utils.validation import KEY_TRAINING_DATA_FORMAT_VERSION
 

--- a/rasa/shared/core/training_data/structures.py
+++ b/rasa/shared/core/training_data/structures.py
@@ -407,6 +407,7 @@ class StoryGraph:
         Returns:
             fingerprint of the stories
         """
+        # TODO: Use yaml story writer
         self_as_string = self.as_story_string()
         return rasa.shared.utils.io.get_text_hash(self_as_string)
 

--- a/rasa/shared/core/training_data/structures.py
+++ b/rasa/shared/core/training_data/structures.py
@@ -407,8 +407,11 @@ class StoryGraph:
         Returns:
             fingerprint of the stories
         """
-        # TODO: Use yaml story writer
-        self_as_string = self.as_story_string()
+        from rasa.shared.core.training_data.story_writer.yaml_story_writer import (
+            YAMLStoryWriter,
+        )
+
+        self_as_string = YAMLStoryWriter().dumps(self.story_steps)
         return rasa.shared.utils.io.get_text_hash(self_as_string)
 
     def ordered_steps(self) -> List[StoryStep]:

--- a/rasa/shared/exceptions.py
+++ b/rasa/shared/exceptions.py
@@ -76,4 +76,4 @@ class InvalidConfigException(ValueError, RasaException):
 
 
 class UnsupportedFeatureException(RasaCoreException):
-    """Raised if a certain feature is not supported."""
+    """Raised if a requested feature is not supported."""

--- a/rasa/shared/exceptions.py
+++ b/rasa/shared/exceptions.py
@@ -73,3 +73,7 @@ class FileIOException(RasaException):
 
 class InvalidConfigException(ValueError, RasaException):
     """Raised if an invalid configuration is encountered."""
+
+
+class UnsupportedFeatureException(RasaCoreException):
+    """Raised if a certain feature is not supported."""

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -214,32 +214,6 @@ class NluDataImporter(TrainingDataImporter):
         return await self._importer.get_nlu_data(language)
 
 
-class CoreDataImporter(TrainingDataImporter):
-    """Importer that skips any NLU related file reading."""
-
-    def __init__(self, actual_importer: TrainingDataImporter):
-        self._importer = actual_importer
-
-    async def get_domain(self) -> Domain:
-        return await self._importer.get_domain()
-
-    async def get_stories(
-        self,
-        template_variables: Optional[Dict] = None,
-        use_e2e: bool = False,
-        exclusion_percentage: Optional[int] = None,
-    ) -> StoryGraph:
-        return await self._importer.get_stories(
-            template_variables, use_e2e, exclusion_percentage
-        )
-
-    async def get_config(self) -> Dict:
-        return await self._importer.get_config()
-
-    async def get_nlu_data(self, language: Optional[Text] = "en") -> TrainingData:
-        return TrainingData()
-
-
 class CombinedDataImporter(TrainingDataImporter):
     """A `TrainingDataImporter` that combines multiple importers.
     Uses multiple `TrainingDataImporter` instances

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -216,6 +216,7 @@ class NluDataImporter(TrainingDataImporter):
 
 class CombinedDataImporter(TrainingDataImporter):
     """A `TrainingDataImporter` that combines multiple importers.
+
     Uses multiple `TrainingDataImporter` instances
     to load the data as if they were a single instance.
     """

--- a/rasa/train.py
+++ b/rasa/train.py
@@ -175,7 +175,7 @@ async def _train_async_internal(
         )
 
     # We will train nlu if there are any nlu example, including from e2e stories.
-    if nlu_data.is_empty():
+    if nlu_data.contains_no_pure_nlu_data() and not nlu_data.has_e2e_examples():
         print_warning("No NLU data present. Just a Rasa Core model will be trained.")
         return await _train_core_with_validated_data(
             file_importer,

--- a/tests/core/featurizers/test_single_state_featurizers.py
+++ b/tests/core/featurizers/test_single_state_featurizers.py
@@ -133,7 +133,7 @@ def test_single_state_featurizer_correctly_encodes_non_existing_value():
     assert (encoded[INTENT][0].features != scipy.sparse.coo_matrix([[0, 0]])).nnz == 0
 
 
-def test_single_state_featurizer_prepare_from_domain():
+def test_single_state_featurizer_prepare_for_training():
     domain = Domain(
         intents=["greet"],
         entities=["name"],
@@ -144,7 +144,7 @@ def test_single_state_featurizer_prepare_from_domain():
     )
 
     f = SingleStateFeaturizer()
-    f.prepare_from_domain(domain)
+    f.prepare_for_training(domain, RegexInterpreter())
 
     assert len(f._default_feature_states[INTENT]) > 1
     assert "greet" in f._default_feature_states[INTENT]
@@ -197,7 +197,7 @@ def test_single_state_featurizer_with_entity_roles_and_groups(
         action_names=[],
     )
     f = SingleStateFeaturizer()
-    f.prepare_from_domain(domain)
+    f.prepare_for_training(domain, RegexInterpreter())
     encoded = f.encode_entities(
         {
             TEXT: "I am flying from London to Paris",

--- a/tests/core/featurizers/test_single_state_featurizers.py
+++ b/tests/core/featurizers/test_single_state_featurizers.py
@@ -181,6 +181,7 @@ def test_single_state_featurizer_creates_encoded_all_actions():
     )
 
 
+@pytest.mark.timeout(300)  # these can take a longer time than the default timeout
 def test_single_state_featurizer_with_entity_roles_and_groups(
     unpacked_trained_moodbot_path: Text,
 ):
@@ -241,6 +242,7 @@ def test_single_state_featurizer_uses_dtype_float():
     assert encoded[ACTION_NAME][0].features.dtype == np.float32
 
 
+@pytest.mark.timeout(300)  # these can take a longer time than the default timeout
 def test_single_state_featurizer_with_interpreter_state_with_action_listen(
     unpacked_trained_moodbot_path: Text,
 ):
@@ -304,6 +306,7 @@ def test_single_state_featurizer_with_interpreter_state_with_action_listen(
     ).nnz == 0
 
 
+@pytest.mark.timeout(300)  # these can take a longer time than the default timeout
 def test_single_state_featurizer_with_interpreter_state_not_with_action_listen(
     unpacked_trained_moodbot_path: Text,
 ):
@@ -340,6 +343,7 @@ def test_single_state_featurizer_with_interpreter_state_not_with_action_listen(
     ).nnz == 0
 
 
+@pytest.mark.timeout(300)  # these can take a longer time than the default timeout
 def test_single_state_featurizer_with_interpreter_state_with_no_action_name(
     unpacked_trained_moodbot_path: Text,
 ):
@@ -402,6 +406,7 @@ def test_to_sparse_sentence_features():
     assert sentence_features[0].features.shape == (1, 10)
 
 
+@pytest.mark.timeout(300)  # these can take a longer time than the default timeout
 def test_single_state_featurizer_uses_regex_interpreter(
     unpacked_trained_moodbot_path: Text,
 ):

--- a/tests/core/featurizers/test_tracker_featurizer.py
+++ b/tests/core/featurizers/test_tracker_featurizer.py
@@ -21,7 +21,7 @@ def test_fail_to_load_non_existent_featurizer():
 
 def test_persist_and_load_tracker_featurizer(tmp_path: Text, moodbot_domain: Domain):
     state_featurizer = SingleStateFeaturizer()
-    state_featurizer.prepare_from_domain(moodbot_domain)
+    state_featurizer.prepare_for_training(moodbot_domain, RegexInterpreter())
     tracker_featurizer = MaxHistoryTrackerFeaturizer(state_featurizer)
 
     tracker_featurizer.persist(tmp_path)

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -1110,10 +1110,7 @@ class TestTwoStageFallbackPolicy(TestFallbackPolicy):
         )
 
         assert "bye" == tracker.latest_message.parse_data["intent"][INTENT_NAME_KEY]
-        assert (
-            tracker.export_stories(MarkdownStoryWriter())
-            == "## sender\n* bye: Random\n"
-        )
+        assert tracker.export_stories(MarkdownStoryWriter()) == "## sender\n* bye\n"
 
     def test_affirm_rephrased_intent(
         self, trained_policy: Policy, default_domain: Domain
@@ -1158,10 +1155,7 @@ class TestTwoStageFallbackPolicy(TestFallbackPolicy):
         )
 
         assert "bye" == tracker.latest_message.parse_data["intent"][INTENT_NAME_KEY]
-        assert (
-            tracker.export_stories(MarkdownStoryWriter())
-            == "## sender\n* bye: Random\n"
-        )
+        assert tracker.export_stories(MarkdownStoryWriter()) == "## sender\n* bye\n"
 
     def test_denied_rephrasing_affirmation(
         self, trained_policy: Policy, default_domain: Domain

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -903,10 +903,12 @@ async def test_restart_triggers_session_start(
             [{"entity": entity, "start": 6, "end": 23, "value": "name1"}],
         ),
         SlotSet(entity, slot_1[entity]),
+        DefinePrevUserUtteredFeaturization(use_text_for_featurization=False),
         ActionExecuted("utter_greet"),
         BotUttered("hey there name1!", metadata={"template_name": "utter_greet"}),
         ActionExecuted(ACTION_LISTEN_NAME),
         UserUttered("/restart", {INTENT_NAME_KEY: "restart", "confidence": 1.0}),
+        DefinePrevUserUtteredFeaturization(use_text_for_featurization=False),
         ActionExecuted(ACTION_RESTART_NAME),
         Restarted(),
         ActionExecuted(ACTION_SESSION_START_NAME),
@@ -914,7 +916,8 @@ async def test_restart_triggers_session_start(
         # No previous slot is set due to restart.
         ActionExecuted(ACTION_LISTEN_NAME),
     ]
-    assert list(tracker.events) == expected
+    for actual, expected in zip(tracker.events, expected):
+        assert actual == expected
 
 
 async def test_handle_message_if_action_manually_rejects(

--- a/tests/core/training/converters/test_story_markdown_to_yaml_converter.py
+++ b/tests/core/training/converters/test_story_markdown_to_yaml_converter.py
@@ -7,14 +7,6 @@ from rasa.core.training.converters.story_markdown_to_yaml_converter import (
     StoryMarkdownToYamlConverter,
 )
 
-from rasa.shared.core.training_data.story_reader.markdown_story_reader import (
-    MarkdownStoryReader,
-)
-
-from rasa.shared.core.training_data.story_reader.yaml_story_reader import (
-    YAMLStoryReader,
-)
-
 from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 
@@ -32,12 +24,12 @@ def test_converter_filters_correct_files(training_data_file: Text, should_filter
     )
 
 
-async def test_stories_are_converted(tmpdir: Path):
-    converted_data_folder = tmpdir / "converted_data"
-    os.mkdir(converted_data_folder)
+async def test_stories_are_converted(tmp_path: Path):
+    converted_data_folder = tmp_path / "converted_data"
+    converted_data_folder.mkdir()
 
-    training_data_folder = tmpdir / "data/core"
-    os.makedirs(training_data_folder, exist_ok=True)
+    training_data_folder = tmp_path / "data" / "core"
+    training_data_folder.mkdir(parents=True)
     training_data_file = Path(training_data_folder / "stories.md")
 
     simple_story_md = """
@@ -48,8 +40,7 @@ async def test_stories_are_converted(tmpdir: Path):
         - slot{"name": ["value1", "value2"]}
     """
 
-    with open(training_data_file, "w") as f:
-        f.write(simple_story_md)
+    training_data_file.write_text(simple_story_md)
 
     await StoryMarkdownToYamlConverter().convert_and_write(
         training_data_file, converted_data_folder
@@ -76,12 +67,12 @@ async def test_stories_are_converted(tmpdir: Path):
         )
 
 
-async def test_test_stories(tmpdir: Path):
-    converted_data_folder = tmpdir / "converted_data"
-    os.mkdir(converted_data_folder)
+async def test_test_stories(tmp_path: Path):
+    converted_data_folder = tmp_path / "converted_data"
+    converted_data_folder.mkdir()
 
-    test_data_folder = tmpdir / "tests"
-    os.makedirs(test_data_folder, exist_ok=True)
+    test_data_folder = tmp_path / "tests"
+    test_data_folder.mkdir(exist_ok=True)
     test_data_file = Path(test_data_folder / "test_stories.md")
 
     simple_story_md = """
@@ -92,14 +83,13 @@ async def test_test_stories(tmpdir: Path):
         - action_set_faq_slot
     """
 
-    with open(test_data_file, "w") as f:
-        f.write(simple_story_md)
+    test_data_file.write_text(simple_story_md)
 
     await StoryMarkdownToYamlConverter().convert_and_write(
         test_data_file, converted_data_folder
     )
 
-    assert len(os.listdir(converted_data_folder)) == 1
+    assert len(list(converted_data_folder.glob("*"))) == 1
 
     with open(f"{converted_data_folder}/test_stories_converted.yml", "r") as f:
         content = f.read()
@@ -118,12 +108,12 @@ async def test_test_stories(tmpdir: Path):
         )
 
 
-async def test_test_stories_conversion_response_key(tmpdir: Path):
-    converted_data_folder = tmpdir / "converted_data"
-    os.mkdir(converted_data_folder)
+async def test_test_stories_conversion_response_key(tmp_path: Path):
+    converted_data_folder = tmp_path / "converted_data"
+    converted_data_folder.mkdir()
 
-    test_data_folder = tmpdir / "tests"
-    os.makedirs(test_data_folder, exist_ok=True)
+    test_data_folder = tmp_path / "tests"
+    test_data_folder.mkdir(exist_ok=True)
     test_data_file = Path(test_data_folder / "test_stories.md")
 
     simple_story_md = """
@@ -133,8 +123,7 @@ async def test_test_stories_conversion_response_key(tmpdir: Path):
         - utter_out_of_scope/other
     """
 
-    with open(test_data_file, "w") as f:
-        f.write(simple_story_md)
+    test_data_file.write_text(simple_story_md)
 
     await StoryMarkdownToYamlConverter().convert_and_write(
         test_data_file, converted_data_folder
@@ -155,12 +144,12 @@ async def test_test_stories_conversion_response_key(tmpdir: Path):
         )
 
 
-async def test_stories_conversion_response_key(tmpdir: Path):
-    converted_data_folder = tmpdir / "converted_data"
-    os.mkdir(converted_data_folder)
+async def test_stories_conversion_response_key(tmp_path: Path):
+    converted_data_folder = tmp_path / "converted_data"
+    converted_data_folder.mkdir()
 
-    training_data_folder = tmpdir / "data/core"
-    os.makedirs(training_data_folder, exist_ok=True)
+    training_data_folder = tmp_path / "data" / "core"
+    training_data_folder.mkdir(parents=True)
     training_data_file = Path(training_data_folder / "stories.md")
 
     simple_story_md = """
@@ -169,8 +158,7 @@ async def test_stories_conversion_response_key(tmpdir: Path):
         - utter_out_of_scope/other
     """
 
-    with open(training_data_file, "w") as f:
-        f.write(simple_story_md)
+    training_data_file.write_text(simple_story_md)
 
     await StoryMarkdownToYamlConverter().convert_and_write(
         training_data_file, converted_data_folder

--- a/tests/shared/core/test_events.py
+++ b/tests/shared/core/test_events.py
@@ -29,7 +29,7 @@ from rasa.shared.core.events import (
     UserUtteranceReverted,
     AgentUttered,
     SessionStarted,
-    md_format_message,
+    format_message,
 )
 from rasa.shared.nlu.constants import INTENT_NAME_KEY
 from tests.core.policies.test_rule_policy import GREET_INTENT_NAME, UTTER_GREET_ACTION
@@ -321,17 +321,15 @@ def test_user_uttered_intent_name(event: UserUttered, intent_name: Optional[Text
 
 
 def test_md_format_message():
-    assert (
-        md_format_message("Hello there!", intent="greet", entities=[]) == "Hello there!"
-    )
+    assert format_message("Hello there!", intent="greet", entities=[]) == "Hello there!"
 
 
 def test_md_format_message_empty():
-    assert md_format_message("", intent=None, entities=[]) == ""
+    assert format_message("", intent=None, entities=[]) == ""
 
 
 def test_md_format_message_using_short_entity_syntax():
-    formatted = md_format_message(
+    formatted = format_message(
         "I am from Berlin.",
         intent="location",
         entities=[{"start": 10, "end": 16, "entity": "city", "value": "Berlin"}],
@@ -340,7 +338,7 @@ def test_md_format_message_using_short_entity_syntax():
 
 
 def test_md_format_message_using_long_entity_syntax():
-    formatted = md_format_message(
+    formatted = format_message(
         "I am from Berlin in Germany.",
         intent="location",
         entities=[

--- a/tests/shared/core/test_events.py
+++ b/tests/shared/core/test_events.py
@@ -9,7 +9,7 @@ from typing import Type, Optional, Text, List, Any, Dict
 
 import rasa.shared.utils.common
 import rasa.shared.core.events
-from rasa.exceptions import UnsupportedFeatureException
+from rasa.shared.exceptions import UnsupportedFeatureException
 from rasa.shared.core.constants import ACTION_LISTEN_NAME, ACTION_SESSION_START_NAME
 from rasa.shared.core.events import (
     Event,

--- a/tests/shared/core/test_events.py
+++ b/tests/shared/core/test_events.py
@@ -9,6 +9,7 @@ from typing import Type, Optional, Text, List, Any, Dict
 
 import rasa.shared.utils.common
 import rasa.shared.core.events
+from rasa.exceptions import UnsupportedFeatureException
 from rasa.shared.core.constants import ACTION_LISTEN_NAME, ACTION_SESSION_START_NAME
 from rasa.shared.core.events import (
     Event,
@@ -30,6 +31,7 @@ from rasa.shared.core.events import (
     SessionStarted,
     md_format_message,
 )
+from rasa.shared.nlu.constants import INTENT_NAME_KEY
 from tests.core.policies.test_rule_policy import GREET_INTENT_NAME, UTTER_GREET_ACTION
 
 
@@ -507,3 +509,20 @@ def test_events_begin_with_session_start(
         rasa.shared.core.events.do_events_begin_with_session_start(test_events)
         == begin_with_session_start
     )
+
+
+@pytest.mark.parametrize(
+    "end_to_end_event",
+    [
+        ActionExecuted(action_text="I insist on using Markdown"),
+        UserUttered(text="Markdown is much more readable"),
+        UserUttered(
+            text="but YAML ❤️",
+            intent={INTENT_NAME_KEY: "use_yaml"},
+            use_text_for_featurization=True,
+        ),
+    ],
+)
+def test_print_end_to_end_events_in_markdown(end_to_end_event: Event):
+    with pytest.raises(UnsupportedFeatureException):
+        end_to_end_event.as_story_string()

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -65,9 +65,6 @@ from tests.core.utilities import (
     get_tracker,
 )
 
-from rasa.shared.core.training_data.story_writer.markdown_story_writer import (
-    MarkdownStoryWriter,
-)
 from rasa.shared.nlu.constants import ACTION_NAME, PREDICTED_CONFIDENCE_KEY
 
 domain = Domain.load("examples/moodbot/domain.yml")
@@ -633,22 +630,6 @@ def test_session_started_not_part_of_applied_events(default_agent: Agent):
     # the SessionStart event was at index 5, the tracker's `applied_events()` should
     # be the same as the list of events from index 6 onwards
     assert tracker.applied_events() == list(tracker.events)[6:]
-
-
-async def test_tracker_dump_e2e_story(default_agent: Agent):
-    sender_id = "test_tracker_dump_e2e_story"
-
-    await default_agent.handle_text("/greet", sender_id=sender_id)
-    await default_agent.handle_text("/goodbye", sender_id=sender_id)
-    tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
-
-    story = tracker.export_stories(MarkdownStoryWriter(), e2e=True)
-    assert story.strip().split("\n") == [
-        "## test_tracker_dump_e2e_story",
-        "* greet: /greet",
-        "    - utter_greet",
-        "* goodbye: /goodbye",
-    ]
 
 
 def test_get_last_event_for():

--- a/tests/shared/core/training_data/story_reader/test_markdown_story_reader.py
+++ b/tests/shared/core/training_data/story_reader/test_markdown_story_reader.py
@@ -360,7 +360,7 @@ async def test_read_rules_without_stories(default_domain: Domain):
     ],
 )
 def test_e2e_parsing(line: Text, expected: Dict):
-    actual = MarkdownStoryReader.parse_e2e_message(line)
+    actual = MarkdownStoryReader().parse_e2e_message(line)
 
     assert actual.as_dict() == expected
 

--- a/tests/shared/core/training_data/story_writer/test_markdown_story_writer.py
+++ b/tests/shared/core/training_data/story_writer/test_markdown_story_writer.py
@@ -1,0 +1,20 @@
+from rasa.core.agent import Agent
+from rasa.shared.core.training_data.story_writer.markdown_story_writer import (
+    MarkdownStoryWriter,
+)
+
+
+async def test_tracker_dump_e2e_story(default_agent: Agent):
+    sender_id = "test_tracker_dump_e2e_story"
+
+    await default_agent.handle_text("/greet", sender_id=sender_id)
+    await default_agent.handle_text("/goodbye", sender_id=sender_id)
+    tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
+
+    story = tracker.export_stories(MarkdownStoryWriter(), e2e=True)
+    assert story.strip().split("\n") == [
+        "## test_tracker_dump_e2e_story",
+        "* greet: /greet",
+        "    - utter_greet",
+        "* goodbye: /goodbye",
+    ]

--- a/tests/shared/core/training_data/story_writer/test_yaml_story_writer.py
+++ b/tests/shared/core/training_data/story_writer/test_yaml_story_writer.py
@@ -18,9 +18,6 @@ from rasa.shared.core.training_data.story_writer.yaml_story_writer import (
     YAMLStoryWriter,
 )
 from rasa.shared.core.training_data.structures import STORY_START
-from rasa.utils.endpoints import EndpointConfig
-
-import rasa.shared.utils.io
 
 
 @pytest.mark.parametrize(

--- a/tests/shared/core/training_data/story_writer/test_yaml_story_writer.py
+++ b/tests/shared/core/training_data/story_writer/test_yaml_story_writer.py
@@ -247,12 +247,12 @@ stories:
     user: Hi
   - action: utter_greet
   - intent: greet
-    user: | 
+    user: |
       [Hi](test)
   - action: utter_greet
   - user: Hi
   - bot: Hi, I'm a bot.
-  - user: | 
+  - user: |
       [Hi](test)
   - bot: Hi, I'm a bot.
     """

--- a/tests/shared/core/training_data/test_structures.py
+++ b/tests/shared/core/training_data/test_structures.py
@@ -1,9 +1,22 @@
 import rasa.core
 from rasa.shared.core.constants import ACTION_SESSION_START_NAME
 from rasa.shared.core.domain import Domain
-from rasa.shared.core.events import SessionStarted, SlotSet, UserUttered, ActionExecuted
+from rasa.shared.core.events import (
+    SessionStarted,
+    SlotSet,
+    UserUttered,
+    ActionExecuted,
+    DefinePrevUserUtteredFeaturization,
+)
 from rasa.shared.core.trackers import DialogueStateTracker
+from rasa.shared.core.training_data.story_reader.yaml_story_reader import (
+    YAMLStoryReader,
+)
+from rasa.shared.core.training_data.story_writer.yaml_story_writer import (
+    YAMLStoryWriter,
+)
 from rasa.shared.core.training_data.structures import Story
+from rasa.shared.nlu.constants import INTENT_NAME_KEY
 
 domain = Domain.load("examples/moodbot/domain.yml")
 
@@ -19,17 +32,28 @@ def test_session_start_is_not_serialised(default_domain: Domain):
     # add the two SessionStarted events and a user event
     tracker.update(ActionExecuted(ACTION_SESSION_START_NAME))
     tracker.update(SessionStarted())
-    tracker.update(UserUttered("say something"))
+    tracker.update(
+        UserUttered("say something", intent={INTENT_NAME_KEY: "some_intent"})
+    )
+    tracker.update(DefinePrevUserUtteredFeaturization(False))
 
-    # make sure session start is not serialised
-    story = Story.from_events(tracker.events, "some-story01")
+    YAMLStoryWriter().dumps(
+        Story.from_events(tracker.events, "some-story01").story_steps
+    )
 
-    expected = """## some-story01
-    - slot{"slot": "value"}
-* say something
+    expected = """version: "2.0"
+stories:
+- story: some-story01
+  steps:
+  - slot_was_set:
+    - slot: value
+  - intent: some_intent
 """
 
-    assert story.as_story_string(flat=True) == expected
+    actual = YAMLStoryWriter().dumps(
+        Story.from_events(tracker.events, "some-story01").story_steps
+    )
+    assert actual == expected
 
 
 def test_as_story_string_or_statement():

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -17,7 +17,6 @@ from rasa.shared.importers.importer import (
     CombinedDataImporter,
     TrainingDataImporter,
     NluDataImporter,
-    CoreDataImporter,
     E2EImporter,
     RetrievalModelsDataImporter,
 )
@@ -153,29 +152,6 @@ async def test_nlu_only(project: Text):
 
     nlu_data = await actual.get_nlu_data()
     assert not nlu_data.is_empty()
-
-
-async def test_core_only(project: Text):
-    config_path = os.path.join(project, DEFAULT_CONFIG_PATH)
-    domain_path = os.path.join(project, DEFAULT_DOMAIN_PATH)
-    default_data_path = os.path.join(project, DEFAULT_DATA_PATH)
-    actual = TrainingDataImporter.load_core_importer_from_config(
-        config_path, domain_path, training_data_paths=[default_data_path]
-    )
-
-    assert isinstance(actual, CoreDataImporter)
-
-    stories = await actual.get_stories()
-    assert not stories.is_empty()
-
-    domain = await actual.get_domain()
-    assert not domain.is_empty()
-
-    config = await actual.get_config()
-    assert config
-
-    nlu_data = await actual.get_nlu_data()
-    assert nlu_data.is_empty()
 
 
 async def test_import_nlu_training_data_from_e2e_stories(
@@ -348,16 +324,10 @@ async def test_nlu_data_domain_sync_with_retrieval_intents(project: Text):
         "data/test_nlu/default_retrieval_intents.md",
         "data/test_responses/default.md",
     ]
-    base_data_importer = TrainingDataImporter.load_from_dict(
+    importer = TrainingDataImporter.load_from_dict(
         {}, config_path, domain_path, data_paths
     )
 
-    nlu_importer = NluDataImporter(base_data_importer)
-    core_importer = CoreDataImporter(base_data_importer)
-
-    importer = RetrievalModelsDataImporter(
-        CombinedDataImporter([nlu_importer, core_importer])
-    )
     domain = await importer.get_domain()
     nlu_data = await importer.get_nlu_data()
 

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -186,9 +186,9 @@ async def test_import_nlu_training_data_from_e2e_stories(
     importer_without_e2e.get_stories = mocked_stories
 
     # The wrapping `E2EImporter` simply forwards these method calls
-    assert (await importer_without_e2e.get_stories()).as_story_string() == (
+    assert (await importer_without_e2e.get_stories()).fingerprint() == (
         await default_importer.get_stories()
-    ).as_story_string()
+    ).fingerprint()
     assert (await importer_without_e2e.get_config()) == (
         await default_importer.get_config()
     )
@@ -208,8 +208,6 @@ async def test_import_nlu_training_data_from_e2e_stories(
         Message(data={TEXT: "how are you doing?"}),
         Message(data={ACTION_TEXT: "Hi Joey."}),
     ]
-
-    print([t.data for t in nlu_data.training_examples])
 
     assert all(m in nlu_data.training_examples for m in expected_additional_messages)
 

--- a/tests/shared/test_data.py
+++ b/tests/shared/test_data.py
@@ -213,21 +213,17 @@ def test_get_core_nlu_directories_with_none():
     assert all(not os.listdir(directory) for directory in directories)
 
 
-def test_same_file_names_get_resolved(tmp_path):
+def test_same_file_names_get_resolved(tmp_path: Path):
     # makes sure the resolution properly handles if there are two files with
     # with the same name in different directories
 
     (tmp_path / "one").mkdir()
     (tmp_path / "two").mkdir()
-    data_dir_one = str(tmp_path / "one" / "stories.md")
-    data_dir_two = str(tmp_path / "two" / "stories.md")
-    shutil.copy2(DEFAULT_STORIES_FILE, data_dir_one)
-    shutil.copy2(DEFAULT_STORIES_FILE, data_dir_two)
+    shutil.copy2(DEFAULT_STORIES_FILE, tmp_path / "one" / "stories.yml")
+    shutil.copy2(DEFAULT_STORIES_FILE, tmp_path / "two" / "stories.yml")
 
-    nlu_dir_one = str(tmp_path / "one" / "nlu.yml")
-    nlu_dir_two = str(tmp_path / "two" / "nlu.yml")
-    shutil.copy2(DEFAULT_NLU_DATA, nlu_dir_one)
-    shutil.copy2(DEFAULT_NLU_DATA, nlu_dir_two)
+    shutil.copy2(DEFAULT_NLU_DATA, tmp_path / "one" / "nlu.yml")
+    shutil.copy2(DEFAULT_NLU_DATA, tmp_path / "two" / "nlu.yml")
 
     core_directory, nlu_directory = rasa.shared.data.get_core_nlu_directories(
         [str(tmp_path)]
@@ -241,7 +237,7 @@ def test_same_file_names_get_resolved(tmp_path):
     stories = os.listdir(core_directory)
 
     assert len(stories) == 2
-    assert all(f.endswith("stories.md") for f in stories)
+    assert all(f.endswith("stories.yml") for f in stories)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -187,7 +187,7 @@ def test_write_classification_errors():
         WronglyPredictedAction("utter_greet", "", "utter_goodbye"),
     ]
     tracker = DialogueStateTracker.from_events("default", events)
-    dump = YAMLStoryWriter().dumps(tracker.as_story().story_steps, is_test_story=True)
+    dump = YAMLStoryWriter().dumps(tracker.as_story().story_steps)
     assert (
         dump.strip()
         == textwrap.dedent(


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/7130
- fix printing of end-to-end bot actions in `rasa interactive`
- fix failing tests due to the `DEFAULT_STORIES_FILE` changed to be yaml
- fix reading and writing of yaml stories with end-to-end tests and end-to-end training data
- raise exception if end-to-end `UserUttered` / `ActionExecuted` events are tried to be printed to markdown
- change fingerprinting to use yaml to make sure it works with end-to-end training data (fingerprinting is still not stable for checkpoints - however, should be fixed on `master` and not here
- change story structure validator to use `str` to represent actions instead of markdown representation which uses `as_story_string`

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
