### PR TITLE
Improve Lockstore Queuing Log Message in 1.10.X

### DIFF
--- a/changelog/8345.improvement.rst
+++ b/changelog/8345.improvement.rst
@@ -1,0 +1,2 @@
+Improved the [lock store](lock-stores.mdx) debug log message when the process has to
+queue because other messages have to be processed before this item.

--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -120,9 +120,12 @@ class LockStore:
                 logger.debug(f"Acquired lock for conversation '{conversation_id}'.")
                 return lock
 
+            items_before_this = ticket - (lock.now_serving or 0)
             logger.debug(
-                f"Failed to acquire lock for conversation ID '{conversation_id}'. "
-                f"Retrying..."
+                f"Failed to acquire lock for conversation ID '{conversation_id}' "
+                f"because {items_before_this} other item(s) for this "
+                f"conversation ID have to be finished processing first. "
+                f"Retrying in {wait_time_in_seconds} seconds ..."
             )
 
             # sleep and update lock

--- a/tests/core/test_lock_store.py
+++ b/tests/core/test_lock_store.py
@@ -1,10 +1,12 @@
 import asyncio
+import logging
 import os
 
 import numpy as np
 import pytest
 import time
 
+from _pytest.logging import LogCaptureFixture
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.tmpdir import TempdirFactory
 from unittest.mock import patch, Mock
@@ -262,6 +264,41 @@ async def test_lock_lifetime_environment_variable(monkeypatch: MonkeyPatch):
     monkeypatch.setenv("TICKET_LOCK_LIFETIME", str(new_lock_lifetime))
 
     assert rasa.core.lock_store._get_lock_lifetime() == new_lock_lifetime
+
+
+@pytest.mark.parametrize("lock_store", [InMemoryLockStore(), FakeRedisLockStore()])
+async def test_acquire_lock_debug_message(
+    lock_store: LockStore, caplog: LogCaptureFixture
+):
+    conversation_id = "test_acquire_lock_debug_message"
+    wait_time_in_seconds = 0.01
+
+    async def locking_task() -> None:
+        async with lock_store.lock(
+            conversation_id, wait_time_in_seconds=wait_time_in_seconds
+        ):
+            # Do a very short sleep so that the other tasks can try to acquire the lock
+            # in the meantime
+            await asyncio.sleep(0.0)
+
+    with caplog.at_level(logging.DEBUG):
+        await asyncio.gather(
+            locking_task(),  # Gets served immediately
+            locking_task(),  # Gets served second
+            locking_task(),  # Gets served last
+        )
+
+    assert any(
+        f"because 1 other item(s) for this conversation ID have to be finished "
+        f"processing first. Retrying in {wait_time_in_seconds} seconds ..." in message
+        for message in caplog.messages
+    )
+
+    assert any(
+        f"because 2 other item(s) for this conversation ID have to be finished "
+        f"processing first. Retrying in {wait_time_in_seconds} seconds ..." in message
+        for message in caplog.messages
+    )
 
 
 async def test_redis_lock_store_timeout(monkeypatch: MonkeyPatch):


### PR DESCRIPTION
**Proposed changes**:
- Improve Lockstore Queuing Log Message in 1.10.X
- Backport of #8105 feature enhancement for 1.10.X

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
