### PR TITLE
fix wait for docs test step in CI

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -63,9 +63,6 @@ jobs:
     needs: [ changes ]
 
     steps:
-      - name: Checkout git repository 🕝
-        uses: actions/checkout@v2
-
       - name: Wait for doc tests
         uses: fountainhead/action-wait-for-check@4699210ccc66e2a13260803fadbb77085421b891
         id: wait-for-doc-tests

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -69,7 +69,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
-          ref: ${{ github.head_ref || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          owner: ${{ github.event.pull_request.head.repo.owner.login || github.actor }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
 


### PR DESCRIPTION
**The problem**:
The `wait for docs test` step in the CI looks for the workflow run based on `the _head_ branch name`. For example, the `wait for docs test` was doing this:
```
Retrieving check runs named Test Documentation on RasaHQ/rasa@fix-wait-for-docs....
```
even when the branch is from a forked repo. The step fails because couldn't find the branch in RasaHQ/rasa (like [this](https://github.com/RasaHQ/rasa/pull/8358)). 

**Proposed changes**:
- Change the reference to SHA so it will look for SHA instead of branch name
- Correct the repo owner so it will know which repo to look for the workflow run
- Also remove the checkout step because the wait for action does not require the checkout step.

**Status (please check what you already did)**:
- [X] tested on the normal situation where the head branch is from RasaHQ/rasa. See the checks in this PR.
- [X] tested on the situation when the head branch is from a forked repo (HotThoughts/rasa). See [here](https://github.com/RasaHQ/rasa/pull/8370).
```
Retrieving check runs named Test Documentation on HotThoughts/rasa@fix_wait_for_doc_tests
```