### PR TITLE
Upon a slot being filled in a form, added ability to run a given action.

### DIFF
--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1818,6 +1818,7 @@ class SlotMapping(Enum):
     FROM_INTENT = 1
     FROM_TRIGGER_INTENT = 2
     FROM_TEXT = 3
+    SLOT_FILLED_ACTION = 4
 
     def __str__(self) -> Text:
         """Returns a string representation of the object."""
@@ -1847,6 +1848,7 @@ class SlotMapping(Enum):
             str(SlotMapping.FROM_INTENT): ["value"],
             str(SlotMapping.FROM_TRIGGER_INTENT): ["value"],
             str(SlotMapping.FROM_TEXT): [],
+            str(SlotMapping.SLOT_FILLED_ACTION): [],
         }
 
         mapping_type = mapping.get("type")
@@ -1867,7 +1869,6 @@ class SlotMapping(Enum):
                     f"for slot '{slot_name}' in the form '{form_name}'. Please see "
                     f"{rasa.shared.constants.DOCS_URL_FORMS} for more information."
                 )
-
 
 def _validate_slot_mappings(forms: Union[Dict, List]) -> None:
     if isinstance(forms, list):


### PR DESCRIPTION
**Proposed changes**:
I wanted to be able to perform an action after a slot is filled in a form. 

Demo:

```
2021-04-18 16:40:40 INFO     root  - Rasa server is up and running.
Bot loaded. Type a message and press enter (use '/stop' to exit): 
Your input ->  Hi I want my id                                                                                                                                                                              
What's your name?
Your input ->  Ivan                                                                                                                                                                                                 
Nice to meet you Ivan!   <- This is the new action
What's your hometown?
Your input ->                
```

The NLU for forms will have the additional optional property for each slot called `slot_filled_action`:
```
forms:
  student_id_card_form:
    name:
      - type: from_entity
        entity: PERSON
        slot_filled_action: "action_confirm_name_slot_filled"
```

The first `slot_filled_action` action will be used.

This isn't ideal but since each slot is represented by a list and not a dictionary, I couldn't easily add a property without refactoring the format representing the slot.

Better proposal: Allow list of potential responses that will be matched depending on what slots are available (like how DialogFlow works). The first matching response_action will be fired. This would require changing some of the validation logic around forms.
```
forms:
  student_id_card_form:
    name:
      - type: from_entity
        entity: PERSON
    birthday:
      - type: from_entity
        entity: DATE
    response_actions: 
      - action_confirm_name_slot_filled
      - action_confirm_birthday_slot_filled
      - action_confirm_name_and_birthday_slots_filled
```

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
