### PR TITLE
add log time rotating handle

### DIFF
--- a/rasa/cli/arguments/run.py
+++ b/rasa/cli/arguments/run.py
@@ -42,6 +42,24 @@ def add_server_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Store logs in specified file.",
     )
+    parser.add_argument(
+        "--log-rotating",
+        type=str,
+        # Rasa should not rotaing log file by default
+        default=None,
+        help="""Handler for logging to a file, rotating the log file at certain timed intervals.
+            supported:
+            # S - Seconds
+            # M - Minutes
+            # H - Hours
+            # D - Days
+            # midnight - roll over at midnight
+            # W{0-6} - roll over on a certain day; 0 - Monday
+            #
+            # Case of the 'when' specifier is not important; lower or upper case
+            # will work.
+        """
+    )
     add_endpoint_param(
         parser,
         help_text="Configuration file for the model server and the connectors as a "

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -257,7 +257,7 @@ def _configure_logging(args: argparse.Namespace) -> None:
     rasa.utils.io.configure_colored_logging(args.loglevel)
 
     set_log_level(log_level)
-    configure_file_logging(logging.root, args.log_file)
+    configure_file_logging(logging.root, args.log_file, args.log_rotating)
 
     logging.getLogger("werkzeug").setLevel(logging.WARNING)
     logging.getLogger("engineio").setLevel(logging.WARNING)

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -94,11 +94,12 @@ def configure_app(
     port: int = constants.DEFAULT_SERVER_PORT,
     endpoints: Optional[AvailableEndpoints] = None,
     log_file: Optional[Text] = None,
+    log_rotating: Optional[Text] = None,
     conversation_id: Optional[Text] = uuid.uuid4().hex,
 ) -> Sanic:
     """Run the agent."""
 
-    rasa.core.utils.configure_file_logging(logger, log_file)
+    rasa.core.utils.configure_file_logging(logger, log_file, log_rotating)
 
     if enable_api:
         app = server.create_app(
@@ -159,6 +160,7 @@ def serve_application(
     endpoints: Optional[AvailableEndpoints] = None,
     remote_storage: Optional[Text] = None,
     log_file: Optional[Text] = None,
+    log_rotating: Optional[Text] = None,
     ssl_certificate: Optional[Text] = None,
     ssl_keyfile: Optional[Text] = None,
     ssl_ca_file: Optional[Text] = None,
@@ -183,6 +185,7 @@ def serve_application(
         port=port,
         endpoints=endpoints,
         log_file=log_file,
+        log_rotating=log_rotating,
         conversation_id=conversation_id,
     )
 

--- a/rasa/core/utils.py
+++ b/rasa/core/utils.py
@@ -43,7 +43,9 @@ logger = logging.getLogger(__name__)
 
 
 def configure_file_logging(
-    logger_obj: logging.Logger, log_file: Optional[Text]
+    logger_obj: logging.Logger,
+    log_file: Optional[Text],
+    log_rotating: Optional[Text] = None,
 ) -> None:
     """Configure logging to a file.
 
@@ -55,9 +57,14 @@ def configure_file_logging(
         return
 
     formatter = logging.Formatter("%(asctime)s [%(levelname)-5.5s]  %(message)s")
-    file_handler = logging.FileHandler(
-        log_file, encoding=rasa.shared.utils.io.DEFAULT_ENCODING
-    )
+    if log_rotating is None:
+        file_handler = logging.FileHandler(
+            log_file, encoding=rasa.shared.utils.io.DEFAULT_ENCODING
+        )
+    else:
+        file_handler = logging.handlers.TimedRotatingFileHandler(
+            log_file, when=log_rotating, encoding=rasa.shared.utils.io.DEFAULT_ENCODING
+        )
     file_handler.setLevel(logger_obj.level)
     file_handler.setFormatter(formatter)
     logger_obj.addHandler(file_handler)


### PR DESCRIPTION
**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

The log of `rasa run` will become larger and larger with the increase of time, and it is necessary to divide it in actual production. The custom component part can be implemented by your own code, but the log of the core part is always written in a file by default. This change only adds the option of converting by time.