### PR TITLE
except ValueErrors during yaml validation

### DIFF
--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1788,7 +1788,7 @@ class Domain:
 
         try:
             content = rasa.shared.utils.io.read_yaml_file(filename)
-        except (RasaException, YamlSyntaxException):
+        except (RasaException, ValueError, YamlSyntaxException):
             return False
 
         return any(key in content for key in ALL_DOMAIN_KEYS)


### PR DESCRIPTION
**Proposed changes**:
- We used to except `(ValueError, YamlSyntaxException)` to fix env var interpolation issues like [this](https://github.com/RasaHQ/rasa-x/issues/4311). Those issues were deemed to be usage errors, so we switched the associated error to a `RasaException`. However there are other issues that might cause `ValueErrors`, such as reading a github workflows file with the `${{ whatever }}` syntax that will cause issues with interpolation. We still want to except these and move on.  

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
