### PR TITLE
correctly validate whether response selector responses from stories are valid if responses are found in the domain

### DIFF
--- a/changelog/8631.bugfix.md
+++ b/changelog/8631.bugfix.md
@@ -1,0 +1,2 @@
+Fixed incorrect `The action 'utter_<response selector intent>' is used in the stories, but is not a valid utterance action`
+error when running `rasa data validate` with response selector responses in the domain file.

--- a/data/test_domains/default_retrieval_intents.yml
+++ b/data/test_domains/default_retrieval_intents.yml
@@ -22,12 +22,3 @@ responses:
     - text: Bye
   utter_iamabot:
     - text: I am a bot, powered by Rasa.
-
-actions:
-  - utter_chitchat
-  - utter_greet
-  - utter_cheer_up
-  - utter_did_that_help
-  - utter_happy
-  - utter_goodbye
-  - utter_iamabot

--- a/data/test_domains/response_selector_responses_in_domain.yml
+++ b/data/test_domains/response_selector_responses_in_domain.yml
@@ -1,0 +1,35 @@
+# This test domain is the same as `default_retrieval_intents.yml`, but the responses
+# for the retrieval intents live in the domain file here
+
+intents:
+  - greet
+  - goodbye
+  - affirm
+  - deny
+  - mood_great
+  - mood_unhappy
+  - bot_challenge
+  - chitchat
+
+responses:
+  utter_greet:
+    - text: Hey! How are you?
+  utter_cheer_up:
+    - text: 'Here is something to cheer you up:'
+      image: https://i.imgur.com/nGF1K8f.jpg
+  utter_did_that_help:
+    - text: Did that help you?
+  utter_happy:
+    - text: Great, carry on!
+  utter_goodbye:
+    - text: Bye
+  utter_iamabot:
+    - text: I am a bot, powered by Rasa.
+  utter_chitchat/ask_name:
+    - image: "https://i.imgur.com/zTvA58i.jpeg"
+      text: hello, my name is retrieval bot.
+    - text: Oh yeah, I am called the retrieval bot.
+  utter_chitchat/ask_weather:
+    - text: Oh, it does look sunny right now in Berlin.
+      image: "https://i.imgur.com/vwv7aHN.png"
+    - text: I am not sure of the whole week but I can see the sun is out today.

--- a/rasa/validator.py
+++ b/rasa/validator.py
@@ -139,17 +139,22 @@ class Validator:
         return everything_is_alright
 
     def _gather_utterance_actions(self) -> Set[Text]:
-        """Return all utterances which are actions."""
+        """Return all utterances which are actions.
 
-        responses = {
+        Returns:
+            A set of response names found in the domain and data files, with the
+            response key stripped in the case of response selector responses.
+        """
+        domain_responses = {
+            response.split(rasa.shared.nlu.constants.RESPONSE_IDENTIFIER_DELIMITER)[0]
+            for response in self.domain.responses.keys()
+            if response in self.domain.action_names_or_texts
+        }
+        data_responses = {
             response.split(rasa.shared.nlu.constants.RESPONSE_IDENTIFIER_DELIMITER)[0]
             for response in self.intents.responses.keys()
         }
-        return responses | {
-            utterance
-            for utterance in self.domain.responses.keys()
-            if utterance in self.domain.action_names_or_texts
-        }
+        return domain_responses.union(data_responses)
 
     def verify_utterances_in_stories(self, ignore_warnings: bool = True) -> bool:
         """Verifies usage of utterances in stories.

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -278,4 +278,3 @@ async def test_invalid_domain_mapping_policy():
     )
     validator = await Validator.from_importer(importer)
     assert validator.verify_domain_validity() is False
-

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -257,3 +257,16 @@ async def test_verify_there_is_not_example_repetition_in_intents():
     )
     validator = await Validator.from_importer(importer)
     assert validator.verify_example_repetition_in_intents(False)
+
+
+async def test_response_selector_responses_in_domain_no_errors(tmp_path: Path):
+    importer = RasaFileImporter(
+        config_file="data/test_config/config_defaults.yml",
+        domain_path="data/test_domains/response_selector_responses_in_domain.yml",
+        training_data_paths=[
+            "data/test_yaml_stories/test_base_retrieval_intent_story.yml"
+        ],
+        training_type=TrainingType.CORE,
+    )
+    validator = await Validator.from_importer(importer)
+    assert validator.verify_utterances_in_stories(ignore_warnings=True)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -259,7 +259,7 @@ async def test_verify_there_is_not_example_repetition_in_intents():
     assert validator.verify_example_repetition_in_intents(False)
 
 
-async def test_response_selector_responses_in_domain_no_errors(tmp_path: Path):
+async def test_response_selector_responses_in_domain_no_errors():
     importer = RasaFileImporter(
         config_file="data/test_config/config_defaults.yml",
         domain_path="data/test_domains/response_selector_responses_in_domain.yml",


### PR DESCRIPTION
**Proposed changes**:
- Only recognize the first chunk of response selector responses when looking for names of actions in the domain file for action/story validation (e.g. `utter_chitchat` of `utter_chitchat/ask_name`
- Fix https://github.com/RasaHQ/rasa/issues/8633


**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
