### PR TITLE
Update links to Sanic docs in our documentation

### DIFF
--- a/changelog/8080.docs.md
+++ b/changelog/8080.docs.md
@@ -1,0 +1,1 @@
+Update links to Sanic docs in the documentation.

--- a/docs/docs/http-api.mdx
+++ b/docs/docs/http-api.mdx
@@ -39,7 +39,7 @@ By default, the HTTP server runs as a single process. You can change the number
 of worker processes using the `SANIC_WORKERS` environment variable. It is
 recommended that you set the number of workers to the number of available CPU cores
 (check out the
-[Sanic docs](https://sanic.readthedocs.io/en/latest/sanic/deploying.html#workers)
+[Sanic docs](https://sanic.readthedocs.io/en/stable/sanic/deploying.html#workers)
 for more details). This will only work in combination with the
 `RedisLockStore` (see [Lock Stores](./lock-stores.mdx).
 

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -1055,7 +1055,7 @@ model before trying to use it with this improved version.
 * The `--num_threads` parameter was removed from the `run` command. The
   server will always run single-threaded, but will now run asynchronously. If you want to
   make use of multiple processes, feel free to check out the [Sanic server
-  documentation](https://sanic.readthedocs.io/en/latest/sanic/deploying.html#running-via-gunicorn).
+  documentation](https://sanic.readthedocs.io/en/stable/sanic/deploying.html#running-via-gunicorn).
 
 * To avoid conflicts in script parameter names, connectors in the `run` command now need to be specified with
   `--connector`, as `-c` is no longer supported. The maximum history in the `rasa visualize` command needs to be


### PR DESCRIPTION
**Proposed changes**:
Sanic recently updated links so the old ones now return 404 which makes `cd docs && yarn mdx-lint` command fail.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
