### PR TITLE
Add use_word_boundaries option for RegexFeaturizer and RegexEntityExtractor

### DIFF
--- a/changelog/7422.bugfix.md
+++ b/changelog/7422.bugfix.md
@@ -1,0 +1,1 @@
+Add option `use_word_boundaries` for `RegexFeaturizer` and `RegexEntityExtractor`. To correctly process languages such as Chinese that don't use whitespace for word separation, the user needs to add the `use_word_boundaries: False` option to those two components.

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -2064,6 +2064,9 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
   Make the entity extractor case sensitive by adding the `case_sensitive: True` option, the default being
   `case_sensitive: False`.
 
+  For correctly process languages such as Chinese that don't use whitespace for word separation,
+  user need add the `use_word_boundaries: False` option, the default being `use_word_boundaries: True`.
+
   ```yaml-rasa
       pipeline:
       - name: RegexEntityExtractor
@@ -2073,6 +2076,8 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
         use_lookup_tables: True
         # use regexes to extract entities
         use_regexes: True
+        # use match word boundaries for lookup table
+        "use_word_boundaries": True
   ```
 
 

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -824,8 +824,8 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
   Make the featurizer case insensitive by adding the `case_sensitive: False` option, the default being
   `case_sensitive: True`.
 
-  For correctly process languages such as Chinese that don't use whitespace for word separation,
-  user need add the `use_word_boundaries: False` option, the default being `use_word_boundaries: True`.
+  To correctly process languages such as Chinese that don't use whitespace for word separation,
+  the user needs to add the `use_word_boundaries: False` option, the default being `use_word_boundaries: True`.
 
   ```yaml-rasa
   pipeline:
@@ -2064,8 +2064,8 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
   Make the entity extractor case sensitive by adding the `case_sensitive: True` option, the default being
   `case_sensitive: False`.
 
-  For correctly process languages such as Chinese that don't use whitespace for word separation,
-  user need add the `use_word_boundaries: False` option, the default being `use_word_boundaries: True`.
+  To correctly process languages such as Chinese that don't use whitespace for word separation,
+  the user needs to add the `use_word_boundaries: False` option, the default being `use_word_boundaries: True`.
 
   ```yaml-rasa
       pipeline:

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -824,11 +824,16 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
   Make the featurizer case insensitive by adding the `case_sensitive: False` option, the default being
   `case_sensitive: True`.
 
+  For correctly process languages such as Chinese that don't use whitespace for word separation,
+  user need add the `use_word_boundaries: False` option, the default being `use_word_boundaries: True`.
+
   ```yaml-rasa
   pipeline:
   - name: "RegexFeaturizer"
     # Text will be processed with case sensitive as default
     "case_sensitive": True
+    # use match word boundaries for lookup table
+    "use_word_boundaries": True
   ```
 
 

--- a/rasa/nlu/extractors/regex_entity_extractor.py
+++ b/rasa/nlu/extractors/regex_entity_extractor.py
@@ -33,6 +33,8 @@ class RegexEntityExtractor(EntityExtractor):
         "use_lookup_tables": True,
         # use regexes to extract entities
         "use_regexes": True,
+        # use match word boundaries for lookup table
+        "use_word_boundaries": True,
     }
 
     def __init__(
@@ -40,6 +42,7 @@ class RegexEntityExtractor(EntityExtractor):
         component_config: Optional[Dict[Text, Any]] = None,
         patterns: Optional[List[Dict[Text, Text]]] = None,
     ):
+        """Extracts entities using the lookup tables and/or regexes defined in the training data."""
         super(RegexEntityExtractor, self).__init__(component_config)
 
         self.case_sensitive = self.component_config["case_sensitive"]
@@ -56,6 +59,7 @@ class RegexEntityExtractor(EntityExtractor):
             use_lookup_tables=self.component_config["use_lookup_tables"],
             use_regexes=self.component_config["use_regexes"],
             use_only_entities=True,
+            use_word_boundaries=self.component_config["use_word_boundaries"],
         )
 
         if not self.patterns:

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -51,7 +51,7 @@ class RegexFeaturizer(SparseFeaturizer):
         component_config: Optional[Dict[Text, Any]] = None,
         known_patterns: Optional[List[Dict[Text, Text]]] = None,
     ) -> None:
-
+        """Construct new features for regexes and lookup table using regex expressions."""
         super().__init__(component_config)
 
         self.known_patterns = known_patterns if known_patterns else []

--- a/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/regex_featurizer.py
@@ -42,6 +42,8 @@ class RegexFeaturizer(SparseFeaturizer):
         "use_lookup_tables": True,
         # use regexes to generate features
         "use_regexes": True,
+        # use match word boundaries for lookup table
+        "use_word_boundaries": True,
     }
 
     def __init__(
@@ -66,6 +68,7 @@ class RegexFeaturizer(SparseFeaturizer):
             training_data,
             use_lookup_tables=self.component_config["use_lookup_tables"],
             use_regexes=self.component_config["use_regexes"],
+            use_word_boundaries=self.component_config["use_word_boundaries"],
         )
 
         for example in training_data.training_examples:

--- a/rasa/nlu/utils/pattern_utils.py
+++ b/rasa/nlu/utils/pattern_utils.py
@@ -10,7 +10,8 @@ def _convert_lookup_tables_to_regex(
     use_only_entities: bool = False,
     use_word_boundaries: bool = True,
 ) -> List[Dict[Text, Text]]:
-    """Convert the lookup tables from the training data to regex patterns.
+    r"""Convert the lookup tables from the training data to regex patterns.
+
     Args:
         training_data: The training data.
         use_only_entities: If True only regex features with a name equal to a entity
@@ -34,7 +35,7 @@ def _convert_lookup_tables_to_regex(
 def _generate_lookup_regex(
     lookup_table: Dict[Text, Union[Text, List[Text]]], use_word_boundaries: bool = True
 ) -> Text:
-    """Creates a regex pattern from the given lookup table.
+    r"""Creates a regex pattern from the given lookup table.
 
     The lookup table is either a file or a list of entries.
 
@@ -121,7 +122,7 @@ def extract_patterns(
     use_only_entities: bool = False,
     use_word_boundaries: bool = True,
 ) -> List[Dict[Text, Text]]:
-    """Extract a list of patterns from the training data.
+    r"""Extract a list of patterns from the training data.
 
     The patterns are constructed using the regex features and lookup tables defined
     in the training data.

--- a/rasa/nlu/utils/pattern_utils.py
+++ b/rasa/nlu/utils/pattern_utils.py
@@ -6,13 +6,17 @@ from rasa.shared.nlu.training_data.training_data import TrainingData
 
 
 def _convert_lookup_tables_to_regex(
-    training_data: TrainingData, use_only_entities: bool = False
+    training_data: TrainingData,
+    use_only_entities: bool = False,
+    use_word_boundaries: bool = True,
 ) -> List[Dict[Text, Text]]:
     """Convert the lookup tables from the training data to regex patterns.
     Args:
         training_data: The training data.
         use_only_entities: If True only regex features with a name equal to a entity
           are considered.
+        use_word_boundaries: If True add `\b` around the regex expression
+          for each lookup table expressions.
 
     Returns:
         A list of regex patterns.
@@ -21,19 +25,23 @@ def _convert_lookup_tables_to_regex(
     for table in training_data.lookup_tables:
         if use_only_entities and table["name"] not in training_data.entities:
             continue
-        regex_pattern = _generate_lookup_regex(table)
+        regex_pattern = _generate_lookup_regex(table, use_word_boundaries)
         lookup_regex = {"name": table["name"], "pattern": regex_pattern}
         patterns.append(lookup_regex)
     return patterns
 
 
-def _generate_lookup_regex(lookup_table: Dict[Text, Union[Text, List[Text]]]) -> Text:
+def _generate_lookup_regex(
+    lookup_table: Dict[Text, Union[Text, List[Text]]], use_word_boundaries: bool = True
+) -> Text:
     """Creates a regex pattern from the given lookup table.
 
     The lookup table is either a file or a list of entries.
 
     Args:
         lookup_table: The lookup table.
+        use_word_boundaries: If True add `\b` around the regex expression
+          for each lookup table expressions.
 
     Returns:
         The regex pattern.
@@ -50,8 +58,11 @@ def _generate_lookup_regex(lookup_table: Dict[Text, Union[Text, List[Text]]]) ->
     # sanitize the regex, escape special characters
     elements_sanitized = [re.escape(e) for e in elements_to_regex]
 
-    # regex matching elements with word boundaries on either side
-    return "(\\b" + "\\b|\\b".join(elements_sanitized) + "\\b)"
+    if use_word_boundaries:
+        # regex matching elements with word boundaries on either side
+        return "(\\b" + "\\b|\\b".join(elements_sanitized) + "\\b)"
+    else:
+        return "(" + "|".join(elements_sanitized) + ")"
 
 
 def read_lookup_table_file(lookup_table_file: Text) -> List[Text]:
@@ -108,6 +119,7 @@ def extract_patterns(
     use_lookup_tables: bool = True,
     use_regexes: bool = True,
     use_only_entities: bool = False,
+    use_word_boundaries: bool = True,
 ) -> List[Dict[Text, Text]]:
     """Extract a list of patterns from the training data.
 
@@ -120,6 +132,7 @@ def extract_patterns(
           equal to a entity are considered.
         use_regexes: Boolean indicating whether to use regex features or not.
         use_lookup_tables: Boolean indicating whether to use lookup tables or not.
+        use_word_boundaries: Boolean indicating whether to use `\b` around the lookup table regex expressions
 
     Returns:
         The list of regex patterns.
@@ -133,7 +146,9 @@ def extract_patterns(
         patterns.extend(_collect_regex_features(training_data, use_only_entities))
     if use_lookup_tables:
         patterns.extend(
-            _convert_lookup_tables_to_regex(training_data, use_only_entities)
+            _convert_lookup_tables_to_regex(
+                training_data, use_only_entities, use_word_boundaries
+            )
         )
 
     return patterns


### PR DESCRIPTION
**Proposed changes**:
- Add use_word_boundaries option for RegexFeaturizer to control the lookup table regex generation

**Proposal**

Need the user specifies the option (`use_word_boundaries=False`) manually, it will equal to:

```python
result = list(re.finditer("(上海|北京)", "明天上海的天气", flags=0))
print(result)
```

result:
```text
[<_sre.SRE_Match object; span=(2, 4), match='上海'>]
```

fixs #7421 
fixs #7091

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
