### PR TITLE
Check domain file does not include NLU keys

### DIFF
--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -64,6 +64,12 @@ ALL_DOMAIN_KEYS = [
     KEY_E2E_ACTIONS,
 ]
 
+DISALLOWED_DOMAIN_KEYS = [
+    "nlu",
+    "stories",
+    "rules",
+]
+
 PREV_PREFIX = "prev_"
 
 # State is a dictionary with keys (USER, PREVIOUS_ACTION, SLOTS, ACTIVE_LOOP)
@@ -1588,6 +1594,9 @@ class Domain:
         try:
             content = rasa.shared.utils.io.read_yaml_file(filename)
         except (ValueError, YamlSyntaxException):
+            return False
+
+        if any(key in content for key in DISALLOWED_DOMAIN_KEYS):
             return False
 
         return any(key in content for key in ALL_DOMAIN_KEYS)

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -34,6 +34,7 @@ from rasa.shared.core.domain import (
     Domain,
     KEY_FORMS,
     KEY_E2E_ACTIONS,
+    DISALLOWED_DOMAIN_KEYS,
 )
 from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.shared.core.events import ActionExecuted, SlotSet, UserUttered
@@ -1299,6 +1300,23 @@ def test_is_valid_domain_doesnt_raise_with_valid_domain(tmpdir: Path):
         domain_path,
     )
     assert Domain.is_domain_file(domain_path)
+
+
+@pytest.mark.parametrize("disallowed_key", DISALLOWED_DOMAIN_KEYS)
+def test_is_valid_domain_false_with_nlu_file(disallowed_key, tmpdir: Path):
+    domain_path = str(tmpdir / "domain.yml")
+    rasa.shared.utils.io.write_text_file(
+        f"""
+        responses:
+          utter_greet:
+            - text: hey there!
+        {disallowed_key}:
+          - intent: greet
+            examples: |
+              - hello""",
+        domain_path,
+    )
+    assert not Domain.is_domain_file(domain_path)
 
 
 def test_is_valid_domain_doesnt_raise_with_invalid_domain(tmpdir: Path):


### PR DESCRIPTION
**Proposed changes**:
This would allow us to consider domain files in the `data/` directory
again in Rasa X. We currently filter those out, since NLU files with a
`responses` key would wrongly be identified as domain files.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
