### PR TITLE
Fix docs build out of memory errors

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "pre-build": "yarn copy-md-files && yarn variables && yarn program-outputs && yarn included-sources && yarn autodoc && yarn telemetry",
     "start": "yarn pre-build && yarn develop",
     "develop": "docusaurus start --port 3000",
-    "build": "docusaurus build --out-dir build/docs/rasa",
+    "build": "node --max-old-space-size=4096 node_modules/.bin/docusaurus build --out-dir build/docs/rasa",
     "serve": "netlify dev --dir=build --port=5000",
     "deploy": "netlify deploy --dir=build --alias=staging --open",
     "new-version": "docusaurus docs:version",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "pre-build": "yarn copy-md-files && yarn variables && yarn program-outputs && yarn included-sources && yarn autodoc && yarn telemetry",
     "start": "yarn pre-build && yarn develop",
     "develop": "docusaurus start --port 3000",
-    "build": "node --max-old-space-size=4096 node_modules/.bin/docusaurus build --out-dir build/docs/rasa",
+    "build": "node --max-old-space-size=6144 node_modules/.bin/docusaurus build --out-dir build/docs/rasa",
     "serve": "netlify dev --dir=build --port=5000",
     "deploy": "netlify deploy --dir=build --alias=staging --open",
     "new-version": "docusaurus docs:version",


### PR DESCRIPTION
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
