### PR TITLE
fix ted training e2e entities when none are given

### DIFF
--- a/changelog/8194.bugfix.md
+++ b/changelog/8194.bugfix.md
@@ -1,0 +1,2 @@
+Fix `TEDPolicy` training e2e entities when no entities are present in the stories
+but there are entities in the domain.

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -393,6 +393,19 @@ class TEDPolicy(Policy):
 
         return label_data, encoded_all_labels
 
+    @staticmethod
+    def _should_extract_entities(
+        entity_tags: List[List[Dict[Text, List["Features"]]]]
+    ) -> bool:
+        for turns_tags in entity_tags:
+            for turn_tags in turns_tags:
+                if turn_tags:
+                    # if all indices are `0`
+                    # it means that all the inputs only contain NO_ENTITY_TAG
+                    if np.any(turn_tags[ENTITY_TAGS][0].features):
+                        return True
+        return False
+
     def _create_data_for_entities(
         self, entity_tags: Optional[List[List[Dict[Text, List["Features"]]]]]
     ) -> Optional[Data]:
@@ -400,7 +413,7 @@ class TEDPolicy(Policy):
             return
 
         # check that there are real entity tags
-        if entity_tags and any([any(turn_tags) for turn_tags in entity_tags]):
+        if entity_tags and self._should_extract_entities(entity_tags):
             entity_tags_data, _ = convert_to_data_format(entity_tags)
             return entity_tags_data
 

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -399,11 +399,10 @@ class TEDPolicy(Policy):
     ) -> bool:
         for turns_tags in entity_tags:
             for turn_tags in turns_tags:
-                if turn_tags:
+                if turn_tags and np.any(turn_tags[ENTITY_TAGS][0].features):
                     # if all indices are `0`
                     # it means that all the inputs only contain NO_ENTITY_TAG
-                    if np.any(turn_tags[ENTITY_TAGS][0].features):
-                        return True
+                    return True
         return False
 
     def _create_data_for_entities(

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -399,9 +399,9 @@ class TEDPolicy(Policy):
     ) -> bool:
         for turns_tags in entity_tags:
             for turn_tags in turns_tags:
+                # if turn_tags are empty or all entity tag indices are `0`
+                # it means that all the inputs only contain NO_ENTITY_TAG
                 if turn_tags and np.any(turn_tags[ENTITY_TAGS][0].features):
-                    # if all indices are `0`
-                    # it means that all the inputs only contain NO_ENTITY_TAG
                     return True
         return False
 

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -35,7 +35,6 @@ from rasa.utils.tensorflow.constants import (
     VALUE_RELATIVE_ATTENTION,
     MODEL_CONFIDENCE,
     COSINE,
-    INNER,
     AUTO,
     LINEAR_NORM,
 )
@@ -93,7 +92,7 @@ class TestTEDPolicy(PolicyTestCollection):
 
     def create_policy(
         self, featurizer: Optional[TrackerFeaturizer], priority: int
-    ) -> Policy:
+    ) -> TEDPolicy:
         return TEDPolicy(featurizer=featurizer, priority=priority)
 
     def test_similarity_type(self, trained_policy: TEDPolicy):


### PR DESCRIPTION
**Proposed changes**:
- fix ted training e2e entities when none are given in the stories but there are entities in the domain

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
