### PR TITLE
Replace `ValueError` with `RasaException` in `replace_environment_variables` function

### DIFF
--- a/changelog/8382.bugfix.md
+++ b/changelog/8382.bugfix.md
@@ -1,0 +1,2 @@
+Throw `RasaException` instead of `ValueError` in situations when environment variables 
+specified in YAML cannot be expanded.

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1789,7 +1789,7 @@ class Domain:
 
         try:
             content = rasa.shared.utils.io.read_yaml_file(filename)
-        except (ValueError, YamlSyntaxException):
+        except (RasaException, YamlSyntaxException):
             return False
 
         return any(key in content for key in ALL_DOMAIN_KEYS)

--- a/rasa/shared/utils/io.py
+++ b/rasa/shared/utils/io.py
@@ -316,9 +316,8 @@ def replace_environment_variables() -> None:
         ]
         if not_expanded:
             raise RasaException(
-                "Error when trying to expand the environment variables"
-                " in '{}'. Please make sure to also set these environment"
-                " variables: '{}'.".format(value, not_expanded)
+                f"Error when trying to expand the environment variables in '{value}'. "
+                f"Please make sure to also set these environment variables: '{not_expanded}'."
             )
         return expanded_vars
 

--- a/rasa/shared/utils/io.py
+++ b/rasa/shared/utils/io.py
@@ -333,8 +333,7 @@ def read_yaml(content: Text, reader_type: Union[Text, List[Text]] = "safe") -> A
 
     Args:
         content: A text containing yaml content.
-        reader_type: Reader type to use. By default "safe" will be used
-        replace_env_vars: Specifies if environment variables need to be replaced
+        reader_type: Reader type to use. By default "safe" will be used.
 
     Raises:
         ruamel.yaml.parser.ParserError: If there was an error when parsing the YAML.

--- a/rasa/shared/utils/io.py
+++ b/rasa/shared/utils/io.py
@@ -25,6 +25,7 @@ from rasa.shared.exceptions import (
     FileIOException,
     FileNotFoundException,
     YamlSyntaxException,
+    RasaException,
 )
 import rasa.shared.utils.validation
 
@@ -314,7 +315,7 @@ def replace_environment_variables() -> None:
             w for w in expanded_vars.split() if w.startswith("$") and w in value
         ]
         if not_expanded:
-            raise ValueError(
+            raise RasaException(
                 "Error when trying to expand the environment variables"
                 " in '{}'. Please make sure to also set these environment"
                 " variables: '{}'.".format(value, not_expanded)

--- a/tests/shared/utils/test_io.py
+++ b/tests/shared/utils/test_io.py
@@ -5,13 +5,11 @@ import uuid
 from collections import OrderedDict
 from pathlib import Path
 from typing import Callable, Text, List, Set, Any, Dict
-from _pytest.monkeypatch import MonkeyPatch
-from mock import Mock
 
 import pytest
 
 import rasa.shared
-from rasa.shared.exceptions import FileIOException, FileNotFoundException
+from rasa.shared.exceptions import FileIOException, FileNotFoundException, RasaException
 import rasa.shared.utils.io
 import rasa.shared.utils.validation
 from rasa.shared.constants import NEXT_MAJOR_VERSION_FOR_DEPRECATIONS
@@ -147,13 +145,13 @@ def test_read_yaml_string_with_env_var_not_exist():
     user: ${USER_NAME}
     password: ${PASSWORD}
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(RasaException):
         rasa.shared.utils.io.read_yaml(config_with_env_var_not_exist)
 
 
 def test_environment_variable_not_existing():
     content = "model: \n  test: ${variable}"
-    with pytest.raises(ValueError):
+    with pytest.raises(RasaException):
         rasa.shared.utils.io.read_yaml(content)
 
 


### PR DESCRIPTION
**Proposed changes**:
- replace `ValueError` with `RasaException` in `replace_environment_variables` function because it's indeed a usage error
- it's basically a post-merge update to #8140
- fixes #7932 

**Status (please check what you already did)**:
- [x] updated tests
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
