### PR TITLE
Fixed slack double images

### DIFF
--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -69,7 +69,7 @@ class SlackBot(OutputChannel):
         image_block = {"type": "image", "image_url": image, "alt_text": image}
 
         await self._post_message(
-            channel=recipient, as_user=True, text=image, blocks=[image_block]
+            channel=recipient, as_user=True, text="", blocks=[image_block]
         )
 
     async def send_attachment(


### PR DESCRIPTION
**Proposed changes**:
- Rasa will not send the image url as text to slack, which results in 2 images showing up instead of 1, as per [issue  #5681](https://github.com/RasaHQ/rasa/issues/5681)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
