### PR TITLE
Fix tagging the latest stable version as latest

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -333,7 +333,7 @@ jobs:
         # Fetch branch history
         git fetch --prune --unshallow
         LATEST_TAGGED_NON_ALPHA_RASA_VERSION=$(git tag | sort -r -V | grep -E "^[0-9.]+$" | head -n1)
-        CURRENT_TAG=${GITHUB_TAG/refs\/tags\//}
+        CURRENT_TAG=${GITHUB_REF#refs/tags/}
         # Return 'true' if tag version is equal or higher than the latest tagged Rasa version
         IS_NEWEST_VERSION=$((printf '%s\n%s\n' "${LATEST_TAGGED_NON_ALPHA_RASA_VERSION}" "$CURRENT_TAG" \
           | sort -V -C && echo true || echo false) || true)


### PR DESCRIPTION
**Proposed changes**:
- Use the `GITHUB_REF` variable instead of `GITHUB_TAG` that is a custom variable (the name is misleading)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
