### PR TITLE
make enable-squad own rasa.shared

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Code in the `rasa.shared` package is potentially re-used by downstream dependencies
 # such as Rasa X. Hence, changes within this package require double checking.
-/rasa/shared/ @RasaHQ/backend
+/rasa/shared/ @RasaHQ/enable-squad
 /docs/docs/prototype-an-assistant.mdx @ricwo @alwx
 /.github/workflows/ @RasaHQ/infrastructure


### PR DESCRIPTION
**Proposed changes**:
- related to discussion [here](https://rasa-hq.slack.com/archives/C36SS4N8M/p1617800136346200?thread_ts=1617783559.338900&cid=C36SS4N8M)
- make @RasaHQ/enable-squad own `rasa.shared` instead of the entire backend team

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
