### PR TITLE
Remove word boundary added to regex for RegexFeaturizer and RegexEntityExtractor

### DIFF
--- a/rasa/nlu/utils/pattern_utils.py
+++ b/rasa/nlu/utils/pattern_utils.py
@@ -51,7 +51,7 @@ def _generate_lookup_regex(lookup_table: Dict[Text, Union[Text, List[Text]]]) ->
     elements_sanitized = [re.escape(e) for e in elements_to_regex]
 
     # regex matching elements with word boundaries on either side
-    return "(\\b" + "\\b|\\b".join(elements_sanitized) + "\\b)"
+    return "(" + "|".join(elements_sanitized) + ")"
 
 
 def read_lookup_table_file(lookup_table_file: Text) -> List[Text]:

--- a/tests/nlu/utils/test_pattern_utils.py
+++ b/tests/nlu/utils/test_pattern_utils.py
@@ -13,7 +13,7 @@ from rasa.shared.nlu.training_data.message import Message
         (
             {"name": "person", "elements": ["Max", "John"]},
             {},
-            [{"name": "person", "pattern": "(\\bMax\\b|\\bJohn\\b)"}],
+            [{"name": "person", "pattern": "(Max|John)"}],
         ),
         ({}, {}, []),
         (
@@ -26,7 +26,7 @@ from rasa.shared.nlu.training_data.message import Message
             {"name": "zipcode", "pattern": "[0-9]{5}"},
             [
                 {"name": "zipcode", "pattern": "[0-9]{5}"},
-                {"name": "person", "pattern": "(\\bMax\\b|\\bJohn\\b)"},
+                {"name": "person", "pattern": "(Max|John)"},
             ],
         ),
         (
@@ -36,7 +36,7 @@ from rasa.shared.nlu.training_data.message import Message
                 {"name": "zipcode", "pattern": "[0-9]{5}"},
                 {
                     "name": "plates",
-                    "pattern": "(\\btacos\\b|\\bbeef\\b|\\bmapo\\ tofu\\b|\\bburrito\\b|\\blettuce\\ wrap\\b)",
+                    "pattern": "(tacos|beef|mapo\\ tofu|burrito|lettuce\\ wrap)",
                 },
             ],
         ),
@@ -101,7 +101,7 @@ def test_extract_patterns_use_only_entities_regexes(
         (
             "person",
             {"name": "person", "elements": ["Max", "John"]},
-            [{"name": "person", "pattern": "(\\bMax\\b|\\bJohn\\b)"}],
+            [{"name": "person", "pattern": "(Max|John)"}],
         ),
         ("entity", {"name": "person", "elements": ["Max", "John"]}, []),
     ],
@@ -148,7 +148,7 @@ def test_extract_patterns_use_only_entities_lookup_tables(
             {"name": "zipcode", "pattern": "[0-9]{5}"},
             True,
             False,
-            [{"name": "person", "pattern": "(\\bMax\\b|\\bJohn\\b)"}],
+            [{"name": "person", "pattern": "(Max|John)"}],
         ),
         (
             {"name": "person", "elements": ["Max", "John"]},


### PR DESCRIPTION
Fixes RasaHQ/rasa#7167
**Proposed changes**:
Remove word boundary entirely.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
