### PR TITLE
Added Locking Mechanism to Reminders Handler

### DIFF
--- a/changelog/8001.bugfix.md
+++ b/changelog/8001.bugfix.md
@@ -1,0 +1,1 @@
+Fixed bug where the conversation does not lock before handling a reminder event.

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -824,6 +824,7 @@ class Agent:
             self.policy_ensemble,
             self.domain,
             self.tracker_store,
+            self.lock_store,
             self.nlg,
             action_endpoint=self.action_endpoint,
             message_preprocessor=preprocessor,

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -44,6 +44,7 @@ from rasa.shared.constants import (
     UTTER_PREFIX,
 )
 from rasa.core.nlg import NaturalLanguageGenerator
+from rasa.core.lock_store import LockStore
 from rasa.core.policies.ensemble import PolicyEnsemble
 import rasa.core.tracker_store
 import rasa.shared.core.trackers
@@ -63,6 +64,7 @@ class MessageProcessor:
         policy_ensemble: PolicyEnsemble,
         domain: Domain,
         tracker_store: rasa.core.tracker_store.TrackerStore,
+        lock_store: LockStore,
         generator: NaturalLanguageGenerator,
         action_endpoint: Optional[EndpointConfig] = None,
         max_number_of_predictions: int = MAX_NUMBER_OF_PREDICTIONS,
@@ -74,6 +76,7 @@ class MessageProcessor:
         self.policy_ensemble = policy_ensemble
         self.domain = domain
         self.tracker_store = tracker_store
+        self.lock_store = lock_store
         self.max_number_of_predictions = max_number_of_predictions
         self.message_preprocessor = message_preprocessor
         self.on_circuit_break = on_circuit_break
@@ -419,22 +422,25 @@ class MessageProcessor:
     ) -> None:
         """Handle a reminder that is triggered asynchronously."""
 
-        tracker = await self.fetch_tracker_and_update_session(sender_id, output_channel)
+        async with self.lock_store.lock(sender_id):
+            tracker = await self.get_tracker_with_session_start(
+                sender_id, output_channel
+            )
 
-        if (
-            reminder_event.kill_on_user_message
-            and self._has_message_after_reminder(tracker, reminder_event)
-            or not self._is_reminder_still_valid(tracker, reminder_event)
-        ):
-            logger.debug(
-                f"Canceled reminder because it is outdated ({reminder_event})."
-            )
-        else:
-            intent = reminder_event.intent
-            entities = reminder_event.entities or {}
-            await self.trigger_external_user_uttered(
-                intent, entities, tracker, output_channel
-            )
+            if (
+                reminder_event.kill_on_user_message
+                and self._has_message_after_reminder(tracker, reminder_event)
+                or not self._is_reminder_still_valid(tracker, reminder_event)
+            ):
+                logger.debug(
+                    f"Canceled reminder because it is outdated ({reminder_event})."
+                )
+            else:
+                intent = reminder_event.intent
+                entities = reminder_event.entities or {}
+                await self.trigger_external_user_uttered(
+                    intent, entities, tracker, output_channel
+                )
 
     async def trigger_external_user_uttered(
         self,

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -421,7 +421,6 @@ class MessageProcessor:
         output_channel: OutputChannel,
     ) -> None:
         """Handle a reminder that is triggered asynchronously."""
-
         async with self.lock_store.lock(sender_id):
             tracker = await self.get_tracker_with_session_start(
                 sender_id, output_channel

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -422,7 +422,7 @@ class MessageProcessor:
     ) -> None:
         """Handle a reminder that is triggered asynchronously."""
         async with self.lock_store.lock(sender_id):
-            tracker = await self.get_tracker_with_session_start(
+            tracker = await self.fetch_tracker_and_update_session(
                 sender_id, output_channel
             )
 

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -9,6 +9,7 @@ from rasa.core.agent import Agent
 from rasa.core.policies.policy import PolicyPrediction
 from rasa.core.processor import MessageProcessor
 from rasa.core.tracker_store import InMemoryTrackerStore
+from rasa.core.lock_store import InMemoryLockStore
 from rasa.core.actions import action
 from rasa.core.actions.action import ActionExecutionRejection
 from rasa.shared.core.constants import ACTION_LISTEN_NAME, REQUESTED_SLOT
@@ -144,6 +145,7 @@ responses:
         default_agent.policy_ensemble,
         domain,
         InMemoryTrackerStore(domain),
+        InMemoryLockStore(),
         TemplatedNaturalLanguageGenerator(domain.templates),
     )
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -21,6 +21,7 @@ from rasa.core.policies.memoization import Policy
 from rasa.core.processor import MessageProcessor
 from rasa.shared.core.slots import Slot
 from rasa.core.tracker_store import InMemoryTrackerStore, MongoTrackerStore
+from rasa.core.lock_store import LockStore, InMemoryLockStore
 from rasa.shared.core.trackers import DialogueStateTracker
 
 DEFAULT_DOMAIN_PATH_WITH_SLOTS = "data/test_domains/default_with_slots.yml"
@@ -142,11 +143,13 @@ def default_channel() -> OutputChannel:
 @pytest.fixture
 async def default_processor(default_agent: Agent) -> MessageProcessor:
     tracker_store = InMemoryTrackerStore(default_agent.domain)
+    lock_store = InMemoryLockStore()
     return MessageProcessor(
         default_agent.interpreter,
         default_agent.policy_ensemble,
         default_agent.domain,
         tracker_store,
+        lock_store,
         TemplatedNaturalLanguageGenerator(default_agent.domain.templates),
     )
 

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -6,6 +6,7 @@ import time
 import uuid
 import json
 from _pytest.monkeypatch import MonkeyPatch
+from _pytest.logging import LogCaptureFixture
 from aioresponses import aioresponses
 from typing import Optional, Text, List, Callable, Type, Any, Tuple
 from unittest.mock import patch, Mock
@@ -134,7 +135,9 @@ async def test_http_parsing():
 
         inter = RasaNLUHttpInterpreter(endpoint_config=endpoint)
         try:
-            await MessageProcessor(inter, None, None, None, None).parse_message(message)
+            await MessageProcessor(inter, None, None, None, None, None).parse_message(
+                message
+            )
         except KeyError:
             pass  # logger looks for intent and entities, so we except
 
@@ -202,6 +205,31 @@ async def test_reminder_scheduled(
         f"{EXTERNAL_MESSAGE_PREFIX}remind",
         intent={INTENT_NAME_KEY: "remind", IS_EXTERNAL: True},
     )
+
+
+async def test_reminder_lock(
+    default_channel: CollectingOutputChannel,
+    default_processor: MessageProcessor,
+    caplog: LogCaptureFixture,
+):
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        sender_id = uuid.uuid4().hex
+
+        reminder = ReminderScheduled("remind", datetime.datetime.now())
+        tracker = default_processor.tracker_store.get_or_create_tracker(sender_id)
+
+        tracker.update(UserUttered("test"))
+        tracker.update(ActionExecuted("action_schedule_reminder"))
+        tracker.update(reminder)
+
+        default_processor.tracker_store.save(tracker)
+
+        await default_processor.handle_reminder(
+            reminder, sender_id, default_channel, default_processor.nlg
+        )
+
+        assert f"Deleted lock for conversation '{sender_id}'." in caplog.text
 
 
 async def test_trigger_external_latest_input_channel(


### PR DESCRIPTION
**Proposed changes**:
- Added lock_store as an input to MessageProcessor so that handle_reminder can properly lock the conversation
- Updated handle_reminder to lock the conversation before retrieving the tracker store & executing
- Updated default_processor to pass in InMemoryLockStore as a param for test cases
- Resolves Issue #7887

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
