### PR TITLE
Bugfix/pass metadata to remote action start event

### DIFF
--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -583,7 +583,8 @@ class RemoteAction(Action):
         """Expected response schema for an Action endpoint.
 
         Used for validation of the response returned from the
-        Action endpoint."""
+        Action endpoint.
+        """
         return {
             "type": "object",
             "properties": {

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -566,14 +566,17 @@ class RemoteAction(Action):
         from rasa.shared.core.trackers import EventVerbosity
 
         tracker_state = tracker.current_state(EventVerbosity.ALL)
-
-        return {
+        value = {
             "next_action": self._name,
             "sender_id": tracker.sender_id,
             "tracker": tracker_state,
             "domain": domain.as_dict(),
             "version": rasa.__version__,
         }
+
+        if self._name == ACTION_SESSION_START_NAME and hasattr(self, "metadata"):
+            value["metadata"] = self.__getattribute__("metadata")
+        return value
 
     @staticmethod
     def action_response_format_spec() -> Dict[Text, Any]:


### PR DESCRIPTION
**Proposed changes**:
- Fixed issue: https://github.com/RasaHQ/rasa/issues/7420
- Have created the PR as per the first approach mentioned here https://github.com/RasaHQ/rasa/issues/7420#issuecomment-763364402. This is just the producer part. Need to create PR for consumer part as well. But still don't know if that is good enough. This change will not break anything existing code as such.  

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
