### PR TITLE
External Message Entity Auto-Filling Fix

### DIFF
--- a/changelog/7972.bugfix.md
+++ b/changelog/7972.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug where, if a user injects an intent using the HTTP API, slot auto-filling is not performed on the entities provided.

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -476,7 +476,8 @@ class MessageProcessor:
         input_channel = tracker.get_latest_input_channel()
 
         tracker.update(
-            UserUttered.create_external(intent_name, entity_list, input_channel)
+            UserUttered.create_external(intent_name, entity_list, input_channel),
+            self.domain,
         )
         await self._predict_and_execute_next_action(output_channel, tracker)
         # save tracker state to continue conversation from this state

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1505,6 +1505,21 @@ async def test_trigger_intent(rasa_app: SanicASGITestClient):
     assert parsed_content["messages"]
 
 
+async def test_trigger_intent_with_entity(rasa_app: SanicASGITestClient):
+    name = "Sara"
+    data = {INTENT_NAME_KEY: "greet", "entities": {"name": name}}
+    _, response = await rasa_app.post(
+        "/conversations/test_trigger/trigger_intent", json=data
+    )
+
+    assert response.status == HTTPStatus.OK
+
+    parsed_content = response.json()
+    assert parsed_content["tracker"]
+    assert parsed_content["tracker"]["slots"] == name
+    assert parsed_content["messages"]
+
+
 async def test_trigger_intent_with_missing_intent_name(rasa_app: SanicASGITestClient):
     test_sender = "test_trigger_intent_with_missing_action_name"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1506,8 +1506,9 @@ async def test_trigger_intent(rasa_app: SanicASGITestClient):
 
 
 async def test_trigger_intent_with_entity(rasa_app: SanicASGITestClient):
-    name = "Sara"
-    data = {INTENT_NAME_KEY: "greet", "entities": {"name": name}}
+    entity_name = "name"
+    entity_value = "Sara"
+    data = {INTENT_NAME_KEY: "greet", "entities": {entity_name: entity_value}}
     _, response = await rasa_app.post(
         "/conversations/test_trigger/trigger_intent", json=data
     )
@@ -1523,7 +1524,8 @@ async def test_trigger_intent_with_entity(rasa_app: SanicASGITestClient):
 
     assert parsed_content["tracker"]
     assert parsed_content["messages"]
-    assert last_slot_set_event["value"] == name
+    assert last_slot_set_event["name"] == entity_name
+    assert last_slot_set_event["value"] == entity_value
 
 
 async def test_trigger_intent_with_missing_intent_name(rasa_app: SanicASGITestClient):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1515,9 +1515,15 @@ async def test_trigger_intent_with_entity(rasa_app: SanicASGITestClient):
     assert response.status == HTTPStatus.OK
 
     parsed_content = response.json()
+    last_slot_set_event = [
+        event
+        for event in parsed_content["tracker"]["events"]
+        if event["event"] == "slot"
+    ][-1]
+
     assert parsed_content["tracker"]
-    assert parsed_content["tracker"]["slots"] == name
     assert parsed_content["messages"]
+    assert last_slot_set_event["value"] == name
 
 
 async def test_trigger_intent_with_missing_intent_name(rasa_app: SanicASGITestClient):


### PR DESCRIPTION
**Proposed changes**:
- Fixed external message's tracker update call to enable slot-autofilling when an entity is passed in via the t[rigger_intent API endpoint](https://rasa.com/docs/rasa/pages/http-api#operation/triggerConversationIntent)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
