### PR TITLE
fix one caution box; rm reference to converttokenizer

### DIFF
--- a/docs/docs/fallback-handoff.mdx
+++ b/docs/docs/fallback-handoff.mdx
@@ -328,13 +328,13 @@ class ActionDefaultFallback(Action):
         return [ConversationPaused(), UserUtteranceReverted()]
 ```
 
-  :::caution Events Returned By A Custom Ultimate Fallback Action
-    You should include `UserUtteranceReverted()` as one of the events returned by your custom
-    `action_default_fallback`. Not including this event will cause the tracker to include all events that happened
-    during the Two-Stage Fallback process which could interfere with subsequent action predictions from the bot's policy
-    pipeline. It is better to treat events that occurred during the Two-Stage Fallback process as if they did not happen
-    so that your bot can apply its rules or memorized stories to correctly predict the next action.
-  :::
+:::caution Events Returned By A Custom Ultimate Fallback Action
+  You should include `UserUtteranceReverted()` as one of the events returned by your custom
+  `action_default_fallback`. Not including this event will cause the tracker to include all events that happened
+  during the Two-Stage Fallback process which could interfere with subsequent action predictions from the bot's policy
+  pipeline. It is better to treat events that occurred during the Two-Stage Fallback process as if they did not happen
+  so that your bot can apply its rules or memorized stories to correctly predict the next action.
+:::
 
 
 ## Human Handoff

--- a/docs/docs/tuning-your-model.mdx
+++ b/docs/docs/tuning-your-model.mdx
@@ -186,8 +186,7 @@ A pipeline usually consists of three main parts:
 
 ### Tokenization
 
-For tokenization of English input, we recommend the [ConveRTTokenizer](./components.mdx#converttokenizer).
-You can process other whitespace-tokenized (i.e. words are separated by spaces) languages
+You can process whitespace-tokenized (i.e. words are separated by spaces) languages
 with the [WhitespaceTokenizer](./components.mdx#whitespacetokenizer). If your language is not whitespace-tokenized, you should use a different tokenizer.
 We support a number of different [tokenizers](./components.mdx), or you can
 create your own [custom tokenizer](./components.mdx).


### PR DESCRIPTION
**Description**:
- box didn't render with the indentation
- ConvertTokenizer was recommended but it's link directly leads to a deprecation message (https://rasa.com/docs/rasa/components#converttokenizer)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
