### PR TITLE
Support transports other than HTTP(S)

### DIFF
--- a/rasa/core/channels/channel.py
+++ b/rasa/core/channels/channel.py
@@ -78,6 +78,13 @@ class UserMessage:
         self.metadata = metadata
 
 
+class InputChannelSetupOptions:
+    """Parameters used to setup InputChannels"""
+
+    def __init__(self, url_prefix: Optional[Text] = None):
+        self.url_prefix = url_prefix
+
+
 def register(
     input_channels: List["InputChannel"], app: Sanic, route: Optional[Text]
 ) -> None:
@@ -89,7 +96,9 @@ def register(
             p = urljoin(route, channel.url_prefix())
         else:
             p = None
-        app.blueprint(channel.blueprint(handler), url_prefix=p)
+
+        options = InputChannelSetupOptions(p)
+        channel.setup(handler, app, options)
 
     app.input_channels = input_channels
 
@@ -106,6 +115,18 @@ class InputChannel:
 
     def url_prefix(self) -> Text:
         return self.name()
+
+    def setup(
+        self,
+        on_new_message: Callable[[UserMessage], Awaitable[Any]],
+        app: Sanic,
+        options: InputChannelSetupOptions,
+    ) -> NoReturn:
+        """Registers the channel's blueprint on the Sanic application"""
+
+        url_prefix = options.url_prefix
+
+        app.blueprint(self.blueprint(on_new_message), url_prefix=url_prefix)
 
     def blueprint(
         self, on_new_message: Callable[[UserMessage], Awaitable[Any]]

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -30,7 +30,7 @@ from asyncio import AbstractEventLoop
 logger = logging.getLogger()  # get the root logger
 
 
-def create_http_input_channels(
+def create_input_channels(
     channel: Optional[Text], credentials_file: Optional[Text]
 ) -> List["InputChannel"]:
     """Instantiate the chosen input channel."""
@@ -171,7 +171,7 @@ def serve_application(
     if not channel and not credentials:
         channel = "cmdline"
 
-    input_channels = create_http_input_channels(channel, credentials)
+    input_channels = create_input_channels(channel, credentials)
 
     app = configure_app(
         input_channels,

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -15,8 +15,8 @@ from rasa.core.utils import AvailableEndpoints
 CREDENTIALS_FILE = "examples/moodbot/credentials.yml"
 
 
-def test_create_http_input_channels():
-    channels = run.create_http_input_channels(None, CREDENTIALS_FILE)
+def test_create_input_channels():
+    channels = run.create_input_channels(None, CREDENTIALS_FILE)
     assert len(channels) == 7
 
     # ensure correct order
@@ -32,13 +32,13 @@ def test_create_http_input_channels():
 
 
 def test_create_single_input_channels():
-    channels = run.create_http_input_channels("facebook", CREDENTIALS_FILE)
+    channels = run.create_input_channels("facebook", CREDENTIALS_FILE)
     assert len(channels) == 1
     assert channels[0].name() == "facebook"
 
 
 def test_create_single_input_channels_by_class():
-    channels = run.create_http_input_channels(
+    channels = run.create_input_channels(
         "rasa.core.channels.rest.RestInput", CREDENTIALS_FILE
     )
     assert len(channels) == 1
@@ -46,7 +46,7 @@ def test_create_single_input_channels_by_class():
 
 
 def test_create_single_input_channels_by_class_wo_credentials():
-    channels = run.create_http_input_channels(
+    channels = run.create_input_channels(
         "rasa.core.channels.rest.RestInput", credentials_file=None
     )
 


### PR DESCRIPTION
This implements a solution for the issue #7789.

What I did was the second idea I proposed, where basically we create an intermediary method `setup` (which I referred to as `register` in the issue) to actually register the Channel blueprint to the app. (I give my reasons for it below, but, please, bring it up if you feel like another approach would be better)

What that allows us to do is basically access both the Sanic app and the `on_new_message` callback, which makes it possible for us to register a listener on the app and use the `on_new_message` only when it is ready.

Suppose we have an InputChannel that is supposed to receive it's messages using AMQP:

```python
class AmqpInput(InputChannel):
    # ...

    # override setup
    def setup(self, on_new_message, app, options):
        # we may still register the blueprint for health-check, etc
        super().setup(on_new_message, app, options)

        # defer actual setup for when the server has started
        app.register_listener(
            # when this lambda executes, we may be sure on_new_message is ready to be called
            # so we may start consuming immediately
            lambda _, loop: self._setup_connection(on_new_message, loop),
            "after_server_start",
        )
``` 

Also, I created a class (that could very well be a _dataclass_) to hold extra options, just in case we need to add more. Then we may do it in a backwards-compatible way.

---

The reasons why I chose this approach over the other one (creating a `on_agent_ready` method to run specifically when the server has started) are:
1. It just seems much easier to implement
2. I imagine it will be easier to use this solution to solve #7525 (more below)
3. Basically, compared to the other approach, this seems more future-proof, in the sense that it gives more power to the end-user to do what they want. 

---

Regarding the issue #7525 (and PR #7526), the improvement I imagine this would enable would be to do something like:

```python
class SlackInput(InputChannel):
    # ...

    # override setup
    def setup(self, on_new_message, app, options):
        # do not register the blueprint at first

        # by deferring the setup to just before the server starts, we are able to get access to the event loop
        app.register_listener(
            # then we may give the would-be-blueprint method access to it
            lambda _, loop: self.blueprint_with_loop(on_new_message, loop),
            "before_server_start",
        )

    def blueprint_with_loop(on_new_message, loop):
        # ...

        loop.create_task(on_new_message(user_msg))
```

---

## Questions

- Are there any tests I need to change / add? From what I looked, the `tests/core/test_channels.py`,  `tests/core/test_run.py` and the ones in `tests/core/channels` passed. Does that mean it's ok?

**Status**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
