### PR TITLE
Fix choco install error

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -273,7 +273,7 @@ jobs:
           New-Item -Path $spacy_data_dir -Type Directory
         }
         make install-full
-        make prepare-tests-windows
+        make prepare-tests-windows-gha
 
     - name: Add github workflow problem matchers
       if: needs.changes.outputs.backend == 'true' && matrix.python-version == 3.6 && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -250,7 +250,6 @@ jobs:
       # that needs to be cached.
       run: poetry config virtualenvs.in-project true
 
-
     - name: Install Dependencies (Linux) 📦
       if: needs.changes.outputs.backend == 'true' && matrix.os == 'ubuntu-latest'
       run: |

--- a/Makefile
+++ b/Makefile
@@ -135,17 +135,26 @@ prepare-tests-files: prepare-spacy prepare-mitie prepare-transformers
 prepare-wget-macos:
 	brew install wget || true
 
-prepare-wget-windows:
-	choco install wget
-
 prepare-tests-macos: prepare-wget-macos prepare-tests-files
 	brew install graphviz || true
 
 prepare-tests-ubuntu: prepare-tests-files
 	sudo apt-get -y install graphviz graphviz-dev python-tk
 
+prepare-wget-windows:
+	choco install wget
+
 prepare-tests-windows: prepare-wget-windows prepare-tests-files
 	choco install graphviz
+
+# GitHub Action has pre-installed a helper function for installing Chocolatey packages
+# It will retry the installation 5 times if it fails
+# See: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
+prepare-wget-windows-gha:
+	Choco-Install wget
+
+prepare-tests-windows-gha: prepare-wget-windows-gha prepare-tests-files
+	Choco-Install graphviz
 
 test: clean
 	# OMP_NUM_THREADS can improve overall performance using one thread by process (on tensorflow), avoiding overload

--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,10 @@ prepare-tests-windows: prepare-wget-windows prepare-tests-files
 # It will retry the installation 5 times if it fails
 # See: https://github.com/actions/virtual-environments/blob/main/images/win/scripts/ImageHelpers/ChocoHelpers.ps1
 prepare-wget-windows-gha:
-	Choco-Install wget
+	powershell -command "Choco-Install wget"
 
 prepare-tests-windows-gha: prepare-wget-windows-gha prepare-tests-files
-	Choco-Install graphviz
+	powershell -command "Choco-Install graphviz"
 
 test: clean
 	# OMP_NUM_THREADS can improve overall performance using one thread by process (on tensorflow), avoiding overload


### PR DESCRIPTION
**Proposed changes**:
- Resolves https://github.com/RasaHQ/rasa/issues/8656

The errors are most likely caused by the downtime of the external server. The package manager we are using for Windows is very unreliable. We can check the status here: https://status.chocolatey.org

There seems [no out-of-box solution for it](https://docs.chocolatey.org/en-us/choco/commands/install). The good news is that the GitHub Action team implemented a choco installation helper in their Windows VM, we can use it directly in the CI. 

