### PR TITLE
fix wait for docs test step in CI: 2nd try

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
-          ref: ${{ github.head_ref || github.sha }}
+          ref: ${{ github.event.pull_request.head.ref || github.sha }}
           owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -61,7 +61,7 @@ jobs:
     name: Wait for docs tests
     runs-on: ubuntu-latest
     needs: [ changes ]
-    if: needs.changes.outputs.docs == 'true'
+    # if: needs.changes.outputs.docs == 'true'
 
     steps:
       - name: Wait for doc tests
@@ -74,7 +74,7 @@ jobs:
           owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
-
+  
 
   quality:
     name: Code Quality

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+          # owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
   

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -74,7 +74,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+          # owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
 

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -61,7 +61,6 @@ jobs:
     name: Wait for docs tests
     runs-on: ubuntu-latest
     needs: [ changes ]
-    # if: needs.changes.outputs.docs == 'true' || github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || github.ref == 'refs/heads/main')
 
     steps:
       - name: Checkout git repository 🕝

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -79,7 +79,7 @@ jobs:
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
           
       - name: fail the step if the doc tests run could not be found
-        if: steps.wait-for-build.outputs.conclusion != 'success'
+        if: steps.wait-for-doc-tests.outputs.conclusion != 'success'
         run: |
           echo "Could not find the doc tests run."
           exit 1

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -61,9 +61,12 @@ jobs:
     name: Wait for docs tests
     runs-on: ubuntu-latest
     needs: [ changes ]
-    if: needs.changes.outputs.docs == 'true' || github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || github.ref == 'refs/heads/main')
+    # if: needs.changes.outputs.docs == 'true' || github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || github.ref == 'refs/heads/main')
 
     steps:
+      - name: Checkout git repository 🕝
+        uses: actions/checkout@v2
+        
       - name: Wait for doc tests
         uses: fountainhead/action-wait-for-check@4699210ccc66e2a13260803fadbb77085421b891
         id: wait-for-doc-tests
@@ -71,6 +74,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
 

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -77,7 +77,7 @@ jobs:
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
           
       - name: Fail the step if the doc tests run could not be found
-        if: ${{ steps.wait-for-doc-tests.conclusion == 'timed_out' }}
+        if: ${{ steps.wait-for-doc-tests.outputs.conclusion == 'timed_out' }}
         run: |
           echo "Could not find the doc tests run."
           exit 1

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -77,6 +77,12 @@ jobs:
           # owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
+          
+      - name: fail the step if the doc tests run could not be found
+        if: steps.wait-for-build.outputs.conclusion != 'success'
+        run: |
+          echo "Could not find the doc tests run."
+          exit 1
 
 
   quality:

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -63,16 +63,13 @@ jobs:
     needs: [ changes ]
 
     steps:
-      - name: Checkout git repository 🕝
-        uses: actions/checkout@v2
-        
       - name: Wait for doc tests
         uses: fountainhead/action-wait-for-check@4699210ccc66e2a13260803fadbb77085421b891
         id: wait-for-doc-tests
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
-          ref: ${{ github.event.pull_request.head.ref || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -76,8 +76,8 @@ jobs:
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
           
-      - name: fail the step if the doc tests run could not be found
-        if: ${{ steps.wait-for-doc-tests.conclusion == 'cancelled' || steps.wait-for-doc-tests.conclusion == 'failure' }}
+      - name: Fail the step if the doc tests run could not be found
+        if: ${{ steps.wait-for-doc-tests.conclusion == 'timed_out' }}
         run: |
           echo "Could not find the doc tests run."
           exit 1

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -73,7 +73,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
-  
+
 
   quality:
     name: Code Quality

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -79,7 +79,7 @@ jobs:
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
           
       - name: fail the step if the doc tests run could not be found
-        if: steps.wait-for-doc-tests.outputs.conclusion != 'success'
+        if: steps.wait-for-doc-tests.outputs.conclusion != 'success' || steps.wait-for-doc-tests.outputs.conclusion != 'skipped'
         run: |
           echo "Could not find the doc tests run."
           exit 1

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -61,6 +61,7 @@ jobs:
     name: Wait for docs tests
     runs-on: ubuntu-latest
     needs: [ changes ]
+    if: needs.changes.outputs.docs == 'true'
 
     steps:
       - name: Wait for doc tests

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -79,7 +79,7 @@ jobs:
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
           
       - name: fail the step if the doc tests run could not be found
-        if: steps.wait-for-doc-tests.outputs.conclusion != 'success' || steps.wait-for-doc-tests.outputs.conclusion != 'skipped'
+        if: ${{ steps.wait-for-doc-tests.conclusion == 'cancelled' || steps.wait-for-doc-tests.conclusion == 'failure' }}
         run: |
           echo "Could not find the doc tests run."
           exit 1

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -61,7 +61,7 @@ jobs:
     name: Wait for docs tests
     runs-on: ubuntu-latest
     needs: [ changes ]
-    # if: needs.changes.outputs.docs == 'true'
+    if: needs.changes.outputs.docs == 'true' || github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || github.ref == 'refs/heads/main')
 
     steps:
       - name: Wait for doc tests
@@ -71,7 +71,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          # owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
   

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -73,8 +73,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
-          ref: ${{ github.pull_request.head.sha || github.sha }}
-          # owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
           

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -69,8 +69,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          owner: ${{ github.event.pull_request.head.repo.owner.login || github.actor }}
+          ref: ${{ github.head_ref || github.sha }}
+          owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
 

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.pull_request.head.sha || github.sha }}
           # owner: ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -63,6 +63,9 @@ jobs:
     needs: [ changes ]
 
     steps:
+      - name: Checkout git repository 🕝
+        uses: actions/checkout@v2
+        
       - name: Wait for doc tests
         uses: fountainhead/action-wait-for-check@4699210ccc66e2a13260803fadbb77085421b891
         id: wait-for-doc-tests

--- a/docs/docs/conversation-driven-development.mdx
+++ b/docs/docs/conversation-driven-development.mdx
@@ -11,7 +11,7 @@ Conversation-Driven Development (CDD) is the process of listening to your users 
 
 Developing great AI assistants is challenging because users will always say something you didn't anticipate. The principle behind CDD is that in every conversation users are telling you—in their own words—exactly what they want. By practicing CDD at every stage of bot development, you orient your assistant towards real user language and behavior.
 
-CDD includes the following actions:
+CDD includes the following actions!:
 
 *   **Share** your assistant with users as soon as possible
 *   **Review** conversations on a regular basis


### PR DESCRIPTION
**The problem**:
The previous fix  https://github.com/RasaHQ/rasa/pull/8371 only works when the changes in the branch are only from the owner of the forked repo. This may imply that the workflow run exists in the forked repo when all the changes are from the forked repo. If we update the PR with the base branch via the 'update branch' bottom, the workflow run will be hosted in the base repo, thus we cannot find the workflow run in the forked repo. 

Example: https://github.com/RasaHQ/rasa/pull/8358
Although the `wait for docs test` is green, it didn't find the checks.
```
No completed checks named Test Documentation, waiting for 60 seconds...
166
No completed checks after 3000 seconds, exiting with conclusion 'timed_out'
```

**Proposed changes**:
- Add back the checkout step and remove the owner settings. 
- Add a new step to fail the job if the conclusion is 'timed_out'.

**Status (please check what you already did)**:
