### PR TITLE
Small code-tick fix. 

### DIFF
--- a/docs/docs/migrate-from/google-dialogflow-to-rasa.mdx
+++ b/docs/docs/migrate-from/google-dialogflow-to-rasa.mdx
@@ -79,6 +79,8 @@ To send a request to the server, run:
 
 ```bash
 curl 'localhost:5005/model/parse?emulation_mode=dialogflow' -d '{"text": "hello"}'
+```
+
 The `emulation_mode` parameter tells Rasa that you want your JSON response to have the same format as you would
 get from the Dialogflow `sessions.detectIntent` endpoint (the format is
 described [here](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/DetectIntentResponse)).

--- a/docs/docs/migrate-from/google-dialogflow-to-rasa.mdx
+++ b/docs/docs/migrate-from/google-dialogflow-to-rasa.mdx
@@ -89,6 +89,6 @@ You can also leave it out to get the result in the usual Rasa format.
 ## Terminology:
 
 The words `intent`, `entity`, and `utterance` have the same meaning in Rasa as they do in Dialogflow.
-In Dialogflow, there is a concept called `Fulfillment`. In Rasa we call this a [Custom Action](./actions.mdx#custom-actions).
+In Dialogflow, there is a concept called `Fulfillment`. In Rasa we call this a [Custom Action](../actions.mdx#custom-actions).
 
 Join the [Rasa Community Forum](https://forum.rasa.com/) and let us know how your migration went!


### PR DESCRIPTION
Part of our [docs](https://rasa.com/docs/rasa/migrate-from/google-dialogflow-to-rasa/) don't render nicely because of a few backticks missing.

This PR fixes that. 

**What it currently looks like**

![image](https://user-images.githubusercontent.com/1019791/107606293-f5edc900-6c35-11eb-8413-402bee1ee106.png)
