### PR TITLE
Turn Docs example into valid json

### DIFF
--- a/docs/docs/connectors/your-own-website.mdx
+++ b/docs/docs/connectors/your-own-website.mdx
@@ -45,7 +45,7 @@ After making the `rest` input channel available, you can `POST` messages to
 ```json
 {
   "sender": "test_user",  // sender ID of the user sending the message
-  "message": "Hi there!",
+  "message": "Hi there!"
 }
 ```
 

--- a/docs/docs/connectors/your-own-website.mdx
+++ b/docs/docs/connectors/your-own-website.mdx
@@ -85,7 +85,7 @@ After making the `callback` input available, you can `POST` messages to
 ```json
 {
   "sender": "test_user",  // sender ID of the user sending the message
-  "message": "Hi there!",
+  "message": "Hi there!"
 }
 ```
 


### PR DESCRIPTION
I couldn't copy/paste the example because it didn't list valid json. There's a comma too many. So I made a quick fix. 

The example can be found [here](https://rasa.com/docs/rasa/connectors/your-own-website#request-and-response-format). 

This isn't valid json. 

```json
{
  "sender": "test_user",
  "message": "Hi there!",
}
```

This is. 

```json
{
  "sender": "test_user",
  "message": "Hi there!"
}
```
