### PR TITLE
Do not break if update.message is None

### DIFF
--- a/rasa/core/channels/telegram.py
+++ b/rasa/core/channels/telegram.py
@@ -212,9 +212,9 @@ class TelegramInput(InputChannel):
                     text = update.callback_query.data
                 else:
                     msg = update.message
-                    if self._is_user_message(msg):
+                    if msg is not None and self._is_user_message(msg):
                         text = msg.text.replace("/bot", "")
-                    elif self._is_location(msg):
+                    elif msg is not None and self._is_location(msg):
                         text = '{{"lng":{0}, "lat":{1}}}'.format(
                             msg.location.longitude, msg.location.latitude
                         )


### PR DESCRIPTION
If the update doesn't contain a message, which is true for edited
messages, return a successful response instead of raising an exception
and returning an error to Telegram.

Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>

Issue: https://github.com/RasaHQ/rasa/issues/7686