### PR TITLE
1.10.x Back-port for Kafka Partition Key Implementation

### DIFF
--- a/changelog/8429.enhancement.rst
+++ b/changelog/8429.enhancement.rst
@@ -1,0 +1,1 @@
+Added partition_by_sender flag to Kafka Producer to optionally associate events with Kafka partition based on sender_id.

--- a/data/test_endpoints/event_brokers/kafka_plaintext_endpoint.yml
+++ b/data/test_endpoints/event_brokers/kafka_plaintext_endpoint.yml
@@ -1,5 +1,6 @@
 event_broker:
   url: localhost
+  partition_by_sender: True
   sasl_username: username
   sasl_password: password
   topic: topic

--- a/docs/api/event-brokers.rst
+++ b/docs/api/event-brokers.rst
@@ -176,6 +176,24 @@ list of strings. e.g.:
                                           'kafka_broker_3:9092'],
                                     topic='rasa_events')
 
+
+Partition Key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rasa Open Source's Kafka producer can optionally be configured to partition messages by conversation ID.
+This can be configured by setting `partition_by_sender` in the `endpoints.yml` file to True.
+By default, this parameter is set to `False` and the producer will randomly assign a partition to each message.  
+
+.. code-block:: yaml
+
+    event_broker:
+      type: kafka
+      partition_by_sender: True
+      security_protocol: PLAINTEXT
+      topic: topic
+      url: localhost
+      client_id: kafka-python-rasa
+
 Authentication and Authorization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -53,9 +53,7 @@ class KafkaEventBroker(EventBroker):
 
     @classmethod
     async def from_endpoint_config(
-        cls,
-        broker_config,
-        event_loop: Optional[AbstractEventLoop] = None,
+        cls, broker_config, event_loop: Optional[AbstractEventLoop] = None,
     ) -> Optional["KafkaEventBroker"]:
         if broker_config is None:
             return None

--- a/tests/core/test_broker.py
+++ b/tests/core/test_broker.py
@@ -225,6 +225,7 @@ async def test_kafka_broker_from_config():
         "username",
         "password",
         topic="topic",
+        partition_by_sender=True,
         security_protocol="SASL_PLAINTEXT",
     )
 
@@ -232,6 +233,7 @@ async def test_kafka_broker_from_config():
     assert actual.sasl_username == expected.sasl_username
     assert actual.sasl_password == expected.sasl_password
     assert actual.topic == expected.topic
+    assert actual.partition_by_sender == expected.partition_by_sender
 
 
 async def test_no_pika_logs_if_no_debug_mode(caplog: LogCaptureFixture):


### PR DESCRIPTION
**Proposed changes**:
- Added Partition Key Parameter for Kafka Producer
- Backport of #8335 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
