### PR TITLE
Updated docs for slot type any

### DIFF
--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -343,8 +343,11 @@ information before it is able to predict the weather.
 * **Description**
 
   Slots of type `any` are always ignored during conversations. The property
-  `influence_conversation` cannot be set to `true` for this slot type. If you want to
-  store a custom data structure which should influence the conversation, use a
+  `influence_conversation` cannot be set to `true` for this slot type. 
+  
+  In stories, while annotating slots of type `any` that are in a list or dictionary format, include the set slot value inside single quotes. See example here in [stories](./writing-stories.mdx).
+  
+  If you want to store a custom data structure which should influence the conversation, use a
   [custom slot type](domain.mdx#custom-slot-types).
 
 #### Custom Slot Types

--- a/docs/docs/writing-stories.mdx
+++ b/docs/docs/writing-stories.mdx
@@ -105,6 +105,7 @@ stories:
    - action: action_check_profile
    - slot_was_set:
      - premium_account: true
+     - account_data: '{"id":"zpNi3JA2", "fullName":"Ada Lovelace", "accountRenewalDate":"October 3, 2021"}'
    - action: utter_welcome_premium
 
 - story: Welcome message, basic user
@@ -113,6 +114,7 @@ stories:
    - action: action_check_profile
    - slot_was_set:
      - premium_account: false
+     - account_data: '{"id":"3JcoaEa4", "fullName":"Jack Harkness"}'
    - action: utter_welcome_basic
    - action: utter_ask_upgrade
 ```


### PR DESCRIPTION
**Proposed changes**:
- The update is regarding insufficient documentation for slot type "any" where the the slot can carry a JSON or a list value.  This is not compatible when performing the migration or when generating new stories through `rasa interactive`.  The resulting training file (stories.yml) breaks any subsequent training.
- The corresponding issue has been discussed here in the forums - https://forum.rasa.com/t/the-slot-type-any-does-not-seem-to-work-correctly/38674/3
- The issue on Github has been raised here - https://github.com/RasaHQ/rasa/issues/7683 and is still open.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
