### PR TITLE
fix regex pattern to match all new micro versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -64,7 +64,7 @@ jobs:
       run: make install install-docs
 
     - name: Pre-build Docs 🧶
-      run: cd $DOCS_FOLDER && poetry run yarn pre-build
+      run: make prepare-docs
 
     - name: Build & Publish Docs 🏃‍♀️
       env:

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,11 @@ test-docs: generate-pending-changelog docs
 	poetry run pytest tests/docs/*
 	cd docs && yarn mdx-lint
 
-docs:
-	cd docs/ && poetry run yarn pre-build && yarn build
+prepare-docs:
+	cd docs/ && poetry run yarn pre-build
+
+docs: prepare-docs
+	cd docs/ && yarn build
 
 livedocs:
 	cd docs/ && poetry run yarn start

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 TODAY=`date "+%Y%m%d"`
 # we build new versions only for minors and majors
 PATTERN_FOR_NEW_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.0$"
-PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+$"
+PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+[0-9]*$"
 MASTER_REF=refs/heads/master
 VARIABLES_JSON=docs/docs/variables.json
 SOURCES_FILES=docs/docs/sources/

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -15,7 +15,7 @@ set -Eeuo pipefail
 TODAY=`date "+%Y%m%d"`
 # we build new versions only for minors and majors
 PATTERN_FOR_NEW_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.0$"
-PATTERN_FOR_MICRO_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+[0-9]*$"
+PATTERN_FOR_MICRO_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9][0-9]*$"
 MASTER_REF=refs/heads/master
 VARIABLES_JSON=docs/docs/variables.json
 SOURCES_FILES=docs/docs/sources/

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -4,12 +4,11 @@
 # For instance, if the doc version for 2.2.10 fails to be pushed, you
 # can do:
 #
-# TMP_DOCS_FOLDER=/tmp/documentation DOCS_BRANCH=documentation GITHUB_REF=refs/tags/2.2.10 GITHUB_REPOSITORY=RasaHQ/rasa ./scripts/push_docs_to_branch.sh
+# 1. make install install-docs
+# 2. make prepare-docs
+# 3. TMP_DOCS_FOLDER=/tmp/documentation DOCS_BRANCH=documentation GITHUB_REF=refs/tags/2.2.10 GITHUB_REPOSITORY=RasaHQ/rasa ./scripts/push_docs_to_branch.sh
 #
-# This command will push the changes to the `documentation` branch of this repository.
-#
-# Please make sure to have the proper dependencies installed with `make install install-docs`
-# and that the docs are pre-built with `make prepare-docs`.
+# This script will push the changes to the `documentation` branch of this repository.
 
 set -Eeuo pipefail
 

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -4,7 +4,7 @@
 # For instance, if the doc version for 2.2.10 fails to be pushed, you
 # can do:
 #
-# TMP_DOCS_FOLDER=/tmp/documentation DOCS_BRANCH=documentation GITHUB_REF=refs/tags/2.2.10 ./scripts/push_docs_to_branch.sh
+# TMP_DOCS_FOLDER=/tmp/documentation DOCS_BRANCH=documentation GITHUB_REF=refs/tags/2.2.10 GITHUB_REPOSITORY=RasaHQ/rasa ./scripts/push_docs_to_branch.sh
 #
 # This command will push the changes to the `documentation` branch of this repository.
 #

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -16,7 +16,7 @@ set -Eeuo pipefail
 TODAY=`date "+%Y%m%d"`
 # we build new versions only for minors and majors
 PATTERN_FOR_NEW_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.0$"
-PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+[0-9]*$"
+PATTERN_FOR_MICRO_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+[0-9]*$"
 MASTER_REF=refs/heads/master
 VARIABLES_JSON=docs/docs/variables.json
 SOURCES_FILES=docs/docs/sources/
@@ -25,7 +25,7 @@ CHANGELOG=docs/docs/changelog.mdx
 TELEMETRY_REFERENCE=docs/docs/telemetry/reference.mdx
 
 [[ ! $GITHUB_REF =~ $PATTERN_FOR_NEW_VERSION ]] \
-&& [[ ! $GITHUB_REF =~ $PATTERN_FOR_PATCH_VERSION ]] \
+&& [[ ! $GITHUB_REF =~ $PATTERN_FOR_MICRO_VERSION ]] \
 && [[ $GITHUB_REF != $MASTER_REF ]] \
 && echo "Not on master or tagged version, skipping." \
 && exit 0
@@ -35,7 +35,7 @@ EXISTING_VERSION=
 if [[ "$GITHUB_REF" =~ $PATTERN_FOR_NEW_VERSION ]]
 then
     NEW_VERSION=$(echo $GITHUB_REF | sed -E "s/^refs\/tags\/([0-9]+)\.([0-9]+)\.0$/\1.\2.x/")
-elif [[ "$GITHUB_REF" =~ $PATTERN_FOR_PATCH_VERSION ]]
+elif [[ "$GITHUB_REF" =~ $PATTERN_FOR_MICRO_VERSION ]]
 then
     EXISTING_VERSION=$(echo $GITHUB_REF | sed -E "s/^refs\/tags\/([0-9]+)\.([0-9]+)\.[0-9]+$/\1.\2.x/")
 fi

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# In case this script fails in our CI workflows, you can run it locally.
+# For instance, if the doc version for 2.2.10 fails to be pushed, you
+# can do:
+#
+# TMP_DOCS_FOLDER=/tmp/documentation DOCS_BRANCH=documentation GITHUB_REF=refs/tags/2.2.10 ./scripts/push_docs_to_branch.sh
+#
+# This command will push the changes to the `documentation` branch of this repository.
+#
+# Please make sure to have the proper dependencies installed with `make install install-docs`
+# and docs need to be pre-built using: cd docs/ && poetry run yarn pre-build.
+
 set -Eeuo pipefail
 
 TODAY=`date "+%Y%m%d"`

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -9,7 +9,7 @@
 # This command will push the changes to the `documentation` branch of this repository.
 #
 # Please make sure to have the proper dependencies installed with `make install install-docs`
-# and docs need to be pre-built using: cd docs/ && poetry run yarn pre-build.
+# and that the docs are pre-built with `make prepare-docs`.
 
 set -Eeuo pipefail
 


### PR DESCRIPTION
**Proposed changes**:
- Fix regex pattern in doc release script to match all micros. Until now it matched all the micros not containing a "0" digit (`2.2.1`, `2.2.7`, `2.2.12`), missing micros like `2.2.10` or `2.2.20`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
