### PR TITLE
load schema files for `pykwalify` to avoid global `yaml` usage

### DIFF
--- a/changelog/7970.bugfix.md
+++ b/changelog/7970.bugfix.md
@@ -1,0 +1,3 @@
+Fixed a YAML validation error which happened when executing multiple validations
+concurrently. This could e.g. happen when sending concurrent requests to server
+endpoints which process YAML training data.

--- a/rasa/shared/utils/validation.py
+++ b/rasa/shared/utils/validation.py
@@ -154,9 +154,15 @@ def validate_yaml_schema(yaml_file_content: Text, schema_path: Text) -> None:
         PACKAGE_NAME, SCHEMA_EXTENSIONS_FILE
     )
 
+    # Load schema content using our YAML loader as `pykwalify` uses a global instance
+    # which can fail when used concurrently
+    schema_content = rasa.shared.utils.io.read_yaml_file(schema_file)
+    schema_utils_content = rasa.shared.utils.io.read_yaml_file(schema_utils_file)
+    schema_content = dict(schema_content, **schema_utils_content)
+
     c = Core(
         source_data=source_data,
-        schema_files=[schema_file, schema_utils_file],
+        schema_data=schema_content,
         extensions=[schema_extensions],
     )
 

--- a/tests/shared/utils/test_validation.py
+++ b/tests/shared/utils/test_validation.py
@@ -1,3 +1,5 @@
+from threading import Thread
+
 import pytest
 
 from pep440_version_utils import Version
@@ -12,6 +14,7 @@ from rasa.shared.constants import (
     DOMAIN_SCHEMA_FILE,
     LATEST_TRAINING_DATA_FORMAT_VERSION,
 )
+from rasa.shared.nlu.training_data.formats.rasa_yaml import NLU_SCHEMA_FILE
 from rasa.shared.utils.validation import KEY_TRAINING_DATA_FORMAT_VERSION
 
 
@@ -181,3 +184,55 @@ async def test_invalid_training_data_format_version_warns():
     for version in [invalid_version_1, invalid_version_2]:
         with pytest.warns(UserWarning):
             assert validation_utils.validate_training_data_format_version(version, "")
+
+
+def test_concurrent_schema_validation():
+    successful_results = []
+
+    def validate() -> None:
+        payload = """
+version: "2.0"
+nlu:
+- intent: greet
+  examples: |
+    - hey
+    - hello
+    - hi
+    - hello there
+    - good morning
+    - good evening
+    - moin
+    - hey there
+    - let's go
+    - hey dude
+    - goodmorning
+    - goodevening
+    - good afternoon
+- intent: goodbye
+  examples: |
+    - good afternoon
+    - cu
+    - good by
+    - cee you later
+    - good night
+    - bye
+    - goodbye
+    - have a nice day
+    - see you around
+    - bye bye
+    - see you later
+        """
+        rasa.shared.utils.validation.validate_yaml_schema(payload, NLU_SCHEMA_FILE)
+        successful_results.append(True)
+
+    threads = []
+    for i in range(10):
+        threads.append(Thread(target=validate))
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    assert len(successful_results) == len(threads)


### PR DESCRIPTION
**Proposed changes**:
- `pykwalify` uses a global `ruamel.yaml` instance. This instance sets object attributes while reading files (e.g. the YAML schema files itself!) . This can lead to problem when we  have multiple concurrent yaml validations.  Fix: Either load the yaml files for pykwalify (what I did in my PR) or provide the schema files in json

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
