### PR TITLE
Correctly set slots in domain when just updating nlg.

### DIFF
--- a/changelog/7417.bugfix.md
+++ b/changelog/7417.bugfix.md
@@ -1,0 +1,3 @@
+Categorical slots will have a default value set when just updating nlg data in the domain.
+
+Previously this resulted in `InvalidDomain` being thrown.

--- a/data/test_domains/domain_with_categorical_slot.yml
+++ b/data/test_domains/domain_with_categorical_slot.yml
@@ -1,0 +1,10 @@
+slots:
+  category_slot:
+    type: categorical
+    values:
+      - value_one
+      - value_two
+
+responses:
+  utter_greet:
+    - text: "hey there!"

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -355,9 +355,7 @@ class Agent:
         self.policy_ensemble = self._create_ensemble(policies)
 
         if self.domain is not None:
-            self.domain.add_requested_slot()
-            self.domain.add_knowledge_base_slots()
-            self.domain.add_categorical_slot_default_value()
+            self.domain.setup_slots()
 
         PolicyEnsemble.check_domain_ensemble_compatibility(
             self.policy_ensemble, self.domain

--- a/rasa/model.py
+++ b/rasa/model.py
@@ -513,5 +513,5 @@ async def update_model_with_new_domain(
 
     model_path = Path(unpacked_model_path) / DEFAULT_CORE_SUBDIRECTORY_NAME
     domain = await importer.get_domain()
-
+    domain.setup_slots()
     domain.persist(model_path / DEFAULT_DOMAIN_PATH)

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -683,6 +683,12 @@ class Domain:
         """
         return rasa.shared.nlu.constants.RESPONSE_IDENTIFIER_DELIMITER in template[0]
 
+    def setup_slots(self) -> None:
+        """Sets up the default slots and slot values for the domain."""
+        self.add_requested_slot()
+        self.add_knowledge_base_slots()
+        self.add_categorical_slot_default_value()
+
     def add_categorical_slot_default_value(self) -> None:
         """Add a default value to all categorical slots.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from tests.core.conftest import (
     DEFAULT_DOMAIN_PATH_WITH_SLOTS,
     DEFAULT_STACK_CONFIG,
     DEFAULT_STORIES_FILE,
+    DOMAIN_WITH_CATEGORICAL_SLOT,
     END_TO_END_STORY_FILE,
     INCORRECT_NLU_DATA,
 )
@@ -123,6 +124,11 @@ async def nlu_agent(trained_nlu_model: Text) -> Agent:
 @pytest.fixture(scope="session")
 def default_domain_path() -> Text:
     return DEFAULT_DOMAIN_PATH_WITH_SLOTS
+
+
+@pytest.fixture(scope="session")
+def domain_with_categorical_slot_path() -> Text:
+    return DOMAIN_WITH_CATEGORICAL_SLOT
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -24,6 +24,8 @@ from rasa.shared.core.trackers import DialogueStateTracker
 
 DEFAULT_DOMAIN_PATH_WITH_SLOTS = "data/test_domains/default_with_slots.yml"
 
+DOMAIN_WITH_CATEGORICAL_SLOT = "data/test_domains/domain_with_categorical_slot.yml"
+
 DEFAULT_DOMAIN_PATH_WITH_SLOTS_AND_NO_ACTIONS = (
     "data/test_domains/default_with_slots_and_no_actions.yml"
 )


### PR DESCRIPTION
**Proposed changes**:
`Domain.compare_with_specification` was failing when running `rasa train` after only changing NLG data. This is because the categorical slots were not having the default `__other__` value added when the domain was updated using `update_model_with_new_domain` - so it ended up being inconsistent. 
Solution was to also set up the default slots in this method.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
