### PR TITLE
Fix a link markdown

### DIFF
--- a/docs/docs/reaching-out-to-user.mdx
+++ b/docs/docs/reaching-out-to-user.mdx
@@ -90,7 +90,7 @@ In a real-life scenario, your external device would get the conversation ID from
 In the dry plant example, you might have a database of plants, the users that water them, and the users'
 conversation IDs. Your Raspberry Pi would get the conversation ID directly from the database.
 To try out the reminderbot example locally, you'll need to get the conversation ID manually. See
-the reminderbot [README](https://github.com/RasaHQ/rasa/blob/main/examples/reminderbot for more information.
+the reminderbot [README](https://github.com/RasaHQ/rasa/blob/main/examples/reminderbot) for more information.
 
 ### 3. Add NLU Training Data
 


### PR DESCRIPTION
**Proposed changes**:
- Fix markdown of link to the reminderbot's README file in docs ("[Reaching Out to the User](https://rasa.com/docs/rasa/reaching-out-to-user#2-get-the-conversation-id)")

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
