### PR TITLE
Raises an error when an undefined key is used in domain.yml

### DIFF
--- a/rasa/shared/nlu/training_data/schemas/responses.yml
+++ b/rasa/shared/nlu/training_data/schemas/responses.yml
@@ -11,6 +11,7 @@ schema;responses:
       - type: "map"
         required: True
         allowempty: False
+        matching: any
         mapping:
           text:
             type: "str"


### PR DESCRIPTION
I validated this using a working domain.yml using `rasa train --dry-run`