### PR TITLE
Use response selector keys for confusion matrix labelling

### DIFF
--- a/changelog/7423.improvement.md
+++ b/changelog/7423.improvement.md
@@ -1,0 +1,1 @@
+Use response selector keys (sub-intents) as labels for plotting the confusion matrix during NLU evaluation to improve readability.

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -31,7 +31,7 @@ from rasa.nlu.constants import (
     ENTITY_ATTRIBUTE_TYPE,
     ENTITY_ATTRIBUTE_GROUP,
     ENTITY_ATTRIBUTE_ROLE,
-    RESPONSE_KEY_ATTRIBUTE
+    RESPONSE_KEY_ATTRIBUTE,
 )
 from rasa.model import get_model
 from rasa.nlu import config, training_data, utils
@@ -1056,7 +1056,9 @@ def get_eval_data(
             ).get("full_retrieval_intent", {})
 
             if isinstance(response_prediction_full_intent, str):
-                response_prediction_full_intent = response_prediction_full_intent.split("/")[1]
+                response_prediction_full_intent = response_prediction_full_intent.split(
+                    "/"
+                )[1]
 
             response_target = example.get("response", "")
             response_key = example.get(RESPONSE_KEY_ATTRIBUTE, "")

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -471,14 +471,18 @@ def test_response_evaluation_report(tmpdir_factory):
     response_results = [
         ResponseSelectionEvaluationResult(
             "chitchat",
+            "weather",
             "It's sunny in Berlin",
+            "weather",
             "It's sunny in Berlin",
             "What's the weather",
             0.65432,
         ),
         ResponseSelectionEvaluationResult(
             "chitchat",
+            "bot_name",
             "My name is Mr.bot",
+            "bot_name",
             "My name is Mr.bot",
             "What's your name?",
             0.98765,
@@ -506,7 +510,7 @@ def test_response_evaluation_report(tmpdir_factory):
     }
 
     assert len(report.keys()) == 5
-    assert report["My name is Mr.bot"] == name_query_results
+    assert report["bot_name"] == name_query_results
     assert result["predictions"][1] == prediction
 
 
@@ -591,11 +595,13 @@ def test_empty_intent_removal():
 def test_empty_response_removal():
     response_results = [
         ResponseSelectionEvaluationResult(
-            "chitchat", None, "It's sunny in Berlin", "What's the weather", 0.65432
+            "chitchat", None, None, "It's sunny in Berlin", None, "What's the weather", 0.65432
         ),
         ResponseSelectionEvaluationResult(
             "chitchat",
+            None,
             "My name is Mr.bot",
+            None,
             "My name is Mr.bot",
             "What's your name?",
             0.98765,

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -595,7 +595,13 @@ def test_empty_intent_removal():
 def test_empty_response_removal():
     response_results = [
         ResponseSelectionEvaluationResult(
-            "chitchat", None, None, "It's sunny in Berlin", None, "What's the weather", 0.65432
+            "chitchat",
+            None,
+            None,
+            "It's sunny in Berlin",
+            None,
+            "What's the weather",
+            0.65432,
         ),
         ResponseSelectionEvaluationResult(
             "chitchat",

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -470,22 +470,10 @@ def test_response_evaluation_report(tmpdir_factory):
 
     response_results = [
         ResponseSelectionEvaluationResult(
-            "chitchat",
-            "weather",
-            "It's sunny in Berlin",
-            "weather",
-            "It's sunny in Berlin",
-            "What's the weather",
-            0.65432,
+            "weather/ask_weather", "weather/ask_weather", "What's the weather", 0.65432,
         ),
         ResponseSelectionEvaluationResult(
-            "chitchat",
-            "bot_name",
-            "My name is Mr.bot",
-            "bot_name",
-            "My name is Mr.bot",
-            "What's your name?",
-            0.98765,
+            "faq/ask_name", "faq/ask_name", "What's your name?", 0.98765,
         ),
     ]
 
@@ -503,14 +491,13 @@ def test_response_evaluation_report(tmpdir_factory):
 
     prediction = {
         "text": "What's your name?",
-        "intent_target": "chitchat",
-        "response_target": "My name is Mr.bot",
-        "response_predicted": "My name is Mr.bot",
+        "response_key": "faq/ask_name",
+        "response_predicted": "faq/ask_name",
         "confidence": 0.98765,
     }
 
     assert len(report.keys()) == 5
-    assert report["bot_name"] == name_query_results
+    assert report["faq/ask_name"] == name_query_results
     assert result["predictions"][1] == prediction
 
 
@@ -594,31 +581,16 @@ def test_empty_intent_removal():
 
 def test_empty_response_removal():
     response_results = [
+        ResponseSelectionEvaluationResult(None, None, "What's the weather", 0.65432,),
         ResponseSelectionEvaluationResult(
-            "chitchat",
-            None,
-            None,
-            "It's sunny in Berlin",
-            None,
-            "What's the weather",
-            0.65432,
-        ),
-        ResponseSelectionEvaluationResult(
-            "chitchat",
-            None,
-            "My name is Mr.bot",
-            None,
-            "My name is Mr.bot",
-            "What's your name?",
-            0.98765,
+            "faq/ask_name", "faq/ask_name", "What's your name?", 0.98765,
         ),
     ]
     response_results = remove_empty_response_examples(response_results)
 
     assert len(response_results) == 1
-    assert response_results[0].intent_target == "chitchat"
-    assert response_results[0].response_target == "My name is Mr.bot"
-    assert response_results[0].response_prediction == "My name is Mr.bot"
+    assert response_results[0].response_key == "faq/ask_name"
+    assert response_results[0].response_prediction_full_intent == "faq/ask_name"
     assert response_results[0].confidence == 0.98765
     assert response_results[0].message == "What's your name?"
 


### PR DESCRIPTION
**Proposed changes**:
- At the moment, when running an NLU evaluation for response selectors the plotted confusion matrix with use the training data utterances as plot labels. This small PR uses the response selector keys and predicted (sub)-intents as labels instead. This make the confusion matrix a lot more readable and useful.
- Similarly, the `response_selection_report.json` uses the same labels leading to better comprehension.

**Examples** 
Before 
![response_selection_confmat_old](https://user-images.githubusercontent.com/1105056/100725470-5eadff00-33c4-11eb-8d24-d911aa42f0e0.png)

After

![response_selection_confmat copy](https://user-images.githubusercontent.com/1105056/100725128-f2330000-33c3-11eb-8d17-f7740a3f564f.png)


**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
