### PR TITLE
[Feature] RedisSentinel support of RedisLockStore

### DIFF
--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -224,7 +224,7 @@ class RedisLockStore(LockStore):
         """
         import redis
 
-        if sentinel_name is None:
+        if sentinel_url is None:
             self.red = redis.StrictRedis(
                 host=host,
                 port=int(port),


### PR DESCRIPTION
Fixes: #3924

**Proposed changes**:
- Add Redis Sentinel functionality to the Lock Store

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

# TODO: haven't added any tests -- would like some guidance/recommendations and feedback from the contributors

This is the configuration my rasa deployment is currently using to integrate with my Redis Sentinel Cluster which I have as a service in kubernetes - the `sentinel_url` is currently DNS of the namespace and service which GKE resolves to an IP address so we can deploy the LockStore without a fixed IP

I welcome suggestions but feel that the decomposition pattern is a clean way to integrate Sentinel into the code.