### PR TITLE
Temporarily disable windows 3.8 CI tests

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -265,7 +265,7 @@ jobs:
         make prepare-tests-windows
 
     - name: Test Code 🔍
-      if: needs.changes.outputs.backend == 'true'
+      if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest')
       env:
         JOBS: 2
         PYTHONIOENCODING: "utf-8"


### PR DESCRIPTION
This PR temporarily disables windows 3.8 CI tests.