### PR TITLE
Custom action modules

### DIFF
--- a/changelog/7888.improvement.md
+++ b/changelog/7888.improvement.md
@@ -1,0 +1,1 @@
+Allow registration of custom native actions by module path.

--- a/docs/docs/custom-actions.mdx
+++ b/docs/docs/custom-actions.mdx
@@ -9,7 +9,7 @@ Rasa supports two ways of implementing custom actions, using an action server, o
 importing a Python module accessible from your Rasa installation.
 
 
-### Using an Actions Server
+### Using an Action Server
 
 To specify an action server, set its URL under the `action_endpoint` key of `endpoints.yml`:
 
@@ -67,7 +67,7 @@ Your action server should respond with a list of events and responses:
 ```
 
 
-### Using an Action Server
+### Within Rasa itself
 
 Using a dedicated action server is the recommended way to implement custom behavior in Rasa.
 However, if your use case is not supported, it is also possible to bundle Rasa actions with

--- a/docs/docs/custom-actions.mdx
+++ b/docs/docs/custom-actions.mdx
@@ -5,6 +5,19 @@ title: Custom Actions
 abstract: A custom action can run any code you want, including API calls, database queries etc. They can turn on the lights, add an event to a calendar, check a user's bank balance, or anything else you can imagine.
 ---
 
+Rasa supports two ways of implementing custom actions, using an action server, or by
+importing a Python module accessible from your Rasa installation.
+
+
+### Using an Actions Server
+
+To specify an action server, set its URL under the `action_endpoint` key of `endpoints.yml`:
+
+```yaml-rasa
+action_endpoint:
+  url: "http://action-server:5055/webhook"
+```
+
 For details on how to implement a custom action, see the [SDK documentation](https://rasa.com/docs/action-server/running-action-server).
 Any custom action that you want to use in your stories should be added into the
 actions section of your [domain](./domain.mdx).
@@ -52,3 +65,24 @@ Your action server should respond with a list of events and responses:
   "responses": [{}]
 }
 ```
+
+
+### Using an Action Server
+
+Using a dedicated action server is the recommended way to implement custom behavior in Rasa.
+However, if your use case is not supported, it is also possible to bundle Rasa actions with
+your Rasa installation, by specifying module paths under the `custom_actions` key of `endpoints.yml`:
+
+```yaml-rasa
+custom_actions:
+  modules:
+    - my_module.actions
+    - my_module.some_more_actions
+```
+
+In this example, all subclasses of [`rasa.core.actions.action.Action`](./reference/rasa/core/actions/action#action-objects)
+under the specified paths `my_module.actions` and `my_module.some_more_actions` would be registered.
+
+:::note Resolving action names at execution time
+When executing an action, Rasa will first match it against any actions registered using this
+method, and _then_ query the action server, if set.

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -147,12 +147,16 @@ def action_for_name_or_text(
         domain.raise_action_not_found_exception(action_name_or_text)
 
     defaults = {a.name(): a for a in default_actions(action_endpoint)}
+    customs = {a.name(): a for a in getattr(action_endpoint, "custom_actions", [])}
 
     if (
         action_name_or_text in defaults
         and action_name_or_text not in domain.user_actions_and_forms
     ):
         return defaults[action_name_or_text]
+
+    if action_name_or_text in customs:
+        return customs[action_name_or_text]
 
     if action_name_or_text.startswith(UTTER_PREFIX) and is_retrieval_action(
         action_name_or_text, domain.retrieval_intents

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -377,7 +377,7 @@ def list_imported_custom_actions():
         for a in rasa.shared.utils.common.all_subclasses(
             rasa.core.actions.action.Action
         )
-        if not a.__module__.startswith("rasa.") and a.__name__ != "ActionBotfrontForm"
+        if not a.__module__.startswith("rasa.")
     ]
 
 

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -316,6 +316,7 @@ class AvailableEndpoints:
         nlg = read_endpoint_config(endpoint_file, endpoint_type="nlg")
         nlu = read_endpoint_config(endpoint_file, endpoint_type="nlu")
         action = read_endpoint_config(endpoint_file, endpoint_type="action_endpoint")
+        action.custom_actions = cls.find_custom_actions_in_endpoints(endpoint_file)
         model = read_endpoint_config(endpoint_file, endpoint_type="models")
         tracker_store = read_endpoint_config(
             endpoint_file, endpoint_type="tracker_store"
@@ -342,6 +343,42 @@ class AvailableEndpoints:
         self.tracker_store = tracker_store
         self.lock_store = lock_store
         self.event_broker = event_broker
+
+    @staticmethod
+    def find_custom_actions_in_endpoints(endpoint_file):
+        custom_actions = read_endpoint_config(
+            endpoint_file, endpoint_type="custom_actions"
+        )
+        if custom_actions is None:
+            return None
+        custom_action_modules = getattr(custom_actions, "modules", [])
+        import_custom_action_modules(custom_action_modules)
+        return list_imported_custom_actions()
+
+
+def import_custom_action_modules(modules):
+    if not isinstance(modules, list):
+        modules = [modules]
+    for module in modules:
+        try:
+            rasa.shared.utils.common.import_submodules(module)
+        except (AttributeError, ImportError):
+            logger.error(
+                "Could not load custom actions"
+                + (f" from '{module}'" if isinstance(module, str) else "")
+                + "."
+            )
+            continue
+
+
+def list_imported_custom_actions():
+    return [
+        a()
+        for a in rasa.shared.utils.common.all_subclasses(
+            rasa.core.actions.action.Action
+        )
+        if not a.__module__.startswith("rasa.") and a.__name__ != "ActionBotfrontForm"
+    ]
 
 
 def read_endpoints_from_path(


### PR DESCRIPTION
**Proposed changes**:
Rasa allows module path-based custom natural language generators, interpreters, brokers and stores, but there is currently no easy way to extend it with native (non-SDK) actions. This is a limitation for some use cases, for example if one wants to implement a `LoopAction`.

This PR makes it possible to load custom actions by specifying module paths in the endpoints. The current implementation piggybacks on the `action_endpoint` object that's passed to action name resolution methods.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
