### PR TITLE
Return fresh copy of context to make sure telemetry always records OS

### DIFF
--- a/changelog/8016.mis.md
+++ b/changelog/8016.mis.md
@@ -1,0 +1,1 @@
+Fixed telemetry reporting of OS.

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -461,3 +461,13 @@ def test_sentry_strips_absolute_path_from_dist_packages():
 
     stack_frames = stripped["exception"]["values"][0]["stacktrace"]["frames"]
     assert stack_frames[0]["filename"] == f"dist-packages{os.path.sep}rasa\\train.py"
+
+
+def test_context_contains_os():
+    context = telemetry._default_context_fields()
+
+    assert "os" in context
+
+    context.pop("os")
+
+    assert "os" in telemetry._default_context_fields()


### PR DESCRIPTION
**Proposed changes**:
- Return fresh copy of telemetry context to make sure telemetry always records OS

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
