### PR TITLE
make metadata accessible for custom action_session_start

### DIFF
--- a/changelog/7420.bugfix.md
+++ b/changelog/7420.bugfix.md
@@ -1,0 +1,2 @@
+Fixed an error when using the endpoint `GET /conversations/<conversation_id:path>/story`
+with a tracker which contained slots.

--- a/changelog/7420.improvement.md
+++ b/changelog/7420.improvement.md
@@ -1,0 +1,26 @@
+User message metadata can now be accessed via the default slot 
+`session_started_metadata` during the execution of a 
+[custom `action_session_start`](default-actions.mdx#customization).
+
+```python
+from typing import Any, Text, Dict, List
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import SlotSet, SessionStarted, ActionExecuted, EventType
+
+
+class ActionSessionStart(Action):
+    def name(self) -> Text:
+        return "action_session_start"
+
+    async def run(
+      self, dispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        metadata = tracker.get_slot("session_started_metadata")
+
+        # Do something with the metadata
+        print(metadata)
+
+        # the session should begin with a `session_started` event and an `action_listen`
+        # as a user message follows
+        return [SessionStarted(), ActionExecuted("action_listen")]
+```

--- a/changelog/7420.misc.md
+++ b/changelog/7420.misc.md
@@ -1,0 +1,3 @@
+Errors in the configuration of slots now raise a `InvalidSlotConfigError` instead
+of a `ValueError`. As `InvalidSlotConfigError` inherits from `ValueError` existing
+`catch` statements will continue to work as before.

--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -30,7 +30,7 @@
   "paused": false,
   "latest_event_time": 1517821726.211042,
   "followup_action": null,
-  "slots": {"name": null, "requested_slot": null, "session_start_metadata": null},
+  "slots": {"name": null, "requested_slot": null, "session_started_metadata": null},
   "latest_input_channel": null,
   "events": [
     {

--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -30,7 +30,7 @@
   "paused": false,
   "latest_event_time": 1517821726.211042,
   "followup_action": null,
-  "slots": {"name": null, "requested_slot": null},
+  "slots": {"name": null, "requested_slot": null, "session_start_metadata": null},
   "latest_input_channel": null,
   "events": [
     {

--- a/docs/docs/default-actions.mdx
+++ b/docs/docs/default-actions.mdx
@@ -108,7 +108,7 @@ class ActionSessionStart(Action):
 ```
 
 If you want to access the metadata which was sent with the user message which triggered
-the session restart, you can access the special slot `session_started_metadata`:
+the session start, you can access the special slot `session_started_metadata`:
 
 ```python
 from typing import Any, Text, Dict, List

--- a/docs/docs/default-actions.mdx
+++ b/docs/docs/default-actions.mdx
@@ -107,6 +107,32 @@ class ActionSessionStart(Action):
         return events
 ```
 
+If you want to access the metadata which was sent with the user message which triggered
+the session restart, you can access the special slot `session_started_metadata`:
+
+```python
+from typing import Any, Text, Dict, List
+from rasa_sdk import Action, Tracker
+from rasa_sdk.events import SessionStarted, ActionExecuted
+
+
+class ActionSessionStart(Action):
+    def name(self) -> Text:
+        return "action_session_start"
+
+    async def run(
+      self, dispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        metadata = tracker.get_slot("session_started_metadata")
+
+        # Do something with the metadata
+        print(metadata)
+
+        # the session should begin with a `session_started` event and an `action_listen`
+        # as a user message follows
+        return [SessionStarted(), ActionExecuted("action_listen")]
+```
+
 ## action_default_fallback
 
 This action undoes the last user-bot interaction and sends the `utter_default` response if it is defined.

--- a/docs/docs/default-actions.mdx
+++ b/docs/docs/default-actions.mdx
@@ -70,7 +70,7 @@ slots, but only a user's name and their phone number. To do that, you'd override
 `action_session_start` with a custom action that might look like this:
 
 ```python
-from typing import Any, Text, Dict, List, Type
+from typing import Any, Text, Dict, List
 from rasa_sdk import Action, Tracker
 from rasa_sdk.events import SlotSet, SessionStarted, ActionExecuted, EventType
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -22,6 +22,7 @@ from rasa.shared.core.constants import (
     REQUESTED_SLOT,
     SLOTS,
     FOLLOWUP_ACTION,
+    METADATA_SLOT_SESSION_START,
 )
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
@@ -192,7 +193,10 @@ class MessageProcessor:
                 # then be passed to the SessionStart event.
                 # Otherwise the metadata will be lost.
                 action_session_start.metadata = metadata
-            # TODO: Set unfeaturized slot with metadata
+            if metadata:
+                tracker.update(
+                    SlotSet(METADATA_SLOT_SESSION_START, metadata), self.domain
+                )
             await self._run_action(
                 action=action_session_start,
                 tracker=tracker,

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -22,7 +22,7 @@ from rasa.shared.core.constants import (
     REQUESTED_SLOT,
     SLOTS,
     FOLLOWUP_ACTION,
-    METADATA_SLOT_SESSION_START,
+    SESSION_START_METADATA_SLOT,
 )
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
@@ -197,7 +197,7 @@ class MessageProcessor:
 
             if metadata:
                 tracker.update(
-                    SlotSet(METADATA_SLOT_SESSION_START, metadata), self.domain
+                    SlotSet(SESSION_START_METADATA_SLOT, metadata), self.domain
                 )
 
             await self._run_action(

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -184,6 +184,7 @@ class MessageProcessor:
                 f"Starting a new session for conversation ID '{tracker.sender_id}'."
             )
 
+            # TODO: Set unfeaturized slot with metadata
             await self._run_action(
                 action=self._get_action(ACTION_SESSION_START_NAME),
                 tracker=tracker,
@@ -738,6 +739,7 @@ class MessageProcessor:
         # events and return values are used to update
         # the tracker state after an action has been taken
         try:
+            # TODO: move up and think about whether we can remove this
             # Here we set optional metadata to the ActionSessionStart, which will then
             # be passed to the SessionStart event. Otherwise the metadata will be lost.
             if action.name() == ACTION_SESSION_START_NAME:

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -186,17 +186,20 @@ class MessageProcessor:
             )
 
             action_session_start = self._get_action(ACTION_SESSION_START_NAME)
+            # TODO: Remove in 3.0.0 and describe migration to `session_start_metadata`
+            # slot in migration guide.
             if isinstance(
                 action_session_start, rasa.core.actions.action.ActionSessionStart
             ):
                 # Here we set optional metadata to the ActionSessionStart, which will
                 # then be passed to the SessionStart event.
-                # Otherwise the metadata will be lost.
                 action_session_start.metadata = metadata
+
             if metadata:
                 tracker.update(
                     SlotSet(METADATA_SLOT_SESSION_START, metadata), self.domain
                 )
+
             await self._run_action(
                 action=action_session_start,
                 tracker=tracker,

--- a/rasa/shared/core/constants.py
+++ b/rasa/shared/core/constants.py
@@ -6,6 +6,7 @@ USER_INTENT_RESTART = "restart"
 USER_INTENT_BACK = "back"
 USER_INTENT_OUT_OF_SCOPE = "out_of_scope"
 USER_INTENT_SESSION_START = "session_start"
+METADATA_SLOT_SESSION_START = "session_start_metadata"
 
 DEFAULT_INTENTS = [
     USER_INTENT_RESTART,

--- a/rasa/shared/core/constants.py
+++ b/rasa/shared/core/constants.py
@@ -6,7 +6,7 @@ USER_INTENT_RESTART = "restart"
 USER_INTENT_BACK = "back"
 USER_INTENT_OUT_OF_SCOPE = "out_of_scope"
 USER_INTENT_SESSION_START = "session_start"
-METADATA_SLOT_SESSION_START = "session_start_metadata"
+SESSION_START_METADATA_SLOT = "session_started_metadata"
 
 DEFAULT_INTENTS = [
     USER_INTENT_RESTART,

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -722,6 +722,7 @@ class Domain:
         self._add_requested_slot()
         self._add_knowledge_base_slots()
         self._add_categorical_slot_default_value()
+        # TODO: add new slot
 
     def _add_categorical_slot_default_value(self) -> None:
         """Add a default value to all categorical slots.

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -809,7 +809,7 @@ class Domain:
 
     def _add_session_metadata_slot(self) -> None:
         self.slots.append(
-            AnySlot(rasa.shared.core.constants.METADATA_SLOT_SESSION_START,)
+            AnySlot(rasa.shared.core.constants.SESSION_START_METADATA_SLOT,)
         )
 
     def index_for_action(self, action_name: Text) -> Optional[int]:

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -28,7 +28,7 @@ import rasa.shared.utils.validation
 import rasa.shared.utils.io
 import rasa.shared.utils.common
 from rasa.shared.core.events import SlotSet, UserUttered
-from rasa.shared.core.slots import Slot, CategoricalSlot, TextSlot
+from rasa.shared.core.slots import Slot, CategoricalSlot, TextSlot, AnySlot
 from rasa.shared.utils.validation import KEY_TRAINING_DATA_FORMAT_VERSION
 
 
@@ -722,7 +722,7 @@ class Domain:
         self._add_requested_slot()
         self._add_knowledge_base_slots()
         self._add_categorical_slot_default_value()
-        # TODO: add new slot
+        self._add_session_metadata_slot()
 
     def _add_categorical_slot_default_value(self) -> None:
         """Add a default value to all categorical slots.
@@ -806,6 +806,11 @@ class Domain:
             f"call superfluous."
         )
         self._add_knowledge_base_slots()
+
+    def _add_session_metadata_slot(self) -> None:
+        self.slots.append(
+            AnySlot(rasa.shared.core.constants.METADATA_SLOT_SESSION_START,)
+        )
 
     def index_for_action(self, action_name: Text) -> Optional[int]:
         """Looks up which action index corresponds to this action name."""

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -382,3 +382,15 @@ class AnySlot(Slot):
         super().__init__(
             name, initial_value, value_reset_delay, auto_fill, influence_conversation
         )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, AnySlot):
+            return NotImplemented
+
+        return (
+            self.name == other.name
+            and self.initial_value == other.initial_value
+            and self._value_reset_delay == other._value_reset_delay
+            and self.auto_fill == other.auto_fill
+            and self.value == other.value
+        )

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -367,6 +367,7 @@ class AnySlot(Slot):
         influence_conversation: bool = False,
     ) -> None:
         if influence_conversation:
+            # TODO: Fix
             raise ValueError(
                 f"An {AnySlot.__name__} cannot be featurized. "
                 f"Please use a different slot type for slot '{name}' instead. If you "

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -20,6 +20,8 @@ class InvalidSlotConfigError(RasaException, ValueError):
 
 
 class Slot:
+    """Key-value store for storing information during a conversation."""
+
     type_name = None
 
     def __init__(
@@ -384,6 +386,7 @@ class AnySlot(Slot):
         )
 
     def __eq__(self, other: Any) -> bool:
+        """Compares object with other object."""
         if not isinstance(other, AnySlot):
             return NotImplemented
 

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -15,6 +15,10 @@ class InvalidSlotTypeException(RasaException):
     """Raised if a slot type is invalid."""
 
 
+class InvalidSlotConfigError(RasaException, ValueError):
+    """Raised if a slot's config is invalid."""
+
+
 class Slot:
     type_name = None
 
@@ -145,7 +149,7 @@ class FloatSlot(Slot):
         self.min_value = min_value
 
         if min_value >= max_value:
-            raise ValueError(
+            raise InvalidSlotConfigError(
                 "Float slot ('{}') created with an invalid range "
                 "using min ({}) and max ({}) values. Make sure "
                 "min is smaller than max."
@@ -253,7 +257,7 @@ class UnfeaturizedSlot(Slot):
         influence_conversation: bool = False,
     ) -> None:
         if influence_conversation:
-            raise ValueError(
+            raise InvalidSlotConfigError(
                 f"An {UnfeaturizedSlot.__name__} cannot be featurized. "
                 f"Please use a different slot type for slot '{name}' instead. See the "
                 f"documentation for more information: {DOCS_URL_SLOTS}"
@@ -367,8 +371,7 @@ class AnySlot(Slot):
         influence_conversation: bool = False,
     ) -> None:
         if influence_conversation:
-            # TODO: Fix
-            raise ValueError(
+            raise InvalidSlotConfigError(
                 f"An {AnySlot.__name__} cannot be featurized. "
                 f"Please use a different slot type for slot '{name}' instead. If you "
                 f"need to featurize a data type which is not supported out of the box, "

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -907,7 +907,10 @@ def get_trackers_for_conversation_sessions(
 
     return [
         DialogueStateTracker.from_events(
-            tracker.sender_id, evts, tracker.slots, sender_source=tracker.sender_source
+            tracker.sender_id,
+            evts,
+            tracker.slots.values(),
+            sender_source=tracker.sender_source,
         )
         for evts in split_conversations
     ]

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -56,6 +56,7 @@ from rasa.shared.core.constants import (
     ACTIVE_LOOP,
     FOLLOWUP_ACTION,
     REQUESTED_SLOT,
+    METADATA_SLOT_SESSION_START,
 )
 from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.utils.endpoints import ClientResponseError, EndpointConfig
@@ -161,7 +162,11 @@ async def test_remote_action_runs(
                 "paused": False,
                 "latest_event_time": None,
                 FOLLOWUP_ACTION: "action_listen",
-                "slots": {"name": None, REQUESTED_SLOT: None},
+                "slots": {
+                    "name": None,
+                    REQUESTED_SLOT: None,
+                    METADATA_SLOT_SESSION_START: None,
+                },
                 "events": [],
                 "latest_input_channel": None,
             },
@@ -216,7 +221,11 @@ async def test_remote_action_logs_events(
                 "paused": False,
                 FOLLOWUP_ACTION: ACTION_LISTEN_NAME,
                 "latest_event_time": None,
-                "slots": {"name": None, REQUESTED_SLOT: None},
+                "slots": {
+                    "name": None,
+                    REQUESTED_SLOT: None,
+                    METADATA_SLOT_SESSION_START: None,
+                },
                 "events": [],
                 "latest_input_channel": None,
             },

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -56,7 +56,7 @@ from rasa.shared.core.constants import (
     ACTIVE_LOOP,
     FOLLOWUP_ACTION,
     REQUESTED_SLOT,
-    METADATA_SLOT_SESSION_START,
+    SESSION_START_METADATA_SLOT,
 )
 from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.utils.endpoints import ClientResponseError, EndpointConfig
@@ -165,7 +165,7 @@ async def test_remote_action_runs(
                 "slots": {
                     "name": None,
                     REQUESTED_SLOT: None,
-                    METADATA_SLOT_SESSION_START: None,
+                    SESSION_START_METADATA_SLOT: None,
                 },
                 "events": [],
                 "latest_input_channel": None,
@@ -224,7 +224,7 @@ async def test_remote_action_logs_events(
                 "slots": {
                     "name": None,
                     REQUESTED_SLOT: None,
-                    METADATA_SLOT_SESSION_START: None,
+                    SESSION_START_METADATA_SLOT: None,
                 },
                 "events": [],
                 "latest_input_channel": None,

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -62,7 +62,7 @@ from rasa.shared.core.constants import (
     ACTION_SESSION_START_NAME,
     EXTERNAL_MESSAGE_PREFIX,
     IS_EXTERNAL,
-    METADATA_SLOT_SESSION_START,
+    SESSION_START_METADATA_SLOT,
 )
 
 import logging
@@ -540,13 +540,13 @@ async def test_update_tracker_session_with_metadata(
 
     tracker = default_processor.tracker_store.retrieve(sender_id)
     events = list(tracker.events)
-    assert events[0] == SlotSet(METADATA_SLOT_SESSION_START, metadata)
-    assert tracker.slots[METADATA_SLOT_SESSION_START].value == metadata
+    assert events[0] == SlotSet(SESSION_START_METADATA_SLOT, metadata)
+    assert tracker.slots[SESSION_START_METADATA_SLOT].value == metadata
 
     assert events[1] == ActionExecuted(ACTION_SESSION_START_NAME)
     assert events[2] == SessionStarted()
     assert events[2].metadata == metadata
-    assert events[3] == SlotSet(METADATA_SLOT_SESSION_START, metadata)
+    assert events[3] == SlotSet(SESSION_START_METADATA_SLOT, metadata)
     assert events[4] == ActionExecuted(ACTION_LISTEN_NAME)
     assert isinstance(events[5], UserUttered)
 

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1,7 +1,5 @@
 import asyncio
-
 import datetime
-
 import freezegun
 import pytest
 import time
@@ -540,6 +538,7 @@ async def test_update_tracker_session_with_metadata(
 
     tracker = default_processor.tracker_store.retrieve(sender_id)
     events = list(tracker.events)
+
     assert events[0] == SlotSet(SESSION_START_METADATA_SLOT, metadata)
     assert tracker.slots[SESSION_START_METADATA_SLOT].value == metadata
 
@@ -582,8 +581,8 @@ async def test_custom_action_session_start_with_metadata(
         {
             "event": "slot",
             "timestamp": 1580515200.0,
-            "name": "session_start_metadata",
-            "value": {"metadataTestKey": "metadataTestValue"},
+            "name": SESSION_START_METADATA_SLOT,
+            "value": metadata,
         }
     ]
 

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -520,6 +520,7 @@ async def test_update_tracker_session(
     ]
 
 
+# TODO: improve test
 # noinspection PyProtectedMember
 async def test_update_tracker_session_with_metadata(
     default_channel: CollectingOutputChannel,
@@ -549,6 +550,11 @@ async def test_update_tracker_session_with_metadata(
     session_started_event_metadata = tracker.events[session_started_event_idx].metadata
 
     assert session_started_event_metadata == metadata
+
+
+# TODO: write test that ensure metadata is sent to remote action
+async def test_custom_action_session_start_with_metadata():
+    pass
 
 
 # noinspection PyProtectedMember

--- a/tests/shared/core/test_slots.py
+++ b/tests/shared/core/test_slots.py
@@ -15,6 +15,7 @@ from rasa.shared.core.slots import (
     CategoricalSlot,
     bool_from_any,
     AnySlot,
+    InvalidSlotConfigError,
 )
 
 
@@ -202,7 +203,7 @@ class TestUnfeaturizedSlot(SlotTestCollection):
         return request.param
 
     def test_exception_if_featurized(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidSlotConfigError):
             UnfeaturizedSlot("⛔️", influence_conversation=True)
 
     def test_deprecation_warning(self):
@@ -291,7 +292,7 @@ class TestAnySlot(SlotTestCollection):
         return request.param
 
     def test_exception_if_featurized(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidSlotConfigError):
             UnfeaturizedSlot("⛔️", influence_conversation=True)
 
 

--- a/tests/shared/importers/test_rasa.py
+++ b/tests/shared/importers/test_rasa.py
@@ -7,8 +7,9 @@ from rasa.shared.constants import (
     DEFAULT_DOMAIN_PATH,
     DEFAULT_DATA_PATH,
 )
-from rasa.shared.core.constants import DEFAULT_INTENTS
+from rasa.shared.core.constants import DEFAULT_INTENTS, METADATA_SLOT_SESSION_START
 from rasa.shared.core.domain import Domain
+from rasa.shared.core.slots import AnySlot
 from rasa.shared.importers.importer import TrainingDataImporter
 from rasa.shared.importers.rasa import RasaFileImporter
 
@@ -22,7 +23,7 @@ async def test_rasa_file_importer(project: Text):
 
     domain = await importer.get_domain()
     assert len(domain.intents) == 7 + len(DEFAULT_INTENTS)
-    assert domain.slots == []
+    assert domain.slots == [AnySlot(METADATA_SLOT_SESSION_START)]
     assert domain.entities == []
     assert len(domain.action_names_or_texts) == 17
     assert len(domain.templates) == 6

--- a/tests/shared/importers/test_rasa.py
+++ b/tests/shared/importers/test_rasa.py
@@ -7,7 +7,7 @@ from rasa.shared.constants import (
     DEFAULT_DOMAIN_PATH,
     DEFAULT_DATA_PATH,
 )
-from rasa.shared.core.constants import DEFAULT_INTENTS, METADATA_SLOT_SESSION_START
+from rasa.shared.core.constants import DEFAULT_INTENTS, SESSION_START_METADATA_SLOT
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.slots import AnySlot
 from rasa.shared.importers.importer import TrainingDataImporter
@@ -23,7 +23,7 @@ async def test_rasa_file_importer(project: Text):
 
     domain = await importer.get_domain()
     assert len(domain.intents) == 7 + len(DEFAULT_INTENTS)
-    assert domain.slots == [AnySlot(METADATA_SLOT_SESSION_START)]
+    assert domain.slots == [AnySlot(SESSION_START_METADATA_SLOT)]
     assert domain.entities == []
     assert len(domain.action_names_or_texts) == 17
     assert len(domain.templates) == 6

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,7 +49,7 @@ from rasa.shared.core.constants import (
     ACTION_SESSION_START_NAME,
     ACTION_LISTEN_NAME,
     REQUESTED_SLOT,
-    METADATA_SLOT_SESSION_START,
+    SESSION_START_METADATA_SLOT,
 )
 from rasa.shared.core.domain import Domain, SessionConfig
 from rasa.shared.core.events import (
@@ -1099,7 +1099,7 @@ async def test_requesting_non_existent_tracker(rasa_app: SanicASGITestClient):
     assert content["slots"] == {
         "name": None,
         REQUESTED_SLOT: None,
-        METADATA_SLOT_SESSION_START: None,
+        SESSION_START_METADATA_SLOT: None,
     }
     assert content["sender_id"] == "madeupid"
     assert content["events"] == [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,6 +49,7 @@ from rasa.shared.core.constants import (
     ACTION_SESSION_START_NAME,
     ACTION_LISTEN_NAME,
     REQUESTED_SLOT,
+    METADATA_SLOT_SESSION_START,
 )
 from rasa.shared.core.domain import Domain, SessionConfig
 from rasa.shared.core.events import (
@@ -1095,7 +1096,11 @@ async def test_requesting_non_existent_tracker(rasa_app: SanicASGITestClient):
     content = response.json()
     assert response.status == HTTPStatus.OK
     assert content["paused"] is False
-    assert content["slots"] == {"name": None, REQUESTED_SLOT: None}
+    assert content["slots"] == {
+        "name": None,
+        REQUESTED_SLOT: None,
+        METADATA_SLOT_SESSION_START: None,
+    }
     assert content["sender_id"] == "madeupid"
     assert content["events"] == [
         {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1718,6 +1718,28 @@ stories:
         ),
         # empty conversation
         ([], None, True, 'version: "2.0"'),
+        # Conversation with slot
+        (
+            [
+                ActionExecuted(ACTION_SESSION_START_NAME),
+                SessionStarted(),
+                UserUttered("hi", {"name": "greet"}),
+                ActionExecuted("utter_greet"),
+                SlotSet(REQUESTED_SLOT, "some value"),
+            ],
+            None,
+            True,
+            """version: "2.0"
+stories:
+- story: some-conversation-ID
+  steps:
+  - intent: greet
+    user: |-
+      hi
+  - action: utter_greet
+  - slot_was_set:
+    - requested_slot: some value""",
+        ),
     ],
 )
 async def test_get_story(


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/7420
- invalid slot configs now throw an exception which inherits from `RasaException`. This avoids noise in sentry reporting. 
- Fixed an error when using the endpoint `GET /conversations/<conversation_id:path>/story`
with a tracker which contained slots.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
