### PR TITLE
included the enable-api command in step 5

### DIFF
--- a/docs/docs/migrate-from/google-dialogflow-to-rasa.mdx
+++ b/docs/docs/migrate-from/google-dialogflow-to-rasa.mdx
@@ -70,7 +70,7 @@ Press 'control + C' to quit.
 To start a server with your NLU model, run:
 
 ```bash
-rasa run
+rasa run --enable-api
 ```
 
 This will start a server listening on port 5005.


### PR DESCRIPTION
**Proposed changes**:
- Added ```enable-api``` to Step 5 so users following the documentation enable the API server before running the curl command in the next set of code.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
