### PR TITLE
valide slots when coming back from unhappy paths

### DIFF
--- a/changelog/7764.bugfix.md
+++ b/changelog/7764.bugfix.md
@@ -1,1 +1,1 @@
-Fixes a bug where the next slot asked was not consistent when returning to a form from an unhappy path
+Fixes a bug in [forms](forms.mdx) where the next slot asked was not consistent after returning to a form from an unhappy path.

--- a/changelog/7764.bugfix.md
+++ b/changelog/7764.bugfix.md
@@ -1,0 +1,1 @@
+Fixes a bug where the next slot asked was not consistent when returning to a form from an unhappy path

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -620,8 +620,9 @@ class FormAction(LoopAction):
             logger.debug(f"Validating user input '{tracker.latest_message}'.")
             return await self.validate(tracker, domain, output_channel, nlg)
         else:
-            # Needed to determine which slots to request although there are no slots to actually validate
-            # which happens when coming back to the form from an unhappy paths
+            # Needed to determine which slots to request although there are no slots
+            # to actually validate, which happens when coming back to the form from
+            # an unhappy paths
             return await self.validate_slots({}, tracker, domain, output_channel, nlg)
 
     @staticmethod

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -621,8 +621,8 @@ class FormAction(LoopAction):
             return await self.validate(tracker, domain, output_channel, nlg)
         else:
             # Needed to determine which slots to request although there are no slots
-            # to actually validate, which happens when coming back to the form from
-            # an unhappy paths
+            # to actually validate, which happens when coming back to the form after
+            # an unhappy path
             return await self.validate_slots({}, tracker, domain, output_channel, nlg)
 
     @staticmethod

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -615,12 +615,14 @@ class FormAction(LoopAction):
             tracker.latest_action_name == ACTION_LISTEN_NAME
             and not tracker.active_loop.get(LOOP_INTERRUPTED, False)
         )
+
         if needs_validation:
             logger.debug(f"Validating user input '{tracker.latest_message}'.")
             return await self.validate(tracker, domain, output_channel, nlg)
-
-        logger.debug("Skipping validation.")
-        return []
+        else:
+            # Needed to determine which slots to request although there are no slots to actually validate
+            # which happens when coming back to the form from an unhappy paths
+            return await self.validate_slots({}, tracker, domain, output_channel, nlg)
 
     @staticmethod
     def _should_request_slot(tracker: "DialogueStateTracker", slot_name: Text) -> bool:

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -352,7 +352,7 @@ async def test_validate_slots(
         assert events == expected_events
 
 
-async def test_request_correct_slots_from_unhappy_path_with_custom_required_slots():
+async def test_request_correct_slots_after_unhappy_path_with_custom_required_slots():
     form_name = "some_form"
     slot_name_1 = "slot_1"
     slot_name_2 = "slot_2"

--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -1,5 +1,5 @@
 import json
-from typing import Text, Optional
+from typing import Text, Optional, Dict, Any
 
 import pytest
 from aioresponses import aioresponses
@@ -23,16 +23,15 @@ async def test_moodbot_example(unpacked_trained_moodbot_path: Text):
 
 @pytest.mark.timeout(300)
 async def test_formbot_example(form_bot_agent: Agent):
-    async def mock_form_happy_path(
-        input_text: Text, output_text: Text, slot: Optional[Text] = None
-    ) -> None:
+    def response_for_slot(slot: Text) -> Dict[Text, Any]:
         if slot:
             form = "restaurant_form"
             template = f"utter_ask_{slot}"
         else:
             form = None
             template = "utter_submit"
-        response = {
+
+        return {
             "events": [
                 {"event": "form", "name": form, "timestamp": None},
                 {
@@ -44,9 +43,15 @@ async def test_formbot_example(form_bot_agent: Agent):
             ],
             "responses": [{"template": template}],
         }
+
+    async def mock_form_happy_path(
+        input_text: Text, output_text: Text, slot: Optional[Text] = None
+    ) -> None:
         with aioresponses() as mocked:
             mocked.post(
-                "https://example.com/webhooks/actions", payload=response, repeat=True
+                "https://example.com/webhooks/actions",
+                payload=response_for_slot(slot),
+                repeat=True,
             )
             responses = await form_bot_agent.handle_text(input_text)
             assert responses[0]["text"] == output_text
@@ -59,11 +64,17 @@ async def test_formbot_example(form_bot_agent: Agent):
             "action_name": "restaurant_form",
         }
         with aioresponses() as mocked:
-            # noinspection PyTypeChecker
+            # Request which rejects form form execution
             mocked.post(
                 "https://example.com/webhooks/actions",
-                repeat=True,
+                repeat=False,
                 exception=ClientResponseError(400, "", json.dumps(response_error)),
+            )
+            # Request after returning from unhappy path which sets next requested slot
+            mocked.post(
+                "https://example.com/webhooks/actions",
+                payload=response_for_slot(slot),
+                repeat=True,
             )
             responses = await form_bot_agent.handle_text(input_text)
             assert responses[0]["text"] == output_text

--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -64,7 +64,7 @@ async def test_formbot_example(form_bot_agent: Agent):
             "action_name": "restaurant_form",
         }
         with aioresponses() as mocked:
-            # Request which rejects form form execution
+            # Request which rejects form execution
             mocked.post(
                 "https://example.com/webhooks/actions",
                 repeat=False,


### PR DESCRIPTION
**Proposed changes**:
- Call the `validate_slots` function even if there are no slots to validate to get which slots to request next
- This fixes a bug where the next slot asked was not consistent when returning to a form from an unhappy path https://github.com/RasaHQ/rasa-sdk/issues/389

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
