### PR TITLE
speed up rule policy contraction check

### DIFF
--- a/changelog/improvement.8295.md
+++ b/changelog/improvement.8295.md
@@ -1,0 +1,2 @@
+Speed up the contradiction check of the [`RulePolicy`](policies.mdx#rule-policy)
+by a factor of 3.

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -833,7 +833,7 @@ class RulePolicy(MemoizationPolicy):
         return True
 
     @staticmethod
-    # This function is called a lot (e.g. for checking rule predictions) so we cache
+    # This function is called a lot (e.g. for checking contradictions) so we cache
     # its results.
     @functools.lru_cache(maxsize=1000)
     def _rule_key_to_state(rule_key: Text) -> List[State]:

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import time
 from typing import Any, List, Dict, Text, Optional, Set, Tuple, TYPE_CHECKING
 
 from tqdm import tqdm

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -1,4 +1,6 @@
+import functools
 import logging
+import time
 from typing import Any, List, Dict, Text, Optional, Set, Tuple, TYPE_CHECKING
 
 from tqdm import tqdm
@@ -832,6 +834,9 @@ class RulePolicy(MemoizationPolicy):
         return True
 
     @staticmethod
+    # This function is called a lot (e.g. for checking rule predictions) so we cache
+    # its results.
+    @functools.lru_cache(maxsize=1000)
     def _rule_key_to_state(rule_key: Text) -> List[State]:
         return json.loads(rule_key)
 


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/8295
- cache `_rule_key_to_state` as this a hotspot of the contradiction check according to the [profiling results](https://drive.google.com/file/d/154vW5bufikVcjXfrmqDDdA3A4PmXIeEt/view?usp=sharing) (viewable with [snakeviz](https://jiffyclub.github.io/snakeviz/))
- this speeds up the `RulePolicy` training with Sara from 14.4 seconds to 5.26 seconds
- see memory considerations of the cache [here](https://github.com/RasaHQ/rasa/issues/8295#issuecomment-856720809)
- follow up issue for bigger changes to the `RulePolicy` https://github.com/RasaHQ/rasa/issues/8850

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
