### PR TITLE
fix wait for docs test step in CI

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -63,6 +63,9 @@ jobs:
     needs: [ changes ]
 
     steps:
+      - name: Checkout git repository 🕝
+        uses: actions/checkout@v2
+
       - name: Wait for doc tests
         uses: fountainhead/action-wait-for-check@4699210ccc66e2a13260803fadbb77085421b891
         id: wait-for-doc-tests
@@ -70,9 +73,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: Test Documentation
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          owner: ${{ github.event.pull_request.head.repo.owner.login || github.actor }}
           timeoutSeconds: ${{ env.WAIT_TIMEOUT_SECS }}
           intervalSeconds: ${{ env.WAIT_INTERVAL_SECS }}
+
+      - name: Fail the step if the doc tests run could not be found
+        if: ${{ steps.wait-for-doc-tests.outputs.conclusion == 'timed_out' }}
+        run: |
+          echo "Could not find the doc tests run."
+          exit 1
 
 
   quality:


### PR DESCRIPTION
**Proposed changes**:
Change ref for `action-wait-for-check` action to the sha of the head branch such that the step can use it to find the target workflow run in the base repo.


**Status (please check what you already did):**
- [X] Add back the checkout step and remove the owner settings. Now the ref used to look for workflow run is the head sha.
- [X] Add a new step to fail the job if the conclusion is `timed_out`.
