### PR TITLE
Support for writing NLU intent/example metadata to YAML

### DIFF
--- a/changelog/7731.improvement.md
+++ b/changelog/7731.improvement.md
@@ -1,0 +1,2 @@
+Add support for in `RasaYAMLWriter` for writing intent and example metadata back
+into NLU YAML files.

--- a/rasa/shared/nlu/training_data/formats/rasa_yaml.py
+++ b/rasa/shared/nlu/training_data/formats/rasa_yaml.py
@@ -507,7 +507,11 @@ class RasaYAMLWriter(TrainingDataWriter):
         intent_metadata = None
 
         for example in training_examples:
-            converted = {KEY_INTENT_TEXT: example_extraction_predicate(example)}
+            converted = {
+                KEY_INTENT_TEXT: example_extraction_predicate(example).strip(
+                    STRIP_SYMBOLS
+                )
+            }
 
             if isinstance(example, dict) and KEY_METADATA in example:
                 metadata = example[KEY_METADATA]
@@ -536,8 +540,6 @@ class RasaYAMLWriter(TrainingDataWriter):
     @staticmethod
     def _render_training_examples_as_text(examples: List[Dict]) -> List[Text]:
         def render(example: Dict) -> Text:
-            return TrainingDataWriter.generate_list_item(
-                example[KEY_INTENT_TEXT].strip(STRIP_SYMBOLS)
-            )
+            return TrainingDataWriter.generate_list_item(example[KEY_INTENT_TEXT])
 
         return LiteralScalarString("".join([render(example) for example in examples]))

--- a/rasa/shared/nlu/training_data/formats/rasa_yaml.py
+++ b/rasa/shared/nlu/training_data/formats/rasa_yaml.py
@@ -14,6 +14,7 @@ from rasa.shared.constants import (
     DOCS_URL_TRAINING_DATA,
     LATEST_TRAINING_DATA_FORMAT_VERSION,
 )
+from rasa.shared.nlu.constants import METADATA_INTENT, METADATA_EXAMPLE
 from rasa.shared.nlu.training_data.formats.readerwriter import (
     TrainingDataReader,
     TrainingDataWriter,
@@ -37,8 +38,6 @@ KEY_REGEX_EXAMPLES = "examples"
 KEY_LOOKUP = "lookup"
 KEY_LOOKUP_EXAMPLES = "examples"
 KEY_METADATA = "metadata"
-KEY_METADATA_INTENT = "intent"
-KEY_METADATA_EXAMPLE = "example"
 
 MULTILINE_TRAINING_EXAMPLE_LEADING_SYMBOL = "-"
 
@@ -516,11 +515,11 @@ class RasaYAMLWriter(TrainingDataWriter):
             if isinstance(example, dict) and KEY_METADATA in example:
                 metadata = example[KEY_METADATA]
 
-                if KEY_METADATA_EXAMPLE in metadata:
-                    converted[KEY_METADATA] = metadata[KEY_METADATA_EXAMPLE]
+                if METADATA_EXAMPLE in metadata:
+                    converted[KEY_METADATA] = metadata[METADATA_EXAMPLE]
 
-                if intent_metadata is None and KEY_METADATA_INTENT in metadata:
-                    intent_metadata = metadata[KEY_METADATA_INTENT]
+                if intent_metadata is None and METADATA_INTENT in metadata:
+                    intent_metadata = metadata[METADATA_INTENT]
 
             result.append(converted)
 

--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -69,8 +69,12 @@ class TrainingDataWriter:
     @staticmethod
     def generate_list_item(text: Text) -> Text:
         """Generates text for a list item."""
+        return f"- {TrainingDataWriter.generate_string_item(text)}"
 
-        return f"- {rasa.shared.nlu.training_data.util.encode_string(text)}\n"
+    @staticmethod
+    def generate_string_item(text: Text) -> Text:
+        """Generates text for a string item."""
+        return f"{rasa.shared.nlu.training_data.util.encode_string(text)}\n"
 
     @staticmethod
     def generate_message(message: Dict[Text, Any]) -> Text:

--- a/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
+++ b/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
@@ -28,6 +28,8 @@ nlu:
     - what's the carbon footprint of a flight from london to new york?
     - how much co2 to new york?
     - how much co2 is produced on a return flight from london to new york?
+    - what's the co2 usage of a return flight to new york?
+    - can you calculate the co2 footprint of a flight to london?
 """
 
 MULTILINE_INTENT_EXAMPLE_WITH_SYNONYM = """
@@ -65,6 +67,14 @@ nlu:
   examples: |
     - Hi
     - Hello
+- intent: goodbye
+  examples:
+  - text: |
+      bye
+    metadata: positive-sentiment
+  - text: |
+      goodbye
+    metadata: positive-sentiment
 """
 
 
@@ -152,7 +162,7 @@ def test_multiline_intent_is_parsed(example: Text):
 
     assert not len(record)
 
-    assert len(training_data.training_examples) == 5
+    assert len(training_data.training_examples) == 7
     assert training_data.training_examples[0].get(
         INTENT
     ) == training_data.training_examples[1].get(INTENT)
@@ -167,7 +177,7 @@ def test_intent_with_metadata_is_parsed():
 
     assert not len(record)
 
-    assert len(training_data.training_examples) == 5
+    assert len(training_data.training_examples) == 7
     example_1, example_2, *other_examples = training_data.training_examples
     assert example_1.get(METADATA) == {
         METADATA_INTENT: ["johnny"],

--- a/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
+++ b/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
@@ -201,9 +201,6 @@ def test_metadata_roundtrip():
 
     assert dumped_result.training_examples == result.training_examples
 
-    # dumping again should also not change the format
-    assert dumped == RasaYAMLWriter().dumps(dumped_result)
-
 
 def test_write_metadata_stripped():
     reader = RasaYAMLReader()

--- a/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
+++ b/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
@@ -195,6 +195,17 @@ def test_metadata_roundtrip():
     assert dumped == RasaYAMLWriter().dumps(dumped_result)
 
 
+def test_write_metadata_stripped():
+    reader = RasaYAMLReader()
+    result = reader.reads(INTENT_EXAMPLES_WITH_METADATA)
+
+    # Add strippable characters to first example text
+    result.training_examples[0].data["text"] += "    \r\n "
+
+    dumped = RasaYAMLWriter().dumps(result)
+    assert dumped == INTENT_EXAMPLES_WITH_METADATA
+
+
 # This test would work only with examples that have a `version` key specified
 @pytest.mark.parametrize(
     "example",

--- a/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
+++ b/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
@@ -66,6 +66,25 @@ nlu:
     - Hello
 """
 
+INTENT_EXAMPLES_WITH_METADATA_ROUNDTRIP = f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
+nlu:
+- intent: intent_name
+  examples:
+  - text: |
+      how much CO2 will that use?
+    metadata:
+      sentiment: positive
+  - text: |
+      how much carbon will a one way flight from [new york]{{"entity": "city", "role": "from"}} to california produce?
+    metadata: co2-trip-calculation
+  - text: |
+      how much CO2 to [new york]{{"entity": "city", "role": "to"}}?
+- intent: greet
+  examples: |
+    - Hi
+    - Hello
+"""
+
 MINIMAL_VALID_EXAMPLE = """
 nlu:\n
 stories:
@@ -175,6 +194,22 @@ def test_intent_with_metadata_is_parsed():
         METADATA_INTENT: ["johnny"],
         METADATA_EXAMPLE: "co2-trip-calculation",
     }
+
+
+def test_metadata_roundtrip():
+    reader = RasaYAMLReader()
+    result = reader.reads(INTENT_EXAMPLES_WITH_METADATA_ROUNDTRIP)
+
+    dumped = RasaYAMLWriter().dumps(result)
+    assert dumped == INTENT_EXAMPLES_WITH_METADATA_ROUNDTRIP
+
+    validation_reader = RasaYAMLReader()
+    dumped_result = validation_reader.reads(dumped)
+
+    assert dumped_result.training_examples == result.training_examples
+
+    # dumping again should also not change the format
+    assert dumped == RasaYAMLWriter().dumps(dumped_result)
 
 
 # This test would work only with examples that have a `version` key specified

--- a/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
+++ b/tests/shared/nlu/training_data/formats/test_rasa_yaml.py
@@ -61,29 +61,12 @@ nlu:
   - text: |
       how much CO2 to [new york]{{"entity": "city", "role": "to"}}?
 - intent: greet
+  metadata: initiate-conversation
   examples: |
     - Hi
     - Hello
 """
 
-INTENT_EXAMPLES_WITH_METADATA_ROUNDTRIP = f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
-nlu:
-- intent: intent_name
-  examples:
-  - text: |
-      how much CO2 will that use?
-    metadata:
-      sentiment: positive
-  - text: |
-      how much carbon will a one way flight from [new york]{{"entity": "city", "role": "from"}} to california produce?
-    metadata: co2-trip-calculation
-  - text: |
-      how much CO2 to [new york]{{"entity": "city", "role": "to"}}?
-- intent: greet
-  examples: |
-    - Hi
-    - Hello
-"""
 
 MINIMAL_VALID_EXAMPLE = """
 nlu:\n
@@ -198,10 +181,10 @@ def test_intent_with_metadata_is_parsed():
 
 def test_metadata_roundtrip():
     reader = RasaYAMLReader()
-    result = reader.reads(INTENT_EXAMPLES_WITH_METADATA_ROUNDTRIP)
+    result = reader.reads(INTENT_EXAMPLES_WITH_METADATA)
 
     dumped = RasaYAMLWriter().dumps(result)
-    assert dumped == INTENT_EXAMPLES_WITH_METADATA_ROUNDTRIP
+    assert dumped == INTENT_EXAMPLES_WITH_METADATA
 
     validation_reader = RasaYAMLReader()
     dumped_result = validation_reader.reads(dumped)


### PR DESCRIPTION
**Proposed changes**:
This adds support to the `RasaYAMLWriter` for writing intent and example metadata back into YAML files.
The parsing functionality has been added in #5989.

Fixes #7731 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- ~~[ ] updated the documentation~~
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
