### PR TITLE
External Message Entity Auto-Filling Fix

### DIFF
--- a/changelog/7722.bugfix.md
+++ b/changelog/7722.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug where, if a user injects an intent using the HTTP API, slot auto-filling is not performed on the entities provided.

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -405,7 +405,9 @@ class MessageProcessor:
                 f"Invalid entity specification: {entities}. Assuming no entities."
             )
             entity_list = []
-        tracker.update(UserUttered.create_external(intent_name, entity_list), self.domain)
+        tracker.update(
+            UserUttered.create_external(intent_name, entity_list), self.domain
+        )
         await self._predict_and_execute_next_action(output_channel, tracker)
         # save tracker state to continue conversation from this state
         self._save_tracker(tracker)

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -405,7 +405,7 @@ class MessageProcessor:
                 f"Invalid entity specification: {entities}. Assuming no entities."
             )
             entity_list = []
-        tracker.update(UserUttered.create_external(intent_name, entity_list))
+        tracker.update(UserUttered.create_external(intent_name, entity_list), self.domain)
         await self._predict_and_execute_next_action(output_channel, tracker)
         # save tracker state to continue conversation from this state
         self._save_tracker(tracker)


### PR DESCRIPTION
External Message Entity Auto-Filling Fix

**Proposed changes**:
- Fixed external message's tracker update call to enable slot-autofilling when an entity is passed in via the [trigger_intent API endpoint](https://rasa.com/docs/rasa/pages/http-api#operation/triggerConversationIntent)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
