### PR TITLE
Bug in is_entity_extractor_present() in rasa/nlu/test.py

### DIFF
--- a/data/test_config/stack_config.yml
+++ b/data/test_config/stack_config.yml
@@ -3,6 +3,7 @@
 language: en
 pipeline:
   - name: KeywordIntentClassifier
+  - name: RegexEntityExtractor
 
 # Configuration for Rasa Core.
 # https://rasa.com/docs/rasa/policies

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -1352,7 +1352,7 @@ def is_entity_extractor_present(interpreter: Interpreter) -> bool:
     """Checks whether entity extractor is present."""
 
     extractors = get_entity_extractors(interpreter)
-    return extractors != []
+    return len(extractors) > 0
 
 
 def is_intent_classifier_present(interpreter: Interpreter) -> bool:

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -1350,14 +1350,12 @@ def get_entity_extractors(interpreter: Interpreter) -> Set[Text]:
 
 def is_entity_extractor_present(interpreter: Interpreter) -> bool:
     """Checks whether entity extractor is present."""
-
     extractors = get_entity_extractors(interpreter)
     return len(extractors) > 0
 
 
 def is_intent_classifier_present(interpreter: Interpreter) -> bool:
     """Checks whether intent classifier is present."""
-
     from rasa.nlu.classifiers.classifier import IntentClassifier
 
     intent_classifiers = [

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -6,7 +6,6 @@ import sys
 
 from pathlib import Path
 from typing import Text, Iterator, List, Dict, Any, Set, Optional
-
 from tests.conftest import AsyncMock
 
 import pytest

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -6,6 +6,9 @@ import sys
 
 from pathlib import Path
 from typing import Text, Iterator, List, Dict, Any, Set, Optional
+
+from tensorflow_text import WhitespaceTokenizer
+
 from tests.conftest import AsyncMock
 
 import pytest
@@ -58,6 +61,7 @@ from rasa.nlu.test import (
     align_entity_predictions,
     determine_intersection,
     determine_token_labels,
+    is_entity_extractor_present,
 )
 from rasa.nlu.tokenizers.tokenizer import Token
 from rasa.shared.constants import DEFAULT_NLU_FALLBACK_INTENT_NAME
@@ -1219,3 +1223,13 @@ def test_replacing_fallback_intent():
         and prediction.confidence == expected_confidence
         for prediction in intent_evaluations
     )
+
+
+@pytest.mark.parametrize(
+    "components, expected_result",
+    [([CRFEntityExtractor()], True),
+     ([WhitespaceTokenizer()], False)]
+)
+def test_is_entity_extractor_present(components, expected_result):
+    interpreter = Interpreter(components, context=None)
+    assert is_entity_extractor_present(interpreter) == expected_result

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -7,8 +7,6 @@ import sys
 from pathlib import Path
 from typing import Text, Iterator, List, Dict, Any, Set, Optional
 
-from tensorflow_text import WhitespaceTokenizer
-
 from tests.conftest import AsyncMock
 
 import pytest
@@ -64,6 +62,7 @@ from rasa.nlu.test import (
     is_entity_extractor_present,
 )
 from rasa.nlu.tokenizers.tokenizer import Token
+from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.shared.constants import DEFAULT_NLU_FALLBACK_INTENT_NAME
 from rasa.shared.importers.importer import TrainingDataImporter
 from rasa.shared.nlu.constants import (

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -1227,8 +1227,7 @@ def test_replacing_fallback_intent():
 
 @pytest.mark.parametrize(
     "components, expected_result",
-    [([CRFEntityExtractor()], True),
-     ([WhitespaceTokenizer()], False)]
+    [([CRFEntityExtractor()], True), ([WhitespaceTokenizer()], False)],
 )
 def test_is_entity_extractor_present(components, expected_result):
     interpreter = Interpreter(components, context=None)


### PR DESCRIPTION
closes #8325

Problem: 
we compare set to empty list to check whether set is empty.

Solution:
Check for set len.

**Status (please check what you already did)**:
- [X] added some tests for the functionality
- ~updated the documentation~
- ~updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)~
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
