### PR TITLE
fix rasa-demo url in docs

### DIFF
--- a/docs/docs/setting-up-ci-cd.mdx
+++ b/docs/docs/setting-up-ci-cd.mdx
@@ -144,7 +144,7 @@ would be incompatible with the current production model.
 ## Example CI/CD pipelines
 
 As examples, see the CI/CD pipelines for
-[Sara](https://github.com/RasaHQ/rasa-demo/blob/master/.github/workflows/build_and_deploy.yml),
+[Sara](https://github.com/RasaHQ/rasa-demo/blob/main/.github/workflows/continuous_integration.yml),
 the Rasa assistant that you can talk to in the Rasa Docs, and
 [Carbon Bot](https://github.com/RasaHQ/carbon-bot/blob/master/.github/workflows/model_ci.yml).
 Both use [Github Actions](https://github.com/features/actions) as a CI/CD tool.


### PR DESCRIPTION
**Proposed changes**:
- fix url for rasa-demo pipeline to `main` (it was master)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
