### PR TITLE
CLI command to chat with an assistant using rasa webchat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/rasahq/rasa"
 documentation = "https://rasa.com/docs"
 classifiers = [ "Development Status :: 5 - Production/Stable", "Intended Audience :: Developers", "License :: OSI Approved :: Apache Software License", "Topic :: Software Development :: Libraries",]
 keywords = [ "nlp", "machine-learning", "machine-learning-library", "bot", "bots", "botkit", "rasa conversational-agents", "conversational-ai", "chatbot", "chatbot-framework", "bot-framework",]
-include = [ "LICENSE.txt", "README.md", "rasa/shared/core/training_data/visualization.html", "rasa/cli/default_config.yml", "rasa/shared/importers/*", "rasa/utils/schemas/*", "rasa/keys",]
+include = [ "LICENSE.txt", "README.md", "rasa/shared/core/training_data/visualization.html", "rasa/cli/default_config.yml", "rasa/shared/importers/*", "rasa/utils/schemas/*", "rasa/keys", "rasa/core/channels/chat.html"]
 readme = "README.md"
 license = "Apache-2.0"
 [[tool.poetry.source]]

--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -12,6 +12,7 @@ import rasa.utils.io
 import rasa.utils.tensorflow.environment as tf_env
 from rasa import version
 from rasa.cli import (
+    chat,
     data,
     export,
     interactive,
@@ -62,6 +63,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
     scaffold.add_subparser(subparsers, parents=parent_parsers)
     run.add_subparser(subparsers, parents=parent_parsers)
     shell.add_subparser(subparsers, parents=parent_parsers)
+    chat.add_subparser(subparsers, parents=parent_parsers)
     train.add_subparser(subparsers, parents=parent_parsers)
     interactive.add_subparser(subparsers, parents=parent_parsers)
     telemetry.add_subparser(subparsers, parents=parent_parsers)

--- a/rasa/cli/chat.py
+++ b/rasa/cli/chat.py
@@ -1,0 +1,69 @@
+import argparse
+from asyncio import AbstractEventLoop
+import logging
+from typing import List, Text
+import uuid
+import webbrowser
+
+from sanic import Sanic
+
+from rasa.cli import SubParsersAction
+from rasa.cli.arguments import shell as arguments
+from rasa.core import constants
+
+logger = logging.getLogger(__name__)
+
+
+def add_subparser(
+    subparsers: SubParsersAction, parents: List[argparse.ArgumentParser]
+) -> None:
+    """Add all chat parsers.
+
+    Args:
+        subparsers: subparser we are going to attach to
+        parents: Parent parsers, needed to ensure tree structure in argparse
+    """
+    chat_parser = subparsers.add_parser(
+        "chat",
+        parents=parents,
+        conflict_handler="resolve",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help=(
+            "Loads your trained model and lets you talk to your "
+            "assistant in the browser."
+        ),
+    )
+    chat_parser.set_defaults(func=chat)
+
+    chat_parser.add_argument(
+        "--conversation-id",
+        default=uuid.uuid4().hex,
+        required=False,
+        help="Set the conversation ID.",
+    )
+
+    arguments.set_shell_arguments(chat_parser)
+    chat_parser.set_defaults(enable_api=True)
+
+
+async def open_chat_in_browser(server_url: Text) -> None:
+    """Opens the rasa chat in the default browser."""
+    webbrowser.open(f"{server_url}/webhooks/socketio/chat.html")
+
+
+def chat(args: argparse.Namespace) -> None:
+    """Chat to the bot using the most recent model."""
+    import rasa.cli.run
+
+    args.connector = "socketio"
+
+    logging.getLogger("rasa.core.tracker_store").setLevel(logging.INFO)
+
+    async def after_start_hook_open_chat(_: Sanic, __: AbstractEventLoop) -> None:
+        """Hook to open the browser on server start."""
+        server_url = constants.DEFAULT_SERVER_FORMAT.format("http", args.port)
+        await open_chat_in_browser(server_url)
+
+    args.server_listeners = [(after_start_hook_open_chat, "after_server_start")]
+
+    rasa.cli.run.run(args)

--- a/rasa/core/channels/chat.html
+++ b/rasa/core/channels/chat.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <style>
+    .content {
+      max-width: 30em;
+    }
+
+    .container {
+      display: grid;
+      grid-template-columns: 35% 65%;
+    }
+
+    tr {
+      text-align: left;
+    }
+
+    table {
+      padding-top: 1em;
+    }
+
+    .bold {
+      font-weight: bold;
+    }
+  </style>
+  <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.7.0/styles/default.min.css">
+  <script src="https://unpkg.com/@highlightjs/cdn-assets@11.7.0/highlight.min.js"></script>
+</head>
+
+<body data-new-gr-c-s-check-loaded="14.1014.0" data-gr-ext-installed="" data-new-gr-c-s-loaded="14.1014.0">
+  <div class="logged-in-box auth0-box logged-in">
+    <h2>Happy chatting!</h2>
+    <div>You can include the chat on your own website using the following code:</div>
+    <div class="code"><code><pre>
+&lt;div id="rasa-chat-widget" data-websocket-url="https://example.com/"&gt;&lt;/div&gt;
+&lt;script src="https://unpkg.com/@rasahq/rasa-chat" type="application/javascript"&gt;&lt;/script&gt;
+    </pre></code></div>
+  </div>
+  <p class="content">Make sure to replace <code>https://example.com/</code> with the URL of your server
+    running your bot! You can find more documentation on how to use the chat widget
+    on your own page in the
+    <a href="https://rasa.com/docs/rasa/connectors/your-own-website#chat-widget">rasa documentation</a>
+  </p>
+  <div class="container">
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th>Slot</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody id="slots">
+        </tbody>
+      </table>
+      <div>
+        <p class="content bold">Latest Tracker Changes:</p>
+        <div>
+          <pre class="code language-yml"><code id="tracker-update"></code></pre>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="content bold">Current Story:</p>
+      <div>
+        <pre class="code language-json"><code id="json-data">No story yet</code></pre>
+      </div>
+    </div>
+  </div>
+  <div id="rasa-chat-widget" data-websocket-url="" data-default-open=true></div>
+
+  <script>
+    let chatDiv = document.getElementById("rasa-chat-widget");
+    let websocketUrl = window.location.origin.replace("http", "ws")
+    chatDiv.setAttribute("data-websocket-url", websocketUrl);
+  </script>
+
+  <script>
+    function fetchStory() {
+      let conversationId = window.rasaChatSessionId || "";
+      fetch("/conversations/" + conversationId + "/story")
+        .catch(error => console.error(error))
+        .then(response => {
+          if (!response.ok) {
+            console.error("Error: Story not found");
+            return "No story yet";
+          }
+          return response.text();
+        })
+        .then(data => {
+          let storyBlock = document.getElementById("json-data");
+          storyBlock.textContent = data;
+          if (window.hljs) {
+            hljs.highlightElement(storyBlock);
+          }
+        });
+    }
+    function fetchSlots() {
+      let conversationId = window.rasaChatSessionId || "";
+      fetch("/conversations/" + conversationId + "/tracker?start_session=false")
+        .catch(error => console.error(error))
+        .then(response => {
+          if (!response.ok) {
+            console.error("Error: Story not found");
+            return [];
+          }
+          return response.json()
+        })
+        .then(data => {
+          let slots = data.slots;
+          var root = document.getElementById('slots');
+          root.innerHTML = '';
+          var sortedSlotNames = Object.keys(slots).sort()
+          for (var i = 0; i < sortedSlotNames.length; i++) {
+            var name = sortedSlotNames[i];
+            let slotValue = JSON.stringify(slots[name], null, 2);
+            root.insertAdjacentHTML('afterbegin', `<tr><td>${name}</td><td>${slotValue}</td></tr>`);
+          }
+
+          //loop through events and display all events that happend after the
+          // event that has type user message
+          let trackerUpdates = [];
+
+          // extract all events that happend after the latest user message
+          for (let i = data.events.length - 1; i >= 0; i--) {
+            trackerUpdates.unshift(data.events[i])
+            if (data.events[i].event === "user") {
+              break;
+            }
+          }
+          let trackerUpdate = JSON.stringify(trackerUpdates, null, 2);
+          let updateBlock = document.getElementById("tracker-update");
+          updateBlock.textContent = trackerUpdate;
+          if (window.hljs) {
+            hljs.highlightElement(updateBlock);
+          }
+        });
+    }
+
+    setInterval(fetchStory, 1000); // fetch the Story every second
+
+    setInterval(fetchStory, 1000); // fetch the Story every second
+    setInterval(fetchSlots, 1000); // fetch the Tracker every second
+  </script>
+
+  <script src="https://unpkg.com/@rasahq/rasa-chat" type="application/javascript"></script>
+</body>
+
+</html>

--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -13,8 +13,12 @@ from socketio import AsyncServer
 
 logger = logging.getLogger(__name__)
 
+CHAT_TEMPLATE_PATH = "/chat.html"
+
 
 class SocketBlueprint(Blueprint):
+    """Blueprint for socketio connections."""
+
     def __init__(
         self, sio: AsyncServer, socketio_path: Text, *args: Any, **kwargs: Any
     ) -> None:
@@ -143,7 +147,7 @@ class SocketIOInput(InputChannel):
             credentials.get("user_message_evt", "user_uttered"),
             credentials.get("bot_message_evt", "bot_uttered"),
             credentials.get("namespace"),
-            credentials.get("session_persistence", False),
+            credentials.get("session_persistence", True),
             credentials.get("socketio_path", "/socket.io"),
             credentials.get("jwt_key"),
             credentials.get("jwt_method", "HS256"),
@@ -155,7 +159,7 @@ class SocketIOInput(InputChannel):
         user_message_evt: Text = "user_uttered",
         bot_message_evt: Text = "bot_uttered",
         namespace: Optional[Text] = None,
-        session_persistence: bool = False,
+        session_persistence: bool = True,
         socketio_path: Optional[Text] = "/socket.io",
         jwt_key: Optional[Text] = None,
         jwt_method: Optional[Text] = "HS256",
@@ -186,6 +190,12 @@ class SocketIOInput(InputChannel):
             return None
         return SocketIOOutput(self.sio, self.bot_message_evt)
 
+    def chat_html_path(self) -> Text:
+        """Returns the path to the chat.html file."""
+        import pkg_resources
+
+        return pkg_resources.resource_filename(__name__, CHAT_TEMPLATE_PATH)
+
     def blueprint(
         self, on_new_message: Callable[[UserMessage], Awaitable[Any]]
     ) -> Blueprint:
@@ -203,6 +213,10 @@ class SocketIOInput(InputChannel):
         @socketio_webhook.route("/", methods=["GET"])
         async def health(_: Request) -> HTTPResponse:
             return response.json({"status": "ok"})
+
+        @socketio_webhook.route("/chat.html", methods=["GET"])
+        async def chat(_: Request) -> HTTPResponse:
+            return await response.file(self.chat_html_path())
 
         @sio.on("connect", namespace=self.namespace)
         async def connect(sid: Text, environ: Dict, auth: Optional[Dict]) -> bool:

--- a/rasa/core/run.py
+++ b/rasa/core/run.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 import os
 from functools import partial
-from typing import Any, List, Optional, Text, Union, Dict
+from typing import Any, Callable, List, Optional, Text, Tuple, Union, Dict
 
 import rasa.core.utils
 from rasa.shared.exceptions import RasaException
@@ -95,6 +95,7 @@ def configure_app(
     syslog_port: Optional[int] = None,
     syslog_protocol: Optional[Text] = None,
     request_timeout: Optional[int] = None,
+    server_listeners: Optional[List[Tuple[Callable, Text]]] = None,
 ) -> Sanic:
     """Run the agent."""
     rasa.core.utils.configure_file_logging(
@@ -145,6 +146,10 @@ def configure_app(
 
         app.add_task(run_cmdline_io)
 
+    if server_listeners:
+        for (listener, event) in server_listeners:
+            app.register_listener(listener, event)
+
     return app
 
 
@@ -174,6 +179,7 @@ def serve_application(
     syslog_port: Optional[int] = None,
     syslog_protocol: Optional[Text] = None,
     request_timeout: Optional[int] = None,
+    server_listeners: Optional[List[Tuple[Callable, Text]]] = None,
 ) -> None:
     """Run the API entrypoint."""
     if not channel and not credentials:
@@ -199,6 +205,7 @@ def serve_application(
         syslog_port=syslog_port,
         syslog_protocol=syslog_protocol,
         request_timeout=request_timeout,
+        server_listeners=server_listeners,
     )
 
     ssl_context = server.create_ssl_context(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -43,7 +43,7 @@ def test_data_convert_help(run: Callable[..., RunResult]):
     output = run("--help")
 
     help_text = f"""usage: {RASA_EXE} [-h] [--version]
-            {{init,run,shell,train,interactive,telemetry,test,visualize,data,export,x,evaluate}}
+            {{init,run,shell,chat,train,interactive,telemetry,test,visualize,data,export,x,evaluate}}
             ..."""
 
     lines = help_text.split("\n")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1914,16 +1914,21 @@ async def test_get_story(
     assert response.content.decode().strip() == expected
 
 
-async def test_get_story_without_conversation_id(
+async def test_get_story_with_new_conversation_id(
     rasa_app: SanicASGITestClient, monkeypatch: MonkeyPatch
 ):
-    conversation_id = "some-conversation-ID"
+    conversation_id = "some-conversation-ID-42"
     url = f"/conversations/{conversation_id}/story"
 
     _, response = await rasa_app.get(url)
 
-    assert response.status == HTTPStatus.NOT_FOUND
-    assert response.json["message"] == "Conversation ID not found."
+    expected = """version: "3.1"
+stories:
+- story: some-conversation-ID-42
+  steps: []"""
+
+    assert response.status == HTTPStatus.OK
+    assert response.content.decode().strip() == expected
 
 
 async def test_get_story_does_not_update_conversation_session(


### PR DESCRIPTION
**Proposed changes**:
- add a new CLI command `rasa chat` to run the assistant using SocketIO and open webchat
- added HTML page to host the webchat, keeping everything on localhost

**Example interaction**:

https://user-images.githubusercontent.com/1098412/122185610-83178780-ce8d-11eb-9755-8e99cb922705.mov

If we want to add this, we'd need to update the documentation and I'd suggest recommending using the webchat rather than `rasa shell`.

The HTML surrounding the webchat currently is very basic. We'd at least need some background/design for it. (random idea in the future @TyDunn we could use the background to feature conferences or community events - just a random thought though). We could also use the space to show more state information about the conversation, e.g. grabbing the sidepanel we use in Rasa X:
![Bildschirmfoto 2021-06-16 um 10 35 51](https://user-images.githubusercontent.com/1098412/122186831-bc9cc280-ce8e-11eb-9743-a60ff6a3d036.png)
