### PR TITLE
Rename _redirects to _headers and update X-Robots-Tag

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,4 +1,4 @@
 # target all pages
 /*
   # set noindex, no follow
-  X-Robots-Tag: noindex, nofollow
+  X-Robots-Tag: none

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,7 +182,7 @@ html_title = ""
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_extra_path = ["robots.txt", "_redirects"]
+html_extra_path = ["robots.txt", "_headers"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
**Proposed changes**:
- As @lunelson [mentioned](https://github.com/RasaHQ/rasa/pull/7844#issuecomment-770797441), the `_redirects` file doesn't actually work for headers. Renamed it and simplified the header rule

