### PR TITLE
Fixed long east asian character sequences in interactive training

### DIFF
--- a/changelog/8341.bugfix.md
+++ b/changelog/8341.bugfix.md
@@ -1,0 +1,3 @@
+Fixed a bug in interactive training that 
+lead to crashes for long Chinese, Japanese, 
+or Korean user or bot utterances.

--- a/rasa/core/training/interactive.py
+++ b/rasa/core/training/interactive.py
@@ -22,6 +22,7 @@ from sanic.exceptions import NotFound
 from sanic.request import Request
 from sanic.response import HTTPResponse
 from terminaltables import AsciiTable, SingleTable
+import terminaltables.width_and_alignment
 import numpy as np
 from aiohttp import ClientError
 from colorclass import Color
@@ -486,7 +487,10 @@ def _chat_history_table(events: List[Dict[Text, Any]]) -> Text:
     prediction probabilities."""
 
     def wrap(txt: Text, max_width: int) -> Text:
-        return "\n".join(textwrap.wrap(txt, max_width, replace_whitespace=False))
+        true_wrapping_width = calc_true_wrapping_width(txt, max_width)
+        return "\n".join(
+            textwrap.wrap(txt, true_wrapping_width, replace_whitespace=False)
+        )
 
     def colored(txt: Text, color: Text) -> Text:
         return "{" + color + "}" + txt + "{/" + color + "}"
@@ -1672,3 +1676,42 @@ def run_interactive_learning(
     if not skip_visualization and p is not None:
         p.terminate()
         p.join()
+
+
+def calc_true_wrapping_width(text: Text, monospace_wrapping_width: int) -> int:
+    """Calculates a wrapping width that also works for CJK characters.
+
+    Chinese, Japanese and Korean characters are often broader than ascii
+    characters:
+    abcdefgh (8 chars)
+    我要去北京 (5 chars, roughly same visible width)
+
+    We need to account for that otherwise the wrapping doesn't work
+    appropriately for long strings and the table overflows and creates
+    errors.
+
+    params:
+        text: text sequence that should be wrapped into multiple lines
+        monospace_wrapping_width: the maximum width per line in number of
+            standard ascii characters
+    returns:
+        The maximum line width for the given string that takes into account
+        the strings visible width, so that it won't lead to table overflow.
+    """
+    true_wrapping_width = 0
+
+    # testing potential width from longest to shortest
+    for potential_width in range(monospace_wrapping_width, -1, -1):
+        lines = textwrap.wrap(text, potential_width)
+        # test whether all lines' visible width fits the available width
+        if all(
+            [
+                terminaltables.width_and_alignment.visible_width(line)
+                <= monospace_wrapping_width
+                for line in lines
+            ]
+        ):
+            true_wrapping_width = potential_width
+            break
+
+    return true_wrapping_width

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -768,7 +768,10 @@ def test_calc_true_wrapping_width(
 
 
 def test_no_chat_history_overflow() -> None:
-    """Should run without crashing."""
+    """Should run without crashing.
+
+    originally the long chinese utterance lead to a table width overflow and
+    available width for new utterances being < 0."""
     events = [
         {
             "event": "action",

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -741,3 +741,76 @@ def test_retry_on_error_three_retries(monkeypatch: MonkeyPatch):
         interactive._retry_on_error(m, "export_path", 1, a=2)
     c = mock.call("export_path", 1, a=2)
     m.assert_has_calls([c, c, c])
+
+
+@pytest.mark.parametrize(
+    "text,wrapping_width,true_wrapping_width",
+    [
+        ("abcdefgh", 8, 8),
+        ("abcdefgh", 4, 4),
+        ("abcdefgh", 50, 50),
+        ("Well, hello there my friend!", 20, 20),
+        ("我要去北京", 8, 4),
+        (
+            "牙龈出血的症状对应得疾病可能有：肥大性龈炎、骨髓增生异常综合征、口腔疾病、小儿出血性疾病、边缘性龈炎、获得性维生素K依赖性凝血因子异常、小儿白血病、回归热、坏死性龈口炎、青春期功能失调性子宫出血、郎-奥韦综合征、急性淋巴细胞白血病、感染性血小板减少性紫癜、单纯性牙周炎、单核细胞白血病、δ-贮存池病、小儿特发性血小板减少性紫癜、老年人真性红细胞增多症、急性根尖牙周炎、慢性根尖牙周炎、创伤性口炎、青少年牙周炎、慢性牙周炎",
+            119,
+            60,
+        ),
+    ],
+)
+def test_calc_true_wrapping_width(
+    text: Text, wrapping_width: int, true_wrapping_width: int
+) -> None:
+    assert (
+        interactive.calc_true_wrapping_width(text, wrapping_width)
+        == true_wrapping_width
+    )
+
+
+def test_no_chat_history_overflow() -> None:
+    """Should run without crashing."""
+    events = [
+        {
+            "event": "action",
+            "timestamp": 1619956299.2875981,
+            "name": "action_session_start",
+            "policy": None,
+            "confidence": 1.0,
+            "action_text": None,
+            "hide_rule_turn": False,
+        },
+        {"event": "session_started", "timestamp": 1619956299.287627},
+        {
+            "event": "bot",
+            "timestamp": 1619956324.2313201,
+            "metadata": {"utter_action": "utter_long_chinese"},
+            "text": "牙龈出血的症状对应得疾病可能有：肥大性龈炎、骨髓增生异常综合征、"
+            "口腔疾病、小儿出血性疾病、边缘性龈炎、获得性维生素K依赖性凝血因子异常、"
+            "小儿白血病、回归热、坏死性龈口炎、青春期功能失调性子宫出血、"
+            "郎-奥韦综合征、急性淋巴细胞白血病、感染性血小板减少性紫癜、"
+            "单纯性牙周炎、单核细胞白血病、δ-贮存池病、小儿特发性血小板减少性紫癜、"
+            "老年人真性红细胞增多症、急性根尖牙周炎、慢性根尖牙周炎、创伤性口炎、"
+            "青少年牙周炎、慢性牙周炎",
+        },
+        {
+            "event": "user",
+            "timestamp": 1619956299.509249,
+            "text": "hi",
+            "parse_data": {
+                "intent": {
+                    "id": -2517711783688260279,
+                    "name": "greet",
+                    "confidence": 1.0,
+                },
+                "entities": [],
+                "text": "hi",
+                "message_id": "4a95248b3c6b480c9550f9c19062e2bc",
+                "metadata": {},
+            },
+            "input_channel": None,
+            "message_id": "4a95248b3c6b480c9550f9c19062e2bc",
+            "metadata": {},
+        },
+    ]
+
+    rasa.core.training.interactive._chat_history_table(events)


### PR DESCRIPTION
**Proposed changes**:
- Fixes #8341 
- Chinese and other east asian characters can have a wider visible width than ascii characters, even in monospace fonts. This breaks the table that we have been using (see https://github.com/RasaHQ/rasa/issues/8341#issuecomment-817607778)
- Added a simple search algorithm to find the widest feasible width for line wrapping taking into account the visible width of the specific string

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
