### PR TITLE
Add note on autofilled slots behaviour & consistently refer to duckling as DucklingEntityExtractor

### DIFF
--- a/docs/docs/business-logic.mdx
+++ b/docs/docs/business-logic.mdx
@@ -86,7 +86,7 @@ entities:
 ```
 
 Entities like numbers
-can be extracted by the [DucklingEntityExtractor](./components.mdx#ducklinghttpextractor). To use it, add  DucklingEntityExtractor
+can be extracted by the [DucklingEntityExtractor](./components.mdx#ducklingentityextractor). To use it, add  DucklingEntityExtractor
 to your NLU pipeline:
 
 ```yaml-rasa title="config.yml"
@@ -311,4 +311,4 @@ example above, this is a summary of what you'll need to do:
 To try out your newly defined form, retrain the bot's model by running `rasa train` and start `rasa shell`.
 Because the DucklingEntityExtractor is being used to extract
 entities, you'll need to start Duckling in the background as well
-(see the [instructions for running Duckling](components.mdx#ducklinghttpextractor)).
+(see the [instructions for running Duckling](components.mdx#DucklingEntityExtractor)).

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -1742,7 +1742,7 @@ Entity extractors extract entities, such as person names or locations, from the 
 
 :::note
   If you use multiple entity extractors, we advise that each extractor targets an exclusive
-  set of entity types. For example, use [Duckling](components.mdx#ducklinghttpextractor) to extract dates and times, and
+  set of entity types. For example, use [Duckling](components.mdx#ducklingentityextractor) to extract dates and times, and
   [DIETClassifier](components.mdx#dietclassifier-1) to extract person names. Otherwise, if multiple extractors
   target the same entity types, it is very likely that entities will be extracted multiple times.
 
@@ -2032,7 +2032,7 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
   :::
 
 
-### DucklingHTTPExtractor
+### DucklingEntityExtractor
 
 
 * **Short**
@@ -2064,7 +2064,7 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
           "start": 48,
           "value": "2017-04-10T00:00:00.000+02:00",
           "confidence": 1.0,
-          "extractor": "DucklingHTTPExtractor"
+          "extractor": "DucklingEntityExtractor"
       }]
   }
   ```
@@ -2104,7 +2104,7 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
 
   ```yaml-rasa
   pipeline:
-  - name: "DucklingHTTPExtractor"
+  - name: "DucklingEntityExtractor"
     # url of the running duckling server
     url: "http://localhost:8000"
     # dimensions to extract

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -474,7 +474,13 @@ The slot type `unfeaturized` is deprecated. Please use the property
 ### Slot Auto-fill
 
 The slot will be set automatically if your NLU model picks up an entity, and your domain
- contains a slot with the same name. For example:
+ contains a slot with the same name, provided the following conditions are met:
+ 
+1. `store_entities_as_slots` is set to true
+2. the slot's `auto_fill` property is set to true
+
+
+For example:
 
 ```yaml-rasa
 stories:
@@ -485,19 +491,44 @@ stories:
     - name: Ali
   - slot_was_set:
     - name: Ali
+  - action: utter_greet_by_name
 ```
 
 In this case, you don't have to include the `slot_was_set` part in the
-story, because it is automatically picked up.
+story, because it is automatically picked up:
 
-To disable this behavior for a particular slot, you can set the
-`auto_fill` attribute to `False` in the domain file:
+```yaml-rasa
+stories:
+- story: entity slot-filling
+  steps:
+  - intent: greet
+    entities:
+    - name: Ali
+  - action: utter_greet_by_name
+```
+
+
+:::note Auto-filled slots & `influence_conversation`
+An auto-filled slot that is defined with `influence_conversation: true` will influence the conversation the same way any other slot does.
+
+In the example above, if the `name` slot's type is `text`, then it only matters that some name was detected, but it won't matter which one.
+If the `name` slot is type `categorical`, then the behaviour will vary depending on the categories you have defined for the slot. 
+
+Explicitly including a `slot_was_set` step in your story can make the behaviour of an
+auto-filled slot that influences the conversation clearer, and will not change the behaviour of your story.
+
+:::
+
+
+
+To disable auto-filling for a particular slot, you can set the
+`auto_fill` attribute to `false` in the domain file:
 
 ```yaml-rasa
 slots:
   name:
     type: text
-    auto_fill: False
+    auto_fill: false
 ```
 
 ### Initial slot values

--- a/docs/docs/generating-nlu-data.mdx
+++ b/docs/docs/generating-nlu-data.mdx
@@ -123,7 +123,7 @@ data for an NLU model to generalize effectively.
 
 Rasa Open Source provides two great options for
 pre-trained extraction: [SpacyEntityExtractor](./components.mdx#SpacyEntityExtractor)
-and [DucklingEntityExtractor](./components.mdx#DucklingHTTPExtractor).
+and [DucklingEntityExtractor](./components.mdx#DucklingEntityExtractor).
 Because these extractors have been pre-trained on a large corpus of data, you can use them
 to extract the entities they support without annotating them in your training data.
 


### PR DESCRIPTION
**Proposed changes**:
- DucklingHTTPExtractor -> DucklingEntityExtractor everywhere. This change should have been made in the 2.0 release, but looks like some docs escaped notice
- Add a note about autofilled slots behaviour

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
