### PR TITLE
Fix test_server.py:test_pushing_event occasionally failing

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1175,6 +1175,8 @@ async def test_pushing_event(rasa_app: SanicASGITestClient, event: Event):
     serialized_event.pop("timestamp")
 
     time_before_adding_events = time.time()
+    # Wait a bit so that the server-generated timestamp is strictly greater
+    # than time_before_adding_events
     time.sleep(0.01)
     _, response = await rasa_app.post(
         f"{conversation}/tracker/events",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1175,6 +1175,7 @@ async def test_pushing_event(rasa_app: SanicASGITestClient, event: Event):
     serialized_event.pop("timestamp")
 
     time_before_adding_events = time.time()
+    time.sleep(0.01)
     _, response = await rasa_app.post(
         f"{conversation}/tracker/events",
         json=serialized_event,


### PR DESCRIPTION
**Proposed changes**:
The test case sometimes failed due to the code executing faster than expected, see [this failure](https://github.com/RasaHQ/rasa/pull/7589/checks?check_run_id=2138461367#step:12:105) for instance. I fixed this.

**Status (please check what you already did)**:
- [x] added some tests for the functionality