### PR TITLE
Fix model regression tests after Spacy has been updated

### DIFF
--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -159,7 +159,6 @@ jobs:
           poetry install --extras full
           make install
           poetry run python -m spacy download de_core_news_md
-          poetry run python -m spacy link --force de_core_news_md de
 
       - name: Validate that GPUs are working
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -253,7 +253,6 @@ jobs:
           poetry install --extras full
           make install
           poetry run python -m spacy download de_core_news_md
-          poetry run python -m spacy link --force de_core_news_md de
 
       - name: Validate that GPUs are working
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
@@ -400,7 +399,6 @@ jobs:
           poetry install --extras full
           make install
           poetry run python -m spacy download de_core_news_md
-          poetry run python -m spacy link --force de_core_news_md de
 
       - name: Run test
         id: run_test


### PR DESCRIPTION
Model regression tests broke down with the Spacy update (to 3.0) because `spacy link` is no longer supported.

**Proposed changes**:
In this repo, I'm just removing the problematic command. In the `training-data` repo (see [the PR](https://github.com/RasaHQ/training-data/pull/10)), I specify the Spacy model in the config files. Only once that other PR is merged, the regression tests should work again (with the changes from this PR).