### PR TITLE
Implement interface for bulk inferencing in TF models

### DIFF
--- a/changelog/8560.improvement.md
+++ b/changelog/8560.improvement.md
@@ -1,1 +1,3 @@
 Implement a new interface `run_inference` inside `RasaModel` which performs batch inferencing through tensorflow models.
+
+`rasa_predict` inside `RasaModel` has been made a private method now by changing it to `_rasa_predict`.

--- a/changelog/8560.improvement.md
+++ b/changelog/8560.improvement.md
@@ -1,0 +1,1 @@
+Implement a new interface `run_inference` inside `RasaModel` which performs batch inferencing through tensorflow models.

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -680,13 +680,7 @@ class TEDPolicy(Policy):
             tracker, domain, interpreter
         )
         model_data = self._create_model_data(tracker_state_features)
-        (data_generator, _,) = rasa.utils.train_utils.create_data_generators(
-            model_data=model_data,
-            batch_sizes=self.config[BATCH_SIZES],
-            epochs=1,
-            shuffle=False,
-        )
-        outputs = self.model.run_inference(data_generator)
+        outputs = self.model.run_inference(model_data)
 
         # take the last prediction in the sequence
         similarities = outputs["similarities"][:, -1, :]

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -875,7 +875,13 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
 
         # create session data from message and convert it into a batch of 1
         model_data = self._create_model_data([message], training=False)
-        return self.model.rasa_predict(model_data)
+        (data_generator, _,) = rasa.utils.train_utils.create_data_generators(
+            model_data=model_data,
+            batch_sizes=self.component_config[BATCH_SIZES],
+            epochs=1,
+            shuffle=False,
+        )
+        return self.model.run_inference(data_generator)
 
     def _predict_label(
         self, predict_out: Optional[Dict[Text, tf.Tensor]]

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -875,13 +875,7 @@ class DIETClassifier(IntentClassifier, EntityExtractor):
 
         # create session data from message and convert it into a batch of 1
         model_data = self._create_model_data([message], training=False)
-        (data_generator, _,) = rasa.utils.train_utils.create_data_generators(
-            model_data=model_data,
-            batch_sizes=self.component_config[BATCH_SIZES],
-            epochs=1,
-            shuffle=False,
-        )
-        return self.model.run_inference(data_generator)
+        return self.model.run_inference(model_data)
 
     def _predict_label(
         self, predict_out: Optional[Dict[Text, tf.Tensor]]

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -304,7 +304,7 @@ class RasaModel(TmpKerasModel):
         all_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
         batch_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
     ) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
-        """Merge a batch's output into the output for all batches.
+        """Merges a batch's output into the output for all batches.
 
         Function assumes that the schema of batch output remains the same,
         i.e. keys and their value types do not change from one batch's

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -256,7 +256,7 @@ class RasaModel(TmpKerasModel):
         """Custom prediction method that builds tf graph on the first call.
 
         Args:
-            batch_in: Prepared batch ready for input to predict_step method of model.
+            batch_in: Prepared batch ready for input to `predict_step` method of model.
 
         Return:
             Prediction output, including diagnostic data.

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -62,7 +62,8 @@ def _merge_batch_outputs(
         batch_output: Output for a batch.
 
     Returns:
-        Merged output with the output for current batch stacked below the output for all previous batches.
+        Merged output with the output for current batch stacked
+        below the output for all previous batches.
     """
     if not all_outputs:
         return batch_output
@@ -318,7 +319,8 @@ class RasaModel(TmpKerasModel):
         while True:
             try:
                 # data_generator is a tuple of 2 elements - input and output.
-                # We only need input, since output is always None and not consumed by our TF graphs.
+                # We only need input, since output is always None and not
+                # consumed by our TF graphs.
                 batch_in = next(data_iterator)[0]
                 batch_out = self.rasa_predict(batch_in)
                 outputs = _merge_batch_outputs(outputs, batch_out)

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -307,7 +307,8 @@ class RasaModel(TmpKerasModel):
         """Merge a batch's output into the output for all batches.
 
         Function assumes that the schema of batch output remains the same,
-        i.e. keys and their value types do not change from one batch's output to another.
+        i.e. keys and their value types do not change from one batch's
+        output to another.
 
         Args:
             all_outputs: Existing output for all previous batches.

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -52,6 +52,18 @@ def _merge_batch_outputs(
     all_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
     batch_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
 ) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
+    """Merge a batch's output into the output for all batches.
+
+    Function assumes that the schema of batch output remains the same,
+    i.e. keys and their value types do not change from one batch's output to another.
+
+    Args:
+        all_outputs: Existing output for all previous batches.
+        batch_output: Output for a batch.
+
+    Returns:
+        Merged output with the output for current batch stacked below the output for all previous batches.
+    """
     if not all_outputs:
         return batch_output
     for key, val in batch_output.items():
@@ -305,7 +317,8 @@ class RasaModel(TmpKerasModel):
         data_iterator = iter(data_generator)
         while True:
             try:
-                # Only want x, since y is always None out of our data generators
+                # data_generator is a tuple of 2 elements - input and output.
+                # We only need input, since output is always None and not consumed by our TF graphs.
                 batch_in = next(data_iterator)[0]
                 batch_out = self.rasa_predict(batch_in)
                 outputs = _merge_batch_outputs(outputs, batch_out)

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -35,6 +35,7 @@ from rasa.utils.tensorflow.constants import (
     CONSTRAIN_SIMILARITIES,
     MODEL_CONFIDENCE,
 )
+import rasa.utils.train_utils
 from rasa.utils.tensorflow import layers
 from rasa.utils.tensorflow import rasa_layers
 from rasa.utils.tensorflow.temp_keras_modules import TmpKerasModel
@@ -231,12 +232,12 @@ class RasaModel(TmpKerasModel):
         return [element_spec]
 
     def rasa_predict(
-        self, model_data: RasaModelData
+        self, batch_in: Tuple[np.ndarray]
     ) -> Dict[Text, Union[np.ndarray, Dict[Text, Any]]]:
         """Custom prediction method that builds tf graph on the first call.
 
         Args:
-            model_data: The model data to use for prediction.
+            batch_in: Prepared batch ready for input to predict_step method of model.
 
         Return:
             Prediction output, including diagnostic data.
@@ -247,8 +248,6 @@ class RasaModel(TmpKerasModel):
             # after training, we need to prepare the model for prediction once
             self.prepare_for_predict()
             self.prepared_for_prediction = True
-
-        batch_in = RasaBatchDataGenerator.prepare_batch(model_data.data)
 
         if self._run_eagerly:
             outputs = tf_utils.to_numpy_or_python_type(self.predict_step(batch_in))
@@ -267,6 +266,48 @@ class RasaModel(TmpKerasModel):
             outputs[DIAGNOSTIC_DATA]
         )
         return outputs
+
+    def run_inference(
+        self, data_generator: RasaBatchDataGenerator
+    ) -> Dict[Text, Union[np.ndarray, Dict[Text, Any]]]:
+        """
+
+        Args:
+            data_generator:
+
+        Returns:
+
+        """
+        outputs = {}
+        data_iterator = iter(data_generator)
+        while True:
+            try:
+                # Only want x, since y is always None out of our data generators
+                batch_in = next(data_iterator)[0]
+                batch_out = self.rasa_predict(batch_in)
+                outputs = self._merge_batch_outputs(outputs, batch_out)
+            except StopIteration:
+                # Generator ran out of batches, time to finish inferencing
+                break
+        return outputs
+
+    def _merge_batch_outputs(
+        self,
+        all_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+        batch_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+    ) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
+        if not all_outputs:
+            return batch_output
+        for key, val in batch_output.items():
+            if isinstance(val, np.ndarray):
+                all_outputs[key] = np.concatenate(
+                    [all_outputs[key], batch_output[key]], axis=0
+                )
+            elif isinstance(val, dict):
+                # recurse and merge the inner dict first
+                all_outputs[key] = self._merge_batch_outputs(all_outputs[key], val)
+
+        return batch_output
 
     @staticmethod
     def _empty_lists_to_none_in_dict(input_dict: Dict[Text, Any]) -> Dict[Text, Any]:
@@ -339,7 +380,10 @@ class RasaModel(TmpKerasModel):
         # predict on one data example to speed up prediction during inference
         # the first prediction always takes a bit longer to trace tf function
         if not finetune_mode and predict_data_example:
-            model.rasa_predict(predict_data_example)
+            (data_generator, _,) = rasa.utils.train_utils.create_data_generators(
+                model_data=predict_data_example, batch_sizes=1, epochs=1, shuffle=False
+            )
+            model.run_inference(data_generator)
 
         logger.debug("Finished loading the model.")
         return model

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -268,17 +268,21 @@ class RasaModel(TmpKerasModel):
         return outputs
 
     def run_inference(
-        self, data_generator: RasaBatchDataGenerator
+        self, model_data: RasaModelData, batch_size: Union[int, List[int]] = 1
     ) -> Dict[Text, Union[np.ndarray, Dict[Text, Any]]]:
-        """
+        """Implements bulk inferencing through the model.
 
         Args:
-            data_generator:
+            model_data: Input data to be fed to the model.
+            batch_size: Size of batches that the generator should create.
 
         Returns:
-
+            Model outputs corresponding to the inputs fed.
         """
         outputs = {}
+        (data_generator, _,) = rasa.utils.train_utils.create_data_generators(
+            model_data=model_data, batch_sizes=batch_size, epochs=1, shuffle=False,
+        )
         data_iterator = iter(data_generator)
         while True:
             try:
@@ -380,10 +384,7 @@ class RasaModel(TmpKerasModel):
         # predict on one data example to speed up prediction during inference
         # the first prediction always takes a bit longer to trace tf function
         if not finetune_mode and predict_data_example:
-            (data_generator, _,) = rasa.utils.train_utils.create_data_generators(
-                model_data=predict_data_example, batch_sizes=1, epochs=1, shuffle=False
-            )
-            model.run_inference(data_generator)
+            model.run_inference(predict_data_example)
 
         logger.debug("Finished loading the model.")
         return model

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -48,38 +48,6 @@ from tensorflow.python.keras.utils import tf_utils
 logger = logging.getLogger(__name__)
 
 
-def _merge_batch_outputs(
-    all_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
-    batch_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
-) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
-    """Merge a batch's output into the output for all batches.
-
-    Function assumes that the schema of batch output remains the same,
-    i.e. keys and their value types do not change from one batch's output to another.
-
-    Args:
-        all_outputs: Existing output for all previous batches.
-        batch_output: Output for a batch.
-
-    Returns:
-        Merged output with the output for current batch stacked
-        below the output for all previous batches.
-    """
-    if not all_outputs:
-        return batch_output
-    for key, val in batch_output.items():
-        if isinstance(val, np.ndarray):
-            all_outputs[key] = np.concatenate(
-                [all_outputs[key], batch_output[key]], axis=0
-            )
-
-        elif isinstance(val, dict):
-            # recurse and merge the inner dict first
-            all_outputs[key] = _merge_batch_outputs(all_outputs[key], val)
-
-    return all_outputs
-
-
 # noinspection PyMethodOverriding
 class RasaModel(TmpKerasModel):
     """Abstract custom Keras model.
@@ -263,7 +231,7 @@ class RasaModel(TmpKerasModel):
         # the list
         return [element_spec]
 
-    def rasa_predict(
+    def _rasa_predict(
         self, batch_in: Tuple[np.ndarray]
     ) -> Dict[Text, Union[np.ndarray, Dict[Text, Any]]]:
         """Custom prediction method that builds tf graph on the first call.
@@ -283,9 +251,10 @@ class RasaModel(TmpKerasModel):
 
         if self._run_eagerly:
             outputs = tf_utils.to_numpy_or_python_type(self.predict_step(batch_in))
-            outputs[DIAGNOSTIC_DATA] = self._empty_lists_to_none_in_dict(
-                outputs[DIAGNOSTIC_DATA]
-            )
+            if DIAGNOSTIC_DATA in outputs:
+                outputs[DIAGNOSTIC_DATA] = self._empty_lists_to_none_in_dict(
+                    outputs[DIAGNOSTIC_DATA]
+                )
             return outputs
 
         if self._tf_predict_step is None:
@@ -294,9 +263,10 @@ class RasaModel(TmpKerasModel):
             )
 
         outputs = tf_utils.to_numpy_or_python_type(self._tf_predict_step(batch_in))
-        outputs[DIAGNOSTIC_DATA] = self._empty_lists_to_none_in_dict(
-            outputs[DIAGNOSTIC_DATA]
-        )
+        if DIAGNOSTIC_DATA in outputs:
+            outputs[DIAGNOSTIC_DATA] = self._empty_lists_to_none_in_dict(
+                outputs[DIAGNOSTIC_DATA]
+            )
         return outputs
 
     def run_inference(
@@ -322,12 +292,44 @@ class RasaModel(TmpKerasModel):
                 # We only need input, since output is always None and not
                 # consumed by our TF graphs.
                 batch_in = next(data_iterator)[0]
-                batch_out = self.rasa_predict(batch_in)
-                outputs = _merge_batch_outputs(outputs, batch_out)
+                batch_out = self._rasa_predict(batch_in)
+                outputs = self._merge_batch_outputs(outputs, batch_out)
             except StopIteration:
                 # Generator ran out of batches, time to finish inferencing
                 break
         return outputs
+
+    @staticmethod
+    def _merge_batch_outputs(
+        all_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+        batch_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+    ) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
+        """Merge a batch's output into the output for all batches.
+
+        Function assumes that the schema of batch output remains the same,
+        i.e. keys and their value types do not change from one batch's output to another.
+
+        Args:
+            all_outputs: Existing output for all previous batches.
+            batch_output: Output for a batch.
+
+        Returns:
+            Merged output with the output for current batch stacked
+            below the output for all previous batches.
+        """
+        if not all_outputs:
+            return batch_output
+        for key, val in batch_output.items():
+            if isinstance(val, np.ndarray):
+                all_outputs[key] = np.concatenate(
+                    [all_outputs[key], batch_output[key]], axis=0
+                )
+
+            elif isinstance(val, dict):
+                # recurse and merge the inner dict first
+                all_outputs[key] = RasaModel._merge_batch_outputs(all_outputs[key], val)
+
+        return all_outputs
 
     @staticmethod
     def _empty_lists_to_none_in_dict(input_dict: Dict[Text, Any]) -> Dict[Text, Any]:

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -382,6 +382,7 @@ def create_data_generators(
     batch_strategy: Text = SEQUENCE,
     eval_num_examples: int = 0,
     random_seed: Optional[int] = None,
+    shuffle: bool = True,
 ) -> Tuple[RasaBatchDataGenerator, Optional[RasaBatchDataGenerator]]:
     """Create data generators for train and optional validation data.
 
@@ -392,6 +393,7 @@ def create_data_generators(
         batch_strategy: The batch strategy to use.
         eval_num_examples: Number of examples to use for validation data.
         random_seed: The random seed.
+        shuffle: Whether to shuffle data inside the data generator
 
     Returns:
         The training data generator and optional validation data generator.
@@ -406,7 +408,7 @@ def create_data_generators(
             batch_size=batch_sizes,
             epochs=epochs,
             batch_strategy=batch_strategy,
-            shuffle=True,
+            shuffle=shuffle,
         )
 
     data_generator = RasaBatchDataGenerator(
@@ -414,7 +416,7 @@ def create_data_generators(
         batch_size=batch_sizes,
         epochs=epochs,
         batch_strategy=batch_strategy,
-        shuffle=True,
+        shuffle=shuffle,
     )
 
     return data_generator, validation_data_generator

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -393,7 +393,7 @@ def create_data_generators(
         batch_strategy: The batch strategy to use.
         eval_num_examples: Number of examples to use for validation data.
         random_seed: The random seed.
-        shuffle: Whether to shuffle data inside the data generator
+        shuffle: Whether to shuffle data inside the data generator.
 
     Returns:
         The training data generator and optional validation data generator.

--- a/tests/utils/tensorflow/test_models.py
+++ b/tests/utils/tensorflow/test_models.py
@@ -5,7 +5,6 @@ import tensorflow as tf
 
 from rasa.utils.tensorflow.models import RasaModel
 from rasa.utils.tensorflow.model_data import RasaModelData
-from rasa.shared.constants import DIAGNOSTIC_DATA
 from rasa.utils.tensorflow.model_data import FeatureArray
 from rasa.utils.tensorflow.constants import LABEL, IDS, SENTENCE
 from rasa.shared.nlu.constants import TEXT

--- a/tests/utils/tensorflow/test_models.py
+++ b/tests/utils/tensorflow/test_models.py
@@ -3,7 +3,7 @@ from typing import Dict, Text, Union
 import numpy as np
 import tensorflow as tf
 
-from rasa.utils.tensorflow.models import _merge_batch_outputs, RasaModel
+from rasa.utils.tensorflow.models import RasaModel
 from rasa.utils.tensorflow.model_data import RasaModelData
 from rasa.shared.constants import DIAGNOSTIC_DATA
 from rasa.utils.tensorflow.model_data import FeatureArray
@@ -37,7 +37,9 @@ def test_merging_batch_outputs(
     expected_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
 ):
 
-    predicted_output = _merge_batch_outputs(existing_outputs, new_batch_outputs)
+    predicted_output = RasaModel._merge_batch_outputs(
+        existing_outputs, new_batch_outputs
+    )
 
     def test_equal_dicts(
         dict1: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
@@ -76,7 +78,9 @@ def test_batch_inference(
         dummy_output = batch_in[0]
         output = {
             "dummy_output": dummy_output,
-            DIAGNOSTIC_DATA: tf.constant(np.array([[1, 2]]), dtype=tf.int32),
+            "non_input_affected_output": tf.constant(
+                np.array([[1, 2]]), dtype=tf.int32
+            ),
         }
         return output
 
@@ -108,4 +112,7 @@ def test_batch_inference(
     # equal to the number of batches passed to the model because for every
     # batch passed as input, it would have created a
     # corresponding diagnostic data entry.
-    assert output[DIAGNOSTIC_DATA].shape == (expected_number_of_batch_iterations, 2)
+    assert output["non_input_affected_output"].shape == (
+        expected_number_of_batch_iterations,
+        2,
+    )

--- a/tests/utils/tensorflow/test_models.py
+++ b/tests/utils/tensorflow/test_models.py
@@ -1,0 +1,107 @@
+import pytest
+from typing import Dict, Text, Union
+import numpy as np
+import tensorflow as tf
+
+from rasa.utils.tensorflow.models import _merge_batch_outputs, RasaModel
+from rasa.utils.tensorflow.model_data import RasaModelData
+from rasa.shared.constants import DIAGNOSTIC_DATA
+from rasa.utils.tensorflow.model_data import FeatureArray
+
+
+@pytest.mark.parametrize(
+    "existing_outputs, new_batch_outputs, expected_output",
+    [
+        (
+            {"a": np.array([1, 2]), "b": np.array([3, 1])},
+            {"a": np.array([5, 6]), "b": np.array([2, 4])},
+            {"a": np.array([1, 2, 5, 6]), "b": np.array([3, 1, 2, 4])},
+        ),
+        (
+            {},
+            {"a": np.array([5, 6]), "b": np.array([2, 4])},
+            {"a": np.array([5, 6]), "b": np.array([2, 4])},
+        ),
+        (
+            {"a": np.array([1, 2]), "b": {"c": np.array([3, 1])}},
+            {"a": np.array([5, 6]), "b": {"c": np.array([2, 4])}},
+            {"a": np.array([1, 2, 5, 6]), "b": {"c": np.array([3, 1, 2, 4])}},
+        ),
+    ],
+)
+def test_merging_batch_outputs(
+    existing_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+    new_batch_outputs: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+    expected_output: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+):
+
+    predicted_output = _merge_batch_outputs(existing_outputs, new_batch_outputs)
+
+    def test_equal_dicts(
+        dict1: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+        dict2: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
+    ):
+        assert dict2.keys() == dict1.keys()
+        for key in dict1:
+            val_1 = dict1[key]
+            val_2 = dict2[key]
+            assert type(val_1) == type(val_2)
+
+            if isinstance(val_2, np.ndarray):
+                assert np.array_equal(val_1, val_2)
+
+            elif isinstance(val_2, dict):
+                test_equal_dicts(val_1, val_2)
+
+    test_equal_dicts(predicted_output, expected_output)
+
+
+@pytest.mark.parametrize(
+    "batch_size, number_of_data_points, expected_number_of_batch_iterations",
+    [(2, 3, 2), (1, 3, 3), (5, 3, 1),],
+)
+def test_batch_inference(
+    batch_size: int,
+    number_of_data_points: int,
+    expected_number_of_batch_iterations: int,
+):
+    model = RasaModel()
+
+    def batch_predict(batch_in: np.ndarray):
+
+        dummy_output = batch_in[0]
+        output = {
+            "dummy_output": dummy_output,
+            DIAGNOSTIC_DATA: tf.constant(np.array([[1, 2]]), dtype=tf.int32),
+        }
+        return output
+
+    # Monkeypatch batch predict so that run_inference interface can be tested
+    model.batch_predict = batch_predict
+
+    # Create dummy model data to pass to model
+    model_data = RasaModelData(
+        label_key="label",
+        label_sub_key="ids",
+        data={
+            "text": {
+                "sentence": [
+                    FeatureArray(
+                        np.random.rand(number_of_data_points, 2),
+                        number_of_dimensions=2,
+                    ),
+                ]
+            }
+        },
+    )
+    output = model.run_inference(model_data, batch_size=batch_size)
+
+    # Firstly, the number of data points in dummy_output should be equal
+    # to the number of data points sent as input.
+    assert output["dummy_output"].shape[0] == number_of_data_points
+
+    # Secondly, the number of data points inside diagnostic_data should be
+    # equal to the number of batches passed to the model because for every
+    # batch passed as input, it would have created a
+    # corresponding diagnostic data entry.
+    assert output[DIAGNOSTIC_DATA].shape == (expected_number_of_batch_iterations, 2)

--- a/tests/utils/tensorflow/test_models.py
+++ b/tests/utils/tensorflow/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Dict, Text, Union
+from typing import Dict, Text, Union, Tuple
 import numpy as np
 import tensorflow as tf
 
@@ -71,7 +71,7 @@ def test_batch_inference(
     model = RasaModel()
 
     def _batch_predict(
-        batch_in: np.ndarray,
+        batch_in: Tuple[np.ndarray],
     ) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
 
         dummy_output = batch_in[0]

--- a/tests/utils/tensorflow/test_models.py
+++ b/tests/utils/tensorflow/test_models.py
@@ -7,6 +7,8 @@ from rasa.utils.tensorflow.models import _merge_batch_outputs, RasaModel
 from rasa.utils.tensorflow.model_data import RasaModelData
 from rasa.shared.constants import DIAGNOSTIC_DATA
 from rasa.utils.tensorflow.model_data import FeatureArray
+from rasa.utils.tensorflow.constants import LABEL, IDS, SENTENCE
+from rasa.shared.nlu.constants import TEXT
 
 
 @pytest.mark.parametrize(
@@ -40,7 +42,7 @@ def test_merging_batch_outputs(
     def test_equal_dicts(
         dict1: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
         dict2: Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]],
-    ):
+    ) -> None:
         assert dict2.keys() == dict1.keys()
         for key in dict1:
             val_1 = dict1[key]
@@ -67,7 +69,9 @@ def test_batch_inference(
 ):
     model = RasaModel()
 
-    def batch_predict(batch_in: np.ndarray):
+    def _batch_predict(
+        batch_in: np.ndarray,
+    ) -> Dict[Text, Union[np.ndarray, Dict[Text, np.ndarray]]]:
 
         dummy_output = batch_in[0]
         output = {
@@ -77,15 +81,15 @@ def test_batch_inference(
         return output
 
     # Monkeypatch batch predict so that run_inference interface can be tested
-    model.batch_predict = batch_predict
+    model.batch_predict = _batch_predict
 
     # Create dummy model data to pass to model
     model_data = RasaModelData(
-        label_key="label",
-        label_sub_key="ids",
+        label_key=LABEL,
+        label_sub_key=IDS,
         data={
-            "text": {
-                "sentence": [
+            TEXT: {
+                SENTENCE: [
                     FeatureArray(
                         np.random.rand(number_of_data_points, 2),
                         number_of_dimensions=2,


### PR DESCRIPTION
**Proposed changes**:
- All models now use `run_inference` method to generate predictions through the model. `run_inference` is meant to perform batch inferencing as well which means that it implements the batching and combining of output for different batches. The specific TF models like `TED`, `DIET` do not need to know the implementation details of this batch inferencing.
- Needed for future features like `IntentTEDPolicy`.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
