### PR TITLE
Adding a rasa exception warning for sentry plot_histogram error

### DIFF
--- a/rasa/exceptions.py
+++ b/rasa/exceptions.py
@@ -23,6 +23,10 @@ class MissingDependencyException(RasaException):
     """Raised if a python package dependency is needed, but not installed."""
 
 
+class InvalidTypeException(RasaException):
+    """Raised when an object is of invalid/unexpected type is encountered."""
+
+
 class PublishingError(RasaException):
     """Raised when publishing of an event fails.
 

--- a/rasa/exceptions.py
+++ b/rasa/exceptions.py
@@ -24,7 +24,7 @@ class MissingDependencyException(RasaException):
 
 
 class InvalidTypeException(RasaException):
-    """Raised when an object is of invalid/unexpected type is encountered."""
+    """Raised when an object of invalid/unexpected type is encountered."""
 
 
 class PublishingError(RasaException):

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -59,6 +59,7 @@ from rasa.nlu.components import Component
 from rasa.nlu.tokenizers.tokenizer import Token
 from rasa.utils.tensorflow.constants import ENTITY_RECOGNITION
 from rasa.shared.importers.importer import TrainingDataImporter
+from rasa.exceptions import InvalidTypeException
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -339,9 +340,13 @@ def plot_attribute_confidences(
     ]
 
     if not (all(isinstance(item, float) for item in pos_hist)):
-        raise TypeError("All values of `pos_hist` should be of type `float`.")
+        raise InvalidTypeException(
+            f"All values of the `pos_hist` {type(pos_hist).__name__} should be of type `float`."
+        )
     if not (all(isinstance(item, float) for item in neg_hist)):
-        raise TypeError("All values of `neg_hist` should be of type `float`.")
+        raise InvalidTypeException(
+            f"All values of the `neg_hist` {type(neg_hist).__name__} should be of type `float`."
+        )
 
     plot_utils.plot_histogram([pos_hist, neg_hist], title, hist_filename)
 

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -338,6 +338,11 @@ def plot_attribute_confidences(
         if getattr(r, target_key) != getattr(r, prediction_key)
     ]
 
+    if not (all(isinstance(item, float) for item in pos_hist)):
+        raise TypeError("All values of `pos_hist` should be of type `float`.")
+    if not (all(isinstance(item, float) for item in neg_hist)):
+        raise TypeError("All values of `neg_hist` should be of type `float`.")
+
     plot_utils.plot_histogram([pos_hist, neg_hist], title, hist_filename)
 
 

--- a/rasa/utils/plotting.py
+++ b/rasa/utils/plotting.py
@@ -10,7 +10,6 @@ from matplotlib.ticker import FormatStrFormatter
 
 import rasa.shared.utils.io
 from rasa.constants import RESULTS_FILE
-from rasa.shared.exceptions import RasaException
 
 logger = logging.getLogger(__name__)
 

--- a/rasa/utils/plotting.py
+++ b/rasa/utils/plotting.py
@@ -125,8 +125,6 @@ def plot_confusion_matrix(
         logger.info(f"Confusion matrix, without normalization: \n{confusion_matrix}")
 
     thresh = zmax / 2.0
-    if not thresh:
-        raise RasaException(f"The variable `thresh` cannot be `{type(thresh)}`.")
     for i, j in itertools.product(
         range(confusion_matrix.shape[0]), range(confusion_matrix.shape[1])
     ):

--- a/rasa/utils/plotting.py
+++ b/rasa/utils/plotting.py
@@ -10,6 +10,7 @@ from matplotlib.ticker import FormatStrFormatter
 
 import rasa.shared.utils.io
 from rasa.constants import RESULTS_FILE
+from rasa.shared.exceptions import RasaException
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,8 @@ def plot_confusion_matrix(
         logger.info(f"Confusion matrix, without normalization: \n{confusion_matrix}")
 
     thresh = zmax / 2.0
+    if not thresh:
+        raise RasaException(f"The variable `thresh` cannot be `{type(thresh)}`.")
     for i, j in itertools.product(
         range(confusion_matrix.shape[0]), range(confusion_matrix.shape[1])
     ):

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -1228,14 +1228,18 @@ def test_plot_attribute_confidences_with_invalid_values(tmp_path: Path):
 
     rasa.shared.utils.io.create_directory(report_folder)
 
-    intent_results = [
-        IntentEvaluationResult("", "restaurant_search", 76, -21),
-        IntentEvaluationResult("greet", "greet", -32, 99),
+    response_results = [
+        ResponseSelectionEvaluationResult(
+            "chitchat/ask_weather", "chitchat/ask_weather", "What's the weather", 98,
+        ),
+        ResponseSelectionEvaluationResult(
+            "chitchat/ask_name", "chitchat/ask_name", "What's your name?", 12
+        ),
     ]
 
     with pytest.raises(InvalidTypeException):
-        evaluate_intents(
-            intent_results,
+        evaluate_response_selections(
+            response_results,
             report_folder,
             successes=True,
             errors=True,

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -78,7 +78,7 @@ from rasa.utils.tensorflow.constants import EPOCHS, ENTITY_RECOGNITION
 # this event_loop is used by pytest-asyncio, and redefining it
 # is currently the only way of changing the scope of this fixture
 from tests.nlu.utilities import write_file_config
-
+from rasa.exceptions import InvalidTypeException
 
 # Chinese Example
 # "对面食过敏" -> To be allergic to wheat-based food
@@ -1219,3 +1219,25 @@ def test_replacing_fallback_intent():
 def test_is_entity_extractor_present(components, expected_result):
     interpreter = Interpreter(components, context=None)
     assert is_entity_extractor_present(interpreter) == expected_result
+
+
+def test_plot_attribute_confidences_with_invalid_values(tmp_path: Path):
+    path = tmp_path / "evaluation"
+    path.mkdir()
+    report_folder = str(path / "reports")
+
+    rasa.shared.utils.io.create_directory(report_folder)
+
+    intent_results = [
+        IntentEvaluationResult("", "restaurant_search", 76, -21),
+        IntentEvaluationResult("greet", "greet", -32, 99),
+    ]
+
+    with pytest.raises(InvalidTypeException):
+        evaluate_intents(
+            intent_results,
+            report_folder,
+            successes=True,
+            errors=True,
+            disable_plotting=False,
+        )


### PR DESCRIPTION
**Proposed changes**:
Adding a rasa exception for plot_histogram error message.


**Steps to replicate the error**:
I tried to replicate the error message shown in this [issue](https://github.com/RasaHQ/rasa/issues/8582) by 
- force setting `thresh = None` in line 127 of this [file](https://github.com/RasaHQ/rasa/blob/main/rasa/utils/plotting.py) 
- and then running the command 
`rasa test nlu --cross-validation`
from an example bot (like formbot)

These settings/run, after quite a while, will produce the following error message :
`TypeError: '>' not supported between instances of 'int' and 'NoneType'`

This error message looks similar to the original one in the corresponding ticket but it makes me doubt because : 
- it is actually half of the original sentry error message 
- it is not in the line mentioned in the sentry 
`[max(hist_data[0], default=0), max(hist_data[1], default=0)], default=0`



**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
