### PR TITLE
add kwargs to kafka event broker

### DIFF
--- a/changelog/8007.bugfix.rst
+++ b/changelog/8007.bugfix.rst
@@ -1,0 +1,1 @@
+Added **kwargs parameter back to ``KafkaEventBroker`` to fix error when instantiating event broker with a config containing parameters only relevant to the event consumer, such as ``group_id``.

--- a/changelog/8007.bugfix.rst
+++ b/changelog/8007.bugfix.rst
@@ -1,1 +1,1 @@
-Added **kwargs parameter back to ``KafkaEventBroker`` to fix error when instantiating event broker with a config containing parameters only relevant to the event consumer, such as ``group_id``.
+Added ``**kwargs`` parameter back to ``KafkaEventBroker`` to fix error when instantiating event broker with a config containing parameters only relevant to the event consumer, such as ``group_id``

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -26,7 +26,7 @@ class KafkaEventBroker(EventBroker):
         client_id=None,
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
-        **kwargs 
+        **kwargs
     ) -> None:
 
         self.producer = None
@@ -157,7 +157,7 @@ class KafkaProducer(KafkaEventBroker):
         topic="rasa_core_events",
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
-        **kwargs 
+        **kwargs
     ) -> None:
         raise_warning(
             "The `KafkaProducer` class is deprecated, please inherit "

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -26,6 +26,7 @@ class KafkaEventBroker(EventBroker):
         client_id=None,
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
+        **kwargs 
     ) -> None:
 
         self.producer = None
@@ -156,6 +157,7 @@ class KafkaProducer(KafkaEventBroker):
         topic="rasa_core_events",
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
+        **kwargs 
     ) -> None:
         raise_warning(
             "The `KafkaProducer` class is deprecated, please inherit "
@@ -176,4 +178,5 @@ class KafkaProducer(KafkaEventBroker):
             topic,
             security_protocol,
             loglevel,
+            **kwargs
         )

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -26,7 +26,7 @@ class KafkaEventBroker(EventBroker):
         client_id=None,
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
-        **kwargs
+        **kwargs,
     ) -> None:
 
         self.producer = None
@@ -157,7 +157,7 @@ class KafkaProducer(KafkaEventBroker):
         topic="rasa_core_events",
         security_protocol="SASL_PLAINTEXT",
         loglevel=logging.ERROR,
-        **kwargs
+        **kwargs,
     ) -> None:
         raise_warning(
             "The `KafkaProducer` class is deprecated, please inherit "
@@ -178,5 +178,5 @@ class KafkaProducer(KafkaEventBroker):
             topic,
             security_protocol,
             loglevel,
-            **kwargs
+            **kwargs,
         )


### PR DESCRIPTION
**Proposed changes**:
- Add a **kwargs argument to the Kafka event broker to allow using the config for a Kafka event consumer, which may contain parameters not supported by a Kafka producer, such as in the case of deploying Rasa X with the helm charts

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
