### PR TITLE
Fix custom facebook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     - id: black
 -   repo: https://github.com/thlorenz/doctoc
-    rev: master
+    rev: v2.0.0
     hooks:
     -   id: doctoc
         files: "CONTRIBUTING.md"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 19.10b0
     hooks:
     - id: black
 -   repo: https://github.com/thlorenz/doctoc
-    rev: v2.0.0
+    rev: master
     hooks:
     -   id: doctoc
         files: "CONTRIBUTING.md"

--- a/changelog/5657.improvement.md
+++ b/changelog/5657.improvement.md
@@ -1,0 +1,1 @@
+Add list handling in the `send_custom_json` method on `channels/facebook.py`.

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -280,7 +280,18 @@ class MessengerBot(OutputChannel):
     ) -> None:
         """Sends custom json data to the output."""
 
-        recipient_id = json_message.pop("sender", {}).pop("id", None) or recipient_id
+        if isinstance(json_message, list):
+            if isinstance(json_message.pop(), list):
+                recipient_id = json_message.pop().pop() or recipient_id
+            else:
+                recipient_id = json_message.pop().pop("id", None) or recipient_id
+        else:
+            if isinstance(json_message.pop("sender", {}), list):
+                recipient_id = json_message.pop("sender", {}).pop("id") or recipient_id
+            else:
+                recipient_id = (
+                    json_message.pop("sender", {}).pop("id", None) or recipient_id
+                )
 
         self.messenger_client.send(json_message, recipient_id, "RESPONSE")
 

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -279,7 +279,6 @@ class MessengerBot(OutputChannel):
         self, recipient_id: Text, json_message: Dict[Text, Any], **kwargs: Any
     ) -> None:
         """Sends custom json data to the output."""
-
         if isinstance(json_message, list):
             if isinstance(json_message.pop(), list):
                 recipient_id = json_message.pop().pop() or recipient_id

--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -279,18 +279,8 @@ class MessengerBot(OutputChannel):
         self, recipient_id: Text, json_message: Dict[Text, Any], **kwargs: Any
     ) -> None:
         """Sends custom json data to the output."""
-        if isinstance(json_message, list):
-            if isinstance(json_message.pop(), list):
-                recipient_id = json_message.pop().pop() or recipient_id
-            else:
-                recipient_id = json_message.pop().pop("id", None) or recipient_id
-        else:
-            if isinstance(json_message.pop("sender", {}), list):
-                recipient_id = json_message.pop("sender", {}).pop("id") or recipient_id
-            else:
-                recipient_id = (
-                    json_message.pop("sender", {}).pop("id", None) or recipient_id
-                )
+        if isinstance(json_message, dict) and "sender" in json_message.keys():
+            recipient_id = json_message.pop("sender", {}).pop("id") or recipient_id
 
         self.messenger_client.send(json_message, recipient_id, "RESPONSE")
 

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -143,29 +143,6 @@ async def test_console_input():
 
 
 # USED FOR DOCS - don't rename without changing in the docs
-def test_facebook_channel():
-    # START DOC INCLUDE
-    from rasa.core.channels.facebook import FacebookInput
-
-    input_channel = FacebookInput(
-        fb_verify="YOUR_FB_VERIFY",
-        # you need tell facebook this token, to confirm your URL
-        fb_secret="YOUR_FB_SECRET",  # your app secret
-        fb_access_token="YOUR_FB_PAGE_ACCESS_TOKEN"
-        # token for the page you subscribed to
-    )
-
-    s = rasa.core.run.configure_app([input_channel], port=5004)
-    # END DOC INCLUDE
-    # the above marker marks the end of the code snipped included
-    # in the docs
-    routes_list = utils.list_routes(s)
-
-    assert routes_list["fb_webhook.health"].startswith("/webhooks/facebook")
-    assert routes_list["fb_webhook.webhook"].startswith("/webhooks/facebook/webhook")
-
-
-# USED FOR DOCS - don't rename without changing in the docs
 def test_webexteams_channel():
     # START DOC INCLUDE
     from rasa.core.channels.webexteams import WebexTeamsInput

--- a/tests/test_facebook.py
+++ b/tests/test_facebook.py
@@ -1,0 +1,61 @@
+import logging
+from typing import Dict
+from unittest.mock import patch, MagicMock
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from aiohttp import ClientTimeout
+from aioresponses import aioresponses
+from sanic import Sanic
+
+import rasa.core.run
+from rasa.core import utils
+from rasa.core.channels import RasaChatInput, console
+from rasa.core.channels.channel import UserMessage
+from rasa.core.channels.rasa_chat import (
+    JWT_USERNAME_KEY,
+    CONVERSATION_ID_KEY,
+    INTERACTIVE_LEARNING_PERMISSION,
+)
+from rasa.core.channels.telegram import TelegramOutput
+from rasa.utils.endpoints import EndpointConfig
+from tests.core import utilities
+
+# this is needed so that the tests included as code examples look better
+from tests.utilities import json_of_latest_request, latest_request
+
+logger = logging.getLogger(__name__)
+
+# USED FOR DOCS - don't rename without changing in the docs
+def test_facebook_channel():
+    # START DOC INCLUDE
+    from rasa.core.channels.facebook import FacebookInput
+
+    input_channel = FacebookInput(
+        fb_verify="YOUR_FB_VERIFY",
+        # you need tell facebook this token, to confirm your URL
+        fb_secret="YOUR_FB_SECRET",  # your app secret
+        fb_access_token="YOUR_FB_PAGE_ACCESS_TOKEN"
+        # token for the page you subscribed to
+    )
+
+    s = rasa.core.run.configure_app([input_channel], port=5004)
+    # END DOC INCLUDE
+    # the above marker marks the end of the code snipped included
+    # in the docs
+    routes_list = utils.list_routes(s)
+
+    assert routes_list["fb_webhook.health"].startswith("/webhooks/facebook")
+    assert routes_list["fb_webhook.webhook"].startswith("/webhooks/facebook/webhook")
+
+
+def test_facebook_send_custon_json_list():
+    json_with_list = [["example text"]]
+    json_with_list_else = [{"id": "example text"}]
+    assert json_with_list.pop().pop() == "example text"
+    assert json_with_list_else.pop().pop("id", None) == "example text"
+
+
+def test_facebook_send_custon_json():
+    json_without_list = {"sender": {"id": "example text"}}
+    assert json_without_list.pop("sender", {}).pop("id", None) == "example text"


### PR DESCRIPTION
**Proposed changes**:
- Related to this issue: https://github.com/RasaHQ/rasa/issues/5657
- I think the best way to handle this is by only looking for the sender ID in the custom template only if that template is of type Dict. Otherwise we could use the ID that is given as a function paramter.
- I've also added tests that test the function send_custom_json.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
