### PR TITLE
Increase the timeout to run `tests/test_server.py::assert_trained_model` test successfully on Windows

### DIFF
--- a/changelog/8658.misc.md
+++ b/changelog/8658.misc.md
@@ -1,1 +1,2 @@
-Increase the timeout to run `tests/test_server.py::assert_trained_model` test successfully on Windows. 
+Increase the timeout to run `tests/test_server.py::test_train_with_retrieval_events_success` test 
+successfully on Windows. 

--- a/changelog/8658.misc.md
+++ b/changelog/8658.misc.md
@@ -1,0 +1,1 @@
+Increase the timeout to run `tests/test_server.py::assert_trained_model` test successfully on Windows. 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -538,7 +538,7 @@ async def test_train_core_success_with(
     assert os.path.exists(os.path.join(model_path, "fingerprint.json"))
 
 
-async def assert_trained_model(
+async def test_train_with_retrieval_events_success(
     rasa_app: SanicASGITestClient, stack_config_path: Text, tmp_path: Path
 ):
     with ExitStack() as stack:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import os
 import time
 import urllib.parse
 import uuid
+import sys
 from contextlib import ExitStack
 from http import HTTPStatus
 from multiprocessing import Process, Manager
@@ -537,7 +538,7 @@ async def test_train_core_success_with(
     assert os.path.exists(os.path.join(model_path, "fingerprint.json"))
 
 
-async def test_train_with_retrieval_events_success(
+async def assert_trained_model(
     rasa_app: SanicASGITestClient, stack_config_path: Text, tmp_path: Path
 ):
     with ExitStack() as stack:
@@ -561,7 +562,10 @@ async def test_train_with_retrieval_events_success(
             nlu=nlu_file.read(),
         )
 
-    _, response = await rasa_app.post("/model/train", json=payload, timeout=60 * 5)
+    # it usually takes a bit longer on windows so we're going to double the timeout
+    timeout = 60 * 10 if sys.platform == "win32" else 60 * 5
+
+    _, response = await rasa_app.post("/model/train", json=payload, timeout=timeout)
     assert response.status == HTTPStatus.OK
     assert_trained_model(response.body, tmp_path)
 


### PR DESCRIPTION
**Proposed changes**:
- fix #8658 

The reason for this change: it sometimes takes longer to run the training process on Windows (everything is a bit slower on Windows GH runners), and that's why the test for `tests/test_server.py::assert_trained_model` is sometimes flakey. This change fixes it.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
