### PR TITLE
Fix a bug with `read_yaml` function failing when trying to expand an environment variable which contains a `$`

### DIFF
--- a/changelog/7932.bugfix.md
+++ b/changelog/7932.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug with `read_yaml` function failing when trying to expand an environment variable which contains a `$`

--- a/changelog/7932.bugfix.md
+++ b/changelog/7932.bugfix.md
@@ -1,1 +1,18 @@
-Fix a bug with `read_yaml` function failing when trying to expand an environment variable which contains a `$`
+Fixed a bug when interpolating environment variables in YAML files which included `$` in their value. 
+This led to the following stack trace:
+
+```
+ValueError: Error when trying to expand the environment variables in '${PASSWORD}'. Please make sure to also set these environment variables: '['$qwerty']'.
+(13 additional frame(s) were not displayed)
+...
+  File "rasa/utils/endpoints.py", line 26, in read_endpoint_config
+    content = rasa.shared.utils.io.read_config_file(filename)
+  File "rasa/shared/utils/io.py", line 527, in read_config_file
+    content = read_yaml_file(filename)
+  File "rasa/shared/utils/io.py", line 368, in read_yaml_file
+    return read_yaml(read_file(filename, DEFAULT_ENCODING))
+  File "rasa/shared/utils/io.py", line 349, in read_yaml
+    return yaml_parser.load(content) or {}
+  File "rasa/shared/utils/io.py", line 314, in env_var_constructor
+    " variables: '{}'.".format(value, not_expanded)
+```

--- a/rasa/shared/utils/io.py
+++ b/rasa/shared/utils/io.py
@@ -310,8 +310,8 @@ def replace_environment_variables() -> None:
         """Process environment variables found in the YAML."""
         value = loader.construct_scalar(node)
         expanded_vars = os.path.expandvars(value)
-        if "$" in expanded_vars:
-            not_expanded = [w for w in expanded_vars.split() if "$" in w]
+        not_expanded = [w for w in expanded_vars.split() if "$" in w and w in value]
+        if not_expanded:
             raise ValueError(
                 "Error when trying to expand the environment variables"
                 " in '{}'. Please make sure to also set these environment"

--- a/rasa/shared/utils/io.py
+++ b/rasa/shared/utils/io.py
@@ -310,7 +310,9 @@ def replace_environment_variables() -> None:
         """Process environment variables found in the YAML."""
         value = loader.construct_scalar(node)
         expanded_vars = os.path.expandvars(value)
-        not_expanded = [w for w in expanded_vars.split() if w.startswith("$") and w in value]
+        not_expanded = [
+            w for w in expanded_vars.split() if w.startswith("$") and w in value
+        ]
         if not_expanded:
             raise ValueError(
                 "Error when trying to expand the environment variables"

--- a/rasa/shared/utils/io.py
+++ b/rasa/shared/utils/io.py
@@ -310,7 +310,7 @@ def replace_environment_variables() -> None:
         """Process environment variables found in the YAML."""
         value = loader.construct_scalar(node)
         expanded_vars = os.path.expandvars(value)
-        not_expanded = [w for w in expanded_vars.split() if "$" in w and w in value]
+        not_expanded = [w for w in expanded_vars.split() if w.startswith("$") and w in value]
         if not_expanded:
             raise ValueError(
                 "Error when trying to expand the environment variables"

--- a/tests/shared/utils/test_io.py
+++ b/tests/shared/utils/test_io.py
@@ -202,6 +202,17 @@ def test_environment_variable_dict_with_prefix_and_with_postfix():
     assert content["model"]["test"] == "dir/test/dir"
 
 
+def test_environment_variable_with_dollar_char():
+    os.environ["variable1"] = "$test1"
+    os.environ["variable2"] = "test2"
+    content = "model: \n  test1: ${variable1}\n  test2: ${variable2}"
+
+    content = rasa.shared.utils.io.read_yaml(content)
+
+    assert content["model"]["test1"] == "$test1"
+    assert content["model"]["test2"] == "test2"
+
+
 def test_emojis_in_yaml():
     test_data = """
     data:

--- a/tests/shared/utils/test_io.py
+++ b/tests/shared/utils/test_io.py
@@ -213,6 +213,15 @@ def test_environment_variable_with_dollar_char():
     assert content["model"]["test2"] == "test2"
 
 
+def test_environment_variable_with_dollar_char_in_the_middle():
+    os.environ["variable1"] = "test$123"
+    content = "model: \n  test1: ${variable1}"
+
+    content = rasa.shared.utils.io.read_yaml(content)
+
+    assert content["model"]["test1"] == "test$123"
+
+
 def test_emojis_in_yaml():
     test_data = """
     data:


### PR DESCRIPTION
**Proposed changes**:
- fix #7932

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
