### PR TITLE
Eliminate the CI warnings caused from the migration of gelu activation in TensorFlow

### DIFF
--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -1094,7 +1094,7 @@ class TED(TransformerRasaModel):
         dialogue_transformed, attention_weights = self._tf_layers[
             f"transformer.{DIALOGUE}"
         ](dialogue_in, 1 - mask, self._training)
-        dialogue_transformed = tf.keras.activations.gelu(dialogue_transformed)
+        dialogue_transformed = tf.nn.gelu(dialogue_transformed)
 
         if self.max_history_featurizer_is_used:
             # pick last vector if max history featurizer is used, since we inverted

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -1094,7 +1094,7 @@ class TED(TransformerRasaModel):
         dialogue_transformed, attention_weights = self._tf_layers[
             f"transformer.{DIALOGUE}"
         ](dialogue_in, 1 - mask, self._training)
-        dialogue_transformed = tfa.activations.gelu(dialogue_transformed)
+        dialogue_transformed = tf.keras.activations.gelu(dialogue_transformed)
 
         if self.max_history_featurizer_is_used:
             # pick last vector if max history featurizer is used, since we inverted

--- a/rasa/utils/tensorflow/layers.py
+++ b/rasa/utils/tensorflow/layers.py
@@ -257,7 +257,7 @@ class Ffnn(tf.keras.layers.Layer):
                 DenseWithSparseWeights(
                     units=layer_size,
                     sparsity=sparsity,
-                    activation=tfa.activations.gelu,
+                    activation=tf.nn.gelu,
                     kernel_regularizer=l2_regularizer,
                     name=f"hidden_layer_{layer_name_suffix}_{i}",
                 )

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -1078,7 +1078,7 @@ class TransformerRasaModel(RasaModel):
 
         if num_layers > 0:
             # apply activation
-            outputs = tfa.activations.gelu(outputs)
+            outputs = tf.nn.gelu(outputs)
 
         return outputs, inputs, seq_ids, lm_mask_bool, attention_weights
 

--- a/rasa/utils/tensorflow/transformer.py
+++ b/rasa/utils/tensorflow/transformer.py
@@ -439,9 +439,7 @@ class TransformerEncoderLayer(tf.keras.layers.Layer):
         self._ffn_layers = [
             tf.keras.layers.LayerNormalization(epsilon=1e-6),
             DenseWithSparseWeights(
-                units=filter_units,
-                activation=tf.keras.activations.gelu,
-                sparsity=sparsity,
+                units=filter_units, activation=tf.nn.gelu, sparsity=sparsity,
             ),  # (batch_size, length, filter_units)
             tf.keras.layers.Dropout(dropout_rate),
             DenseWithSparseWeights(

--- a/rasa/utils/tensorflow/transformer.py
+++ b/rasa/utils/tensorflow/transformer.py
@@ -439,7 +439,9 @@ class TransformerEncoderLayer(tf.keras.layers.Layer):
         self._ffn_layers = [
             tf.keras.layers.LayerNormalization(epsilon=1e-6),
             DenseWithSparseWeights(
-                units=filter_units, activation=tfa.activations.gelu, sparsity=sparsity
+                units=filter_units,
+                activation=tf.keras.activations.gelu,
+                sparsity=sparsity,
             ),  # (batch_size, length, filter_units)
             tf.keras.layers.Dropout(dropout_rate),
             DenseWithSparseWeights(


### PR DESCRIPTION
**Description**:
This PR is part of the effort to close this [Issue#7738](https://github.com/RasaHQ/rasa/issues/7738) hence to reduce the amount of warnings that are raised when running all tests in the CI. From the first [investigation](https://docs.google.com/spreadsheets/d/1KtGQdEr2RzoZx7tACns_Sv6tb7uuJpn7Ares6ZpY92w/edit#gid=439956613), it seems that this warning (`DeprecationWarning: gelu activation has been migrated to core TensorFlow`) for which the current PR was opened, has the most occurrences (it appears in total in 2142 tests as seen in the log file below).


**Potential related issues/PRs to this migration**:
- In this [Issue#550](https://github.com/tensorflow/addons/issues/550) they describe the intention of migrating gelu activation to core TensorFlow.
- one of the [PRs](https://github.com/tensorflow/tensorflow/pull/41178) of the implementation. 
- Deprecation of gelu [Issue#2005](https://github.com/tensorflow/addons/issues/2005).
- Maybe this from [TensorFlow docs](https://www.tensorflow.org/api_docs/python/tf/keras/activations/gelu) is useful.

**Warnings as they appear in the CI log file (_3_Run Tests (ubuntu-latest, 3.8).txt_)**:
```
2021-02-22T12:29:04.2560900Z .venv/lib/python3.8/site-packages/tensorflow_addons/activations/gelu.py:70: 1775 tests with warnings
2021-02-22T12:29:04.2562970Z   /home/runner/work/rasa/rasa/.venv/lib/python3.8/site-packages/tensorflow_addons/activations/gelu.py:70: DeprecationWarning: gelu activation has been migrated to core TensorFlow, and will be deprecated in Addons 0.13.
2021-02-22T12:29:04.2564350Z     warnings.warn(
2021-02-22T12:29:04.2564680Z 
2021-02-22T12:29:04.2623302Z .venv/lib/python3.8/site-packages/tensorflow/python/autograph/impl/api.py:493: 367 tests with warnings
2021-02-22T12:29:04.2625352Z   /home/runner/work/rasa/rasa/.venv/lib/python3.8/site-packages/tensorflow/python/autograph/impl/api.py:493: DeprecationWarning: gelu activation has been migrated to core TensorFlow, and will be deprecated in Addons 0.13.
```


**Proposed changes**:
- Update TensorFlow core and Addons 0.13 maybe ?
- The code changes in this PR are not solving the issue but are indicative of the places in the code where `gelu activation` is called. So if an update is done, these are the calls (at least these ones) that will need to be updated.


**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
