### PR TITLE
use session scoped formbot agent fixture

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 
+from rasa.utils.endpoints import EndpointConfig
 from sanic.request import Request
 import uuid
 from datetime import datetime
@@ -201,8 +202,10 @@ def default_tracker(default_domain: Domain) -> DialogueStateTracker:
     return DialogueStateTracker("my-sender", default_domain.slots)
 
 
-@pytest.fixture
-async def form_bot_agent(trained_async) -> Agent:
+@pytest.fixture(scope="session")
+async def form_bot_agent(trained_async: Callable) -> Agent:
+    endpoint = EndpointConfig("https://example.com/webhooks/actions")
+
     zipped_model = await trained_async(
         domain="examples/formbot/domain.yml",
         config="examples/formbot/config.yml",
@@ -212,7 +215,7 @@ async def form_bot_agent(trained_async) -> Agent:
         ],
     )
 
-    return Agent.load_local_model(zipped_model)
+    return Agent.load_local_model(zipped_model, action_endpoint=endpoint)
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -1,16 +1,10 @@
-import sys
-
 import json
-from pathlib import Path
-from typing import Text
+from typing import Text, Optional
 
 from aioresponses import aioresponses
 
 from rasa.core.agent import Agent
-from rasa.core.train import train
-from rasa.core.utils import AvailableEndpoints
-from rasa.shared.importers.importer import TrainingDataImporter
-from rasa.utils.endpoints import EndpointConfig, ClientResponseError
+from rasa.utils.endpoints import ClientResponseError
 
 
 async def test_moodbot_example(unpacked_trained_moodbot_path: Text):
@@ -26,29 +20,10 @@ async def test_moodbot_example(unpacked_trained_moodbot_path: Text):
     assert len(responses) == 4
 
 
-async def test_formbot_example():
-    sys.path.append("examples/formbot/")
-    project = Path("examples/formbot/")
-    config = str(project / "config.yml")
-    domain = str(project / "domain.yml")
-    training_dir = project / "data"
-    training_files = [
-        str(training_dir / "rules.yml"),
-        str(training_dir / "stories.yml"),
-    ]
-    importer = TrainingDataImporter.load_from_config(config, domain, training_files)
-
-    endpoint = EndpointConfig("https://example.com/webhooks/actions")
-    endpoints = AvailableEndpoints(action=endpoint)
-    agent = await train(
-        domain,
-        importer,
-        str(project / "models" / "dialogue"),
-        endpoints=endpoints,
-        policy_config="examples/formbot/config.yml",
-    )
-
-    async def mock_form_happy_path(input_text, output_text, slot=None):
+async def test_formbot_example(form_bot_agent: Agent):
+    async def mock_form_happy_path(
+        input_text: Text, output_text: Text, slot: Optional[Text] = None
+    ) -> None:
         if slot:
             form = "restaurant_form"
             template = f"utter_ask_{slot}"
@@ -71,10 +46,12 @@ async def test_formbot_example():
             mocked.post(
                 "https://example.com/webhooks/actions", payload=response, repeat=True
             )
-            responses = await agent.handle_text(input_text)
+            responses = await form_bot_agent.handle_text(input_text)
             assert responses[0]["text"] == output_text
 
-    async def mock_form_unhappy_path(input_text, output_text, slot):
+    async def mock_form_unhappy_path(
+        input_text: Text, output_text: Text, slot: Optional[Text]
+    ) -> None:
         response_error = {
             "error": f"Failed to extract slot {slot} with action restaurant_form",
             "action_name": "restaurant_form",
@@ -86,7 +63,7 @@ async def test_formbot_example():
                 repeat=True,
                 exception=ClientResponseError(400, "", json.dumps(response_error)),
             )
-            responses = await agent.handle_text(input_text)
+            responses = await form_bot_agent.handle_text(input_text)
             assert responses[0]["text"] == output_text
 
     await mock_form_happy_path("/request_restaurant", "What cuisine?", slot="cuisine")
@@ -101,10 +78,10 @@ async def test_formbot_example():
         "/affirm", "Please provide additional preferences", slot="preferences"
     )
 
-    responses = await agent.handle_text("/restart")
+    responses = await form_bot_agent.handle_text("/restart")
     assert responses[0]["text"] == "restarted"
 
-    responses = await agent.handle_text("/greet")
+    responses = await form_bot_agent.handle_text("/greet")
     assert (
         responses[0]["text"]
         == "Hello! I am restaurant search assistant! How can I help?"
@@ -131,5 +108,5 @@ async def test_formbot_example():
     )
     await mock_form_happy_path('/inform{"feedback": "great"}', "All done!")
 
-    responses = await agent.handle_text("/thankyou")
+    responses = await form_bot_agent.handle_text("/thankyou")
     assert responses[0]["text"] == "You are welcome :)"

--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -1,6 +1,7 @@
 import json
 from typing import Text, Optional
 
+import pytest
 from aioresponses import aioresponses
 
 from rasa.core.agent import Agent
@@ -20,6 +21,7 @@ async def test_moodbot_example(unpacked_trained_moodbot_path: Text):
     assert len(responses) == 4
 
 
+@pytest.mark.timeout(300)
 async def test_formbot_example(form_bot_agent: Agent):
     async def mock_form_happy_path(
         input_text: Text, output_text: Text, slot: Optional[Text] = None


### PR DESCRIPTION
**Proposed changes**:
- use session scoped formbot fixture
- re-use fixture in `test_formbot` test to avoid extra model training
- this hopefully stabilizes failing Windows tests

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
