### PR TITLE
Amendmend to PR #7423

### DIFF
--- a/changelog/7575.bugfix.rst
+++ b/changelog/7575.bugfix.rst
@@ -1,0 +1,1 @@
+Fix scikit-learn crashing during response selector evaluation.

--- a/changelog/7575.bugfix.rst
+++ b/changelog/7575.bugfix.rst
@@ -1,1 +1,1 @@
-Fix scikit-learn crashing during response selector evaluation.
+Fix scikit-learn crashing during evaluation of `ResponseSelector` predictions.

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -1052,9 +1052,11 @@ def get_eval_data(
 
             response_prediction_full_intent = selector_properties.get(
                 response_prediction_key, {}
-            ).get("full_retrieval_intent", {})
+            ).get("full_retrieval_intent", None)
 
-            response_key = example.get_combined_intent_response_key()
+            response_key = None
+            if example.get(RESPONSE_KEY_ATTRIBUTE) is not None:
+                response_key = example.get_combined_intent_response_key()
 
             response_selection_results.append(
                 ResponseSelectionEvaluationResult(


### PR DESCRIPTION
**Proposed changes**:
@dakshvar22 To my dismay I discovered that my refactoring reintroduced a bug in my original PR #7423. Unfortunately, it was not captured by any of the unit the tests. I came across it when running a new response selector evaluation today. This PR should fix it.

In short, the default value for a response selector key was wrong. It needs to default to `None` for all "regular" intent examples or otherwise those won't be filtered out further down the pipeline and crash the sklearn reports.

cc @tmbo 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
