### PR TITLE
typofix: 'Ctr-c' -> 'Ctrl-c'

### DIFF
--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -1428,7 +1428,7 @@ def _print_help(skip_visualization: bool) -> None:
     rasa.shared.utils.cli.print_success(
         f"Bot loaded. {visualization_help}\n"
         f"Type a message and press enter "
-        f"(press 'Ctr-c' to exit)."
+        f"(press 'Ctrl-c' to exit)."
     )
 
 


### PR DESCRIPTION
A tiny typofix for `rasa interactive`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
