### PR TITLE
use nludataimporter to avoid domain errors in nlu testing

### DIFF
--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -16,12 +16,12 @@ from rasa.shared.constants import (
     DEFAULT_MODELS_PATH,
     DEFAULT_DATA_PATH,
     DEFAULT_RESULTS_PATH,
-    DEFAULT_DOMAIN_PATH,
 )
 import rasa.shared.utils.validation as validation_utils
 import rasa.cli.utils
 import rasa.utils.common
-from rasa.shared.importers.importer import TrainingDataImporter
+from rasa.shared.importers.importer import NluDataImporter
+from rasa.shared.importers.rasa import RasaFileImporter
 
 logger = logging.getLogger(__name__)
 
@@ -158,9 +158,7 @@ async def run_nlu_test_async(
     )
 
     data_path = rasa.cli.utils.get_validated_path(data_path, "nlu", DEFAULT_DATA_PATH)
-    test_data_importer = TrainingDataImporter.load_from_dict(
-        training_data_paths=[data_path], domain_path=DEFAULT_DOMAIN_PATH,
-    )
+    test_data_importer = NluDataImporter(RasaFileImporter(training_data_paths=[data_path]))
     nlu_data = await test_data_importer.get_nlu_data()
 
     output = output_dir or DEFAULT_RESULTS_PATH


### PR DESCRIPTION
**Proposed changes**:
- Use an `NluDataImporter` on a `RasaFileImporter` directly instead of loading up a full TrainingDataImporter for NLU testing. 
- Previously, we called [this function](https://github.com/RasaHQ/rasa/blob/main/rasa/cli/test.py#L162) without a config param, so it was automatically using a `RasaFileImporter` no matter what. By making this change, we are still using a RasaFileImporter, but only the NLU part, and avoiding also [adding a bunch of responses stuff, e2e, etc](https://github.com/RasaHQ/rasa/blob/db3cb7d52ab30e39633a0b0fdfd85f64b66178df/rasa/shared/importers/importer.py#L162) which AFAIK shouldn't be needed here (i could be wrong though) 
- close https://github.com/RasaHQ/rasa/issues/8848

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
