### PR TITLE
Clarify the behaviour of `WhitespaceTokenizer`

### DIFF
--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -278,7 +278,6 @@ now implements its behavior.
     - `"1 - 2"` &#8594; `"1"`,`"2"`
 
 
-
   * **Configuration**
 
     ```yaml-rasa

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -256,6 +256,27 @@ now implements its behavior.
 
     Creates a token for every whitespace separated character sequence.
 
+    Any character not in: `a-zA-Z0-9_#@&` will be substituted with whitespace before
+    splitting on whitespace if the character fulfills any of the following conditions:
+    - the character follows a whitespace: `" !word"` &#8594; `"word"`
+    - the character precedes a whitespace: `"word! "` &#8594; `"word"`
+    - the character is at the beginning of the string: `"!word"` &#8594; `"word"`
+    - the character is at the end of the string: `"word!"` &#8594; `"word"`
+
+    Note that:
+    - `"wo!rd"` &#8594; `"wo!rd"`
+
+    In addition, any character not in: `a-zA-Z0-9_#@&.~:\/?[]()!$*+,;=-` will be
+    substituted with whitespace before splitting on whitespace if the character is not
+    between numbers:
+    - `"twenty{one"` &#8594; `"twenty"`, `"one"`         ("{"` is not between numbers)
+    - `"20{1"` &#8594; `"20{1"`                          ("{"` *is* between numbers)
+
+    Note that:
+    - `"name@example.com"` &#8594; `"name@example.com"`
+    - `"10,000.1"` &#8594; `"10,000.1"`
+    - `"1 - 2"` &#8594; `"1"`,`"2"`
+
 
 
   * **Configuration**


### PR DESCRIPTION
We had a [false bug alarm](https://github.com/RasaHQ/rasa/issues/8468) due to some confusion over the behaviour of `WhitespaceTokenizer`. This PR is an attempt to clarify the behaviour of `WhitespaceTokenizer`.

The resulting page looks like:

<img width="675" alt="Screenshot 2021-06-18 at 17 04 44" src="https://user-images.githubusercontent.com/45405119/122582756-cd009900-d058-11eb-8f7b-a9d1b65a2dfa.png">
