### PR TITLE
Failfast when publishing docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -81,3 +81,13 @@ jobs:
         git remote set-url --push origin "git@github.com:${{github.repository}}"
 
         ./scripts/push_docs_to_branch.sh
+
+    - name: Notify slack on failure
+      if: failure()
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      uses: voxmedia/github-action-slack-notify-build@212e9f7a9ca33368c8dd879d6053972128258985  # v1.5.0
+      with:
+        channel_id: ${{ secrets.SLACK_ALERTS_CHANNEL_ID }}
+        status: FAILED
+        color: warning

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -59,21 +59,21 @@ else
     echo "Updating the docs..."
     # remove everything in the previous docs/ folder, except versioned_docs/*, versioned_sidebars/*
     # and versions.js files.
-    cd $TMP_DOCS_FOLDER/docs/ && find . ! -path . ! -regex '.*version.*' -exec rm -rf {} + && cd -
+    cd $TMP_DOCS_FOLDER/docs/ && find . ! -path . ! -regex '.*version.*' -exec rm -rf {} + && cd - || exit 1
     # update the docs/ folder with the latest version of the docs
     cp -R `ls -A | grep -v "^\.git$"` $TMP_DOCS_FOLDER/
 
     if [ ! -z "$NEW_VERSION" ]
     then
         echo "Generating docs for new version $NEW_VERSION..."
-        cd $TMP_DOCS_FOLDER/docs && yarn run new-version $NEW_VERSION && cd -
+        cd $TMP_DOCS_FOLDER/docs && yarn run new-version $NEW_VERSION && cd - || exit 1
     fi
 fi
 
 CURRENTLY_EDITING_VERSION=${EXISTING_VERSION:-$NEW_VERSION}
 if [ -n "$CURRENTLY_EDITING_VERSION" ]
 then
-    cd $TMP_DOCS_FOLDER/docs && yarn run update-versioned-sources -- $CURRENTLY_EDITING_VERSION && cd -
+    cd $TMP_DOCS_FOLDER/docs && yarn run update-versioned-sources -- $CURRENTLY_EDITING_VERSION && cd - || exit 1
 fi
 
 cd $TMP_DOCS_FOLDER


### PR DESCRIPTION
**Proposed changes**:
- Failfast in the bash script that pushes docs
- Notify Slack channel when docs workflow fails (currently we rely on "people" telling us that the docs do not appear on the docs website)
- unifies the behaviour with Rasa X (see https://github.com/RasaHQ/rasa-x/pull/5137)

**This PR needs...**:
- [x] Code review