### PR TITLE
fix slot filling for `ListSlot`s in case only a single matching entity was extracted

### DIFF
--- a/changelog/8364.bugfix.md
+++ b/changelog/8364.bugfix.md
@@ -1,0 +1,5 @@
+Fixed a bug where [`ListSlot`](domain.mdx#list-slot)s were filled with single items
+in case only one matching entity was extracted for this slot.
+
+Values applied to [`ListSlot`](domain.mdx#list-slot)s will be converted to a `List`
+in case they aren't one.

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -239,7 +239,7 @@ class FormAction(LoopAction):
         ) or entity_type_of_slot_to_fill != slot_mapping.get("entity"):
             slot_fulfils_entity_mapping = False
         else:
-            matching_values = self.get_entity_value(
+            matching_values = self.get_entity_value_for_slot(
                 slot_mapping.get("entity"),
                 tracker,
                 slot,
@@ -255,7 +255,7 @@ class FormAction(LoopAction):
         )
 
     @staticmethod
-    def get_entity_value(
+    def get_entity_value_for_slot(
         name: Text,
         tracker: "DialogueStateTracker",
         slot_to_be_filled: Text,
@@ -331,7 +331,7 @@ class FormAction(LoopAction):
                         and self.intent_is_desired(slot_mapping, tracker, domain)
                     )
                     if should_fill_entity_slot:
-                        value = self.get_entity_value(
+                        value = self.get_entity_value_for_slot(
                             slot_mapping["entity"],
                             tracker,
                             slot,
@@ -391,7 +391,7 @@ class FormAction(LoopAction):
             if self.intent_is_desired(requested_slot_mapping, tracker, domain):
                 mapping_type = requested_slot_mapping["type"]
                 if mapping_type == str(SlotMapping.FROM_ENTITY):
-                    value = self.get_entity_value(
+                    value = self.get_entity_value_for_slot(
                         requested_slot_mapping.get("entity"),
                         tracker,
                         slot_to_fill,

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -276,6 +276,8 @@ class ListSlot(Slot):
 
 
 class UnfeaturizedSlot(Slot):
+    """Deprecated slot type to represent slots which don't influence conversations."""
+
     type_name = "unfeaturized"
 
     def __init__(

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -265,6 +265,15 @@ class ListSlot(Slot):
             # we couldn't convert the value to a list - using default value
             return [0.0]
 
+    @Slot.value.setter
+    def value(self, value: Any) -> None:
+        """Sets the slot's value."""
+        if not isinstance(value, list):
+            # Make sure we always store list items
+            value = [value]
+
+        Slot.value.fset(self, value)
+
 
 class UnfeaturizedSlot(Slot):
     type_name = "unfeaturized"

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -288,6 +288,18 @@ class UnfeaturizedSlot(Slot):
         auto_fill: bool = True,
         influence_conversation: bool = False,
     ) -> None:
+        """Creates unfeaturized slot.
+
+        Args:
+            name: The name of the slot.
+            initial_value: Its initial value.
+            value_reset_delay: After how many turns the slot should be reset to the
+                initial_value. This is behavior is currently not implemented.
+            auto_fill: `True` if it should be auto-filled by entities with the same
+                name.
+            influence_conversation: `True` if it should be featurized. Only `False`
+                is allowed. Any other value will lead to a `InvalidSlotConfigError`.
+        """
         if influence_conversation:
             raise InvalidSlotConfigError(
                 f"An {UnfeaturizedSlot.__name__} cannot be featurized. "

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -268,11 +268,12 @@ class ListSlot(Slot):
     @Slot.value.setter
     def value(self, value: Any) -> None:
         """Sets the slot's value."""
-        if not isinstance(value, list):
+        if value and not isinstance(value, list):
             # Make sure we always store list items
             value = [value]
 
-        Slot.value.fset(self, value)
+        # Call property setter of superclass
+        super(ListSlot, self.__class__).value.fset(self, value)
 
 
 class UnfeaturizedSlot(Slot):

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -1383,12 +1383,12 @@ def test_extract_other_list_slot_from_entity(
         textwrap.dedent(
             f"""
     version: "2.0"
-    
+
     slots:
       {slot_name}:
         type: list
         influence_conversation: false
-        
+
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -812,7 +812,7 @@ def test_extract_requested_slot_when_mapping_applies(
 @pytest.mark.parametrize(
     "entities, expected_slot_values",
     [
-        # Two entities were extracted for `ListSlot``
+        # Two entities were extracted for `ListSlot`
         (
             [
                 {"entity": "topping", "value": "mushrooms"},
@@ -820,7 +820,7 @@ def test_extract_requested_slot_when_mapping_applies(
             ],
             ["mushrooms", "kebab"],
         ),
-        # One entities was extracted for `ListSlot``
+        # Only one entity was extracted for `ListSlot`
         ([{"entity": "topping", "value": "kebab"},], ["kebab"],),
     ],
 )
@@ -1362,7 +1362,7 @@ def test_extract_other_slots_with_entity(
 @pytest.mark.parametrize(
     "entities, expected_slot_values",
     [
-        # Two entities were extracted for `ListSlot``
+        # Two entities were extracted for `ListSlot`
         (
             [
                 {"entity": "topping", "value": "mushrooms"},
@@ -1370,7 +1370,7 @@ def test_extract_other_slots_with_entity(
             ],
             ["mushrooms", "kebab"],
         ),
-        # One entities was extracted for `ListSlot``
+        # Only one entity was extracted for `ListSlot`
         ([{"entity": "topping", "value": "kebab"},], ["kebab"],),
     ],
 )

--- a/tests/shared/core/test_slots.py
+++ b/tests/shared/core/test_slots.py
@@ -4,6 +4,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 import rasa.shared.core.constants
+from rasa.shared.core.events import SlotSet
 from rasa.shared.core.slots import (
     InvalidSlotTypeException,
     Slot,
@@ -17,6 +18,7 @@ from rasa.shared.core.slots import (
     AnySlot,
     InvalidSlotConfigError,
 )
+from rasa.shared.core.trackers import DialogueStateTracker
 
 
 class SlotTestCollection:
@@ -200,6 +202,16 @@ class TestListSlot(SlotTestCollection):
     @pytest.fixture(params=[(None, [0]), ([], [0]), ([1], [1]), (["asd", 1, {}], [1])])
     def value_feature_pair(self, request: SubRequest) -> Tuple[Any, List[float]]:
         return request.param
+
+    @pytest.mark.parametrize("value", ["cat", ["cat"]])
+    def test_apply_single_item_to_slot(self, value: Any):
+        slot = self.create_slot(influence_conversation=False)
+        tracker = DialogueStateTracker.from_events("sender", evts=[], slots=[slot])
+
+        slot_event = SlotSet(slot.name, value)
+        tracker.update(slot_event)
+
+        assert tracker.slots[slot.name].value == ["cat"]
 
 
 class TestUnfeaturizedSlot(SlotTestCollection):


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/8364
- The issue was that we decided whether something should be filled with a list based on how many matching entities were extracted. This means if we e.g. asked for pizza toppings and a user only wants "mushrooms" we would have set the slot with the string "mushroom" instead of `[mushroom]`. This behavior is fine unless it's for `ListSlot`s as these should (as the name suggests) always be `List`s
- we are now checking the slot type before deciding whether to convert the entities to single items or not
- I also modified the setter for `ListSlot` so that items which aren't `List`s are automatically put into a list to ensure `ListSlot` values are always `List`s

**Things I didn't do**
- I considered adding a warning if there are multiple entities for a slot type which isn't a `ListSlot`. I didn't do so as this might lead to false warnings for users who are using [custom slots](https://rasa.com/docs/rasa/domain#custom-slot-types)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
