### PR TITLE
Fix RegexEntityExtractor subclass loading

### DIFF
--- a/changelog/8641.misc.md
+++ b/changelog/8641.misc.md
@@ -1,0 +1,1 @@
+Fix RegexEntityExtractor load method to use cls instead of hardcoded class type. This fixes subclassing issues.

--- a/rasa/nlu/extractors/regex_entity_extractor.py
+++ b/rasa/nlu/extractors/regex_entity_extractor.py
@@ -124,9 +124,9 @@ class RegexEntityExtractor(EntityExtractor):
 
         if os.path.exists(regex_file):
             patterns = rasa.shared.utils.io.read_json_file(regex_file)
-            return RegexEntityExtractor(meta, patterns=patterns)
+            return cls(meta, patterns=patterns)
 
-        return RegexEntityExtractor(meta)
+        return cls(meta)
 
     def persist(self, file_name: Text, model_dir: Text) -> Optional[Dict[Text, Any]]:
         """Persist this model into the passed directory.

--- a/rasa/nlu/extractors/regex_entity_extractor.py
+++ b/rasa/nlu/extractors/regex_entity_extractor.py
@@ -130,7 +130,9 @@ class RegexEntityExtractor(EntityExtractor):
 
     def persist(self, file_name: Text, model_dir: Text) -> Optional[Dict[Text, Any]]:
         """Persist this model into the passed directory.
-        Return the metadata necessary to load the model again."""
+
+        Return the metadata necessary to load the model again.
+        """
         file_name = f"{file_name}.json"
         regex_file = os.path.join(model_dir, file_name)
         rasa.shared.utils.io.dump_obj_as_json_to_file(regex_file, self.patterns)


### PR DESCRIPTION
**Proposed changes**:
- `RegexEntityExtractor` load method instantiates the component using the hardcoded class type as oppose to the `cls` argument, which loses the subclass type. This caused issues when subclassing `RegexEntityExtractor`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
