### PR TITLE
Add __repr__ to Token

### DIFF
--- a/rasa/nlu/tokenizers/tokenizer.py
+++ b/rasa/nlu/tokenizers/tokenizer.py
@@ -60,6 +60,9 @@ class Token:
             other.lemma,
         )
 
+    def __repr__(self):
+        return f"<Token object value='{self.text}' start={self.start} end={self.end} at {hex(id(self))}>"
+
 
 class Tokenizer(Component):
     def __init__(self, component_config: Dict[Text, Any] = None) -> None:


### PR DESCRIPTION
Adds a `__repr__` to token. Part of issue https://github.com/RasaHQ/rasa/issues/7250. 

Haven't 100% decided what an ideal `__repr__` of the other message features might be. So I'll do that later in another PR. 