### PR TITLE
Added a timeout on a test's mongodb connection 

### DIFF
--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -900,7 +900,14 @@ def test_login_db_with_no_postgresql(tmp_path: Path):
 
 
 @pytest.mark.parametrize(
-    "config", [{"type": "mongod", "url": "mongodb://0.0.0.0:42",}, {"type": "dynamo",}],
+    "config",
+    [
+        {
+            "type": "mongod",
+            "url": "mongodb://0.0.0.0:42/?serverSelectionTimeoutMS=5000",
+        },
+        {"type": "dynamo",},
+    ],
 )
 def test_tracker_store_connection_error(config: Dict, default_domain: Domain):
     store = EndpointConfig.from_dict(config)


### PR DESCRIPTION
**Proposed changes**:
- Added a timeout of 5 seconds on the mongo db connection of the test
```
pytest tests/core/test_tracker_stores.py::test_tracker_store_connection_error
```
and replacing that way the default MongoDB setting of 30s.

- There are [3 main parameters](https://scalegrid.io/blog/understanding-mongodb-client-timeout-options/) that can affect the timeout of the MongoDB Client : 
  - `serverSelectionTimeoutMS`
  - `connectTimeoutMS` and 
  - `socketTimeoutMS`
- I tried them all and the only one that had any effect was the `serverSelectionTimeoutMS` and [this](https://stackoverflow.com/questions/39297979/how-to-set-connection-timeout-for-mongodb-using-pymongo) stackoverflow post reinforced my decision to use this parameter. 
- I chose 5 seconds thinking that is a good timeout option for a test.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
