### PR TITLE
temporary fix of persisting entity tags

### DIFF
--- a/rasa/core/featurizers/tracker_featurizers.py
+++ b/rasa/core/featurizers/tracker_featurizers.py
@@ -294,6 +294,9 @@ class TrackerFeaturizer:
         featurizer_file = Path(path) / FEATURIZER_FILE
         rasa.shared.utils.io.create_directory_for_file(featurizer_file)
 
+        # entity tags are persisted in TED policy, they are not needed for prediction
+        self.state_featurizer.entity_tag_specs = None
+
         # noinspection PyTypeChecker
         rasa.shared.utils.io.write_text_file(
             str(jsonpickle.encode(self)), featurizer_file

--- a/rasa/core/featurizers/tracker_featurizers.py
+++ b/rasa/core/featurizers/tracker_featurizers.py
@@ -295,7 +295,8 @@ class TrackerFeaturizer:
         rasa.shared.utils.io.create_directory_for_file(featurizer_file)
 
         # entity tags are persisted in TED policy, they are not needed for prediction
-        self.state_featurizer.entity_tag_specs = None
+        if self.state_featurizer is not None:
+            self.state_featurizer.entity_tag_specs = None
 
         # noinspection PyTypeChecker
         rasa.shared.utils.io.write_text_file(


### PR DESCRIPTION
**Proposed changes**:
- entity tags is a list of named tuples with dicts inside. `jsonpickle.decode` cannot recreate the object. The proper fix requires significant refactor of entity tag spec. Created the issue for that: https://github.com/RasaHQ/rasa/issues/7870

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
