### PR TITLE
Fix telegram message update

### DIFF
--- a/changelog/8719.bugfix.md
+++ b/changelog/8719.bugfix.md
@@ -1,0 +1,1 @@
+Handle correctly Telegram edited message.

--- a/rasa/core/channels/telegram.py
+++ b/rasa/core/channels/telegram.py
@@ -178,6 +178,10 @@ class TelegramInput(InputChannel):
         return message.text is not None
 
     @staticmethod
+    def _is_edited_message(message: Update) -> bool:
+        return message.edited_message is not None
+
+    @staticmethod
     def _is_button(message: Update) -> bool:
         return message.callback_query is not None
 
@@ -214,6 +218,9 @@ class TelegramInput(InputChannel):
                 if self._is_button(update):
                     msg = update.callback_query.message
                     text = update.callback_query.data
+                elif self._is_edited_message(update):
+                    msg = update.edited_message
+                    text = update.edited_message.text
                 else:
                     msg = update.message
                     if self._is_user_message(msg):

--- a/tests/core/channels/test_telegram.py
+++ b/tests/core/channels/test_telegram.py
@@ -1,0 +1,64 @@
+import json
+import logging
+from unittest.mock import patch
+
+import rasa
+from rasa.core.channels import TelegramInput
+from rasa.core.channels.telegram import TelegramOutput
+from rasa.core.agent import Agent
+
+logger = logging.getLogger(__name__)
+
+
+def noop(*args, **kwargs):
+    """Just do nothing."""
+    pass
+
+
+def mock_get_me(self):
+    self.username = "YOUR_TELEGRAM_BOT"
+    return self
+
+
+@patch.object(TelegramOutput, "set_webhook", noop)
+@patch.object(TelegramOutput, "get_me", mock_get_me)
+def test_telegram_edit_message():
+    telegram_test_edited_message = {
+        "update_id": 280069275,
+        "edited_message": {
+            "message_id": 591,
+            "from": {
+                "id": 1760450482,
+                "is_bot": "False",
+                "first_name": "Martin",
+                "last_name": "Man",
+                "language_code": "en",
+            },
+            "chat": {
+                "id": 1760450482,
+                "first_name": "Martin",
+                "last_name": "Man",
+                "type": "private",
+            },
+            "date": 1621577771,
+            "edit_date": 1621580124,
+            "text": "Hello!",
+        },
+    }
+
+    input_channel = TelegramInput(
+        # you get this when setting up a bot
+        access_token="123:YOUR_ACCESS_TOKEN",
+        # this is your bots username
+        verify="YOUR_TELEGRAM_BOT",
+        # the url your bot should listen for messages
+        webhook_url="YOUR_WEBHOOK_URL",
+    )
+
+    app = rasa.core.run.configure_app([input_channel], port=5004)
+    app.agent = Agent()
+    _, res = app.test_client.post(
+        "/webhooks/telegram/webhook", json=json.dumps(telegram_test_edited_message)
+    )
+
+    assert res.status_code == 200


### PR DESCRIPTION
**Proposed changes**:
- add handling of edited message on the Telegram channel
- if the edited message is unhandled it is causing crash and all communication on the channel is stopped

When receiving edited message telegram channel connector crashes:
```
Exception occurred while handling uri: 'http://***/webhooks/telegram/webhook'
Traceback (most recent call last):
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/sanic/app.py", line 976, in handle_request
    response = await response
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/rasa/core/channels/telegram.py", line 218, in message
    if self._is_user_message(msg):
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/rasa/core/channels/telegram.py", line 177, in _is_user_message
    return message.text is not None
AttributeError: 'NoneType' object has no attribute 'text'
Exception occurred while handling uri: 'http://***/webhooks/telegram/webhook'
Traceback (most recent call last):
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/sanic/app.py", line 976, in handle_request
    response = await response
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/rasa/core/channels/telegram.py", line 218, in message
    if self._is_user_message(msg):
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/rasa/core/channels/telegram.py", line 177, in _is_user_message
    return message.text is not None
AttributeError: 'NoneType' object has no attribute 'text'
Exception occurred while handling uri: 'http://***/webhooks/telegram/webhook'
Traceback (most recent call last):
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/sanic/app.py", line 976, in handle_request
    response = await response
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/rasa/core/channels/telegram.py", line 218, in message
    if self._is_user_message(msg):
  File "/home/martin/anaconda3/envs/rasa-2.4/lib/python3.7/site-packages/rasa/core/channels/telegram.py", line 177, in _is_user_message
    return message.text is not None
AttributeError: 'NoneType' object has no attribute 'text'
```

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
