### PR TITLE
Sync extra actions and intents from domain into training data

### DIFF
--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -566,7 +566,7 @@ class CountVectorsFeaturizer(SparseFeaturizer):
             attribute_vocabulary = self.vectorizers[attribute].vocabulary_
             first_empty_index = self._get_starting_empty_index(attribute_vocabulary)
             logger.info(
-                f"{first_empty_index - 1} vocabulary slots "
+                f"{first_empty_index} vocabulary slots "
                 f"consumed out of {len(attribute_vocabulary)} "
                 f"slots configured for {attribute} attribute."
             )

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -285,6 +285,14 @@ class CombinedDataImporter(TrainingDataImporter):
 
     @rasa.shared.utils.common.cached_method
     async def get_nlu_data(self, language: Optional[Text] = "en") -> TrainingData:
+        """Gets NLU data from NLU training files and domain.
+
+        Args:
+            language: Language of training data
+
+        Returns:
+            Loaded training data from all sources
+        """
         nlu_data = [importer.get_nlu_data(language) for importer in self._importers]
         nlu_data = await asyncio.gather(
             *nlu_data, self._additional_training_data_from_domain(),

--- a/rasa/shared/importers/importer.py
+++ b/rasa/shared/importers/importer.py
@@ -294,37 +294,11 @@ class CombinedDataImporter(TrainingDataImporter):
             Loaded training data from all sources
         """
         nlu_data = [importer.get_nlu_data(language) for importer in self._importers]
-        nlu_data = await asyncio.gather(
-            *nlu_data, self._additional_training_data_from_domain(),
-        )
+        nlu_data = await asyncio.gather(*nlu_data)
 
         return reduce(
             lambda merged, other: merged.merge(other), nlu_data, TrainingData()
         )
-
-    async def _additional_training_data_from_domain(self) -> TrainingData:
-        domain = await self.get_domain()
-
-        # These messages help to build the complete vocabulary
-        # of labels(intents, action_names) inside NLU components.
-        # The reason why these could be missed otherwise is that
-        # every label defined in the domain is not guaranteed to
-        # appear in NLU training data or Core training data
-        # and hence can be problematic for incremental training
-        # if not taken into account.
-        additional_messages_from_domain = [
-            Message(data={ACTION_NAME: action_name})
-            for action_name in domain.action_names
-        ] + [
-            Message(data={INTENT: intent})
-            for intent in domain.intents
-            if intent not in rasa.shared.core.constants.DEFAULT_INTENTS
-        ]
-        logger.debug(
-            f"Added {len(additional_messages_from_domain)} training data examples "
-            f"from domain."
-        )
-        return TrainingData(additional_messages_from_domain)
 
 
 class RetrievalModelsDataImporter(TrainingDataImporter):
@@ -463,6 +437,7 @@ class RetrievalModelsDataImporter(TrainingDataImporter):
 class E2EImporter(TrainingDataImporter):
     """Importer which
     - enhances the NLU training data with actions / user messages from the stories.
+    - enhances the NLU training data with intents and actions from domain.
     - adds potential end-to-end bot messages from stories as actions to the domain
     """
 
@@ -517,6 +492,7 @@ class E2EImporter(TrainingDataImporter):
         training_datasets += await asyncio.gather(
             self.importer.get_nlu_data(language),
             self._additional_training_data_from_stories(),
+            self._additional_training_data_from_domain(),
         )
 
         return reduce(
@@ -547,6 +523,30 @@ class E2EImporter(TrainingDataImporter):
             f"from the story training data."
         )
         return TrainingData(additional_messages_from_stories)
+
+    async def _additional_training_data_from_domain(self) -> TrainingData:
+        domain = await self.get_domain()
+
+        # These messages help to build the complete vocabulary
+        # of labels(intents, action_names) inside NLU components.
+        # The reason why these could be missed otherwise is that
+        # every label defined in the domain is not guaranteed to
+        # appear in NLU training data or Core training data
+        # and hence can be problematic for incremental training
+        # if not taken into account.
+        additional_messages_from_domain = [
+            Message(data={ACTION_NAME: action_name})
+            for action_name in domain.action_names
+        ] + [
+            Message(data={INTENT: intent})
+            for intent in domain.intents
+            if intent not in rasa.shared.core.constants.DEFAULT_INTENTS
+        ]
+        logger.debug(
+            f"Added {len(additional_messages_from_domain)} training data examples "
+            f"from domain."
+        )
+        return TrainingData(additional_messages_from_domain)
 
 
 def _unique_events_from_stories(

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -319,7 +319,7 @@ class Message:
     def is_core_message(self) -> bool:
         """Checks whether the message is a core message or not.
 
-        E.g. a core message is created from a story, not from the NLU data.
+        E.g. a core message is created from a story or domain, not from the NLU data.
 
         Returns:
             True, if message is a core message, false otherwise.

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -85,7 +85,7 @@ class TrainingData:
         Returns:
             hex string as a fingerprint of the training data labels.
         """
-        return rasa.shared.utils.io.deep_container_fingerprint(self.intents)
+        return rasa.shared.utils.io.deep_container_fingerprint(sorted(self.intents))
 
     def merge(self, *others: Optional["TrainingData"]) -> "TrainingData":
         """Return merged instance of this data with other training data.

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -236,6 +236,64 @@ async def test_import_nlu_training_data_from_e2e_stories(
     assert all(m in nlu_data.training_examples for m in expected_additional_messages)
 
 
+async def test_import_nlu_training_data_from_domain(
+    default_importer: TrainingDataImporter,
+):
+    # The `E2EImporter` correctly wraps the underlying `CombinedDataImporter`
+    assert isinstance(default_importer, E2EImporter)
+    importer_without_e2e = default_importer.importer
+
+    stories = StoryGraph(
+        [
+            StoryStep(
+                events=[
+                    SlotSet("some slot", "doesn't matter"),
+                    UserUttered(intent={"name": "greet_from_stories"}),
+                    ActionExecuted("utter_greet_from_stories"),
+                ]
+            ),
+            StoryStep(
+                events=[
+                    UserUttered("how are you doing?"),
+                    ActionExecuted(action_text="Hi Joey."),
+                ]
+            ),
+        ]
+    )
+
+    async def mocked_stories(*_: Any, **__: Any) -> StoryGraph:
+        return stories
+
+    # Patch to return our test stories
+    importer_without_e2e.get_stories = mocked_stories
+
+    # The wrapping `E2EImporter` simply forwards these method calls
+    assert (await importer_without_e2e.get_stories()).as_story_string() == (
+        await default_importer.get_stories()
+    ).as_story_string()
+    assert (await importer_without_e2e.get_config()) == (
+        await default_importer.get_config()
+    )
+
+    # Check additional NLU training data from stories was added
+    nlu_data = await default_importer.get_nlu_data()
+
+    # The `E2EImporter` adds NLU training data based on our training stories
+    assert len(nlu_data.training_examples) > len(
+        (await importer_without_e2e.get_nlu_data()).training_examples
+    )
+
+    # Check if the NLU training data was added correctly from the story training data
+    expected_additional_messages = [
+        Message(data={INTENT: "greet_from_stories"}),
+        Message(data={ACTION_NAME: "utter_greet_from_stories"}),
+        Message(data={TEXT: "how are you doing?"}),
+        Message(data={ACTION_TEXT: "Hi Joey."}),
+    ]
+
+    assert all(m in nlu_data.training_examples for m in expected_additional_messages)
+
+
 async def test_different_story_order_doesnt_change_nlu_training_data(
     default_importer: E2EImporter,
 ):

--- a/tests/shared/importers/test_importer.py
+++ b/tests/shared/importers/test_importer.py
@@ -236,7 +236,7 @@ async def test_import_nlu_training_data_from_e2e_stories(
     assert all(m in nlu_data.training_examples for m in expected_additional_messages)
 
 
-async def test_import_nlu_training_data_from_domain(project: Text,):
+async def test_import_nlu_training_data_from_domain(project: Text):
     domain_path = "data/test_domains/default.yml"
     config_path = Path(project) / DEFAULT_CONFIG_PATH
 


### PR DESCRIPTION
**Proposed changes**:
- Sync extra actions and intents from domain into training data so that vocabulary of CVF for labels is complete according to the domain.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
