### PR TITLE
IntentTEDPolicy: Add severity to metadata

### DIFF
--- a/rasa/core/policies/intent_ted_policy.py
+++ b/rasa/core/policies/intent_ted_policy.py
@@ -436,7 +436,7 @@ class IntentTEDPolicy(TEDPolicy):
 
         def _compile_metadata_for_label(
             label_name: Text, similarity_score: float, threshold: Optional[float],
-        ) -> Dict[Text, float]:
+        ) -> Dict[Text, Optional[Union[Text, float]]]:
             severity = abs(similarity_score - threshold) if threshold else None
             return {
                 NAME: label_name,

--- a/rasa/core/policies/intent_ted_policy.py
+++ b/rasa/core/policies/intent_ted_policy.py
@@ -406,7 +406,7 @@ class IntentTEDPolicy(TEDPolicy):
     def _collect_action_metadata(
         self, domain: Domain, similarities: np.array, query_intent: Text
     ) -> Dict[Text, Any]:
-        """Adds any metadata to be attached to the predicted action.
+        """Collects metadata to be attached to the predicted action.
 
         Metadata schema looks like this:
 

--- a/rasa/core/policies/intent_ted_policy.py
+++ b/rasa/core/policies/intent_ted_policy.py
@@ -410,6 +410,7 @@ class IntentTEDPolicy(TEDPolicy):
         Returns:
             Metadata to be attached.
         """
+        query_intent_index = domain.intents.index(query_intent)
 
         def _compile_metadata_for_intent(
             intent_name: Text,
@@ -424,7 +425,6 @@ class IntentTEDPolicy(TEDPolicy):
                 "severity": severity,
             }
 
-        query_intent_index = domain.intents.index(query_intent)
         metadata = {
             "query_intent": _compile_metadata_for_intent(
                 query_intent,

--- a/rasa/core/policies/intent_ted_policy.py
+++ b/rasa/core/policies/intent_ted_policy.py
@@ -427,8 +427,6 @@ class IntentTEDPolicy(TEDPolicy):
             "severity": <absolute difference between score and threshold>
         }
 
-        The function also
-
         Args:
             domain: Domain of the assistant.
             similarities: Predicted similarities for each intent.

--- a/rasa/utils/tensorflow/constants.py
+++ b/rasa/utils/tensorflow/constants.py
@@ -102,7 +102,7 @@ POSITIVE_SCORES_KEY = "positive_scores"
 
 NEGATIVE_SCORES_KEY = "negative_scores"
 
-RANKING_KEY = "ranking"
+RANKING_KEY = "label_ranking"
 QUERY_INTENT_KEY = "query_intent"
 SCORE_KEY = "score"
 THRESHOLD_KEY = "threshold"

--- a/rasa/utils/tensorflow/constants.py
+++ b/rasa/utils/tensorflow/constants.py
@@ -101,3 +101,10 @@ TOLERANCE = "tolerance"
 POSITIVE_SCORES_KEY = "positive_scores"
 
 NEGATIVE_SCORES_KEY = "negative_scores"
+
+RANKING_KEY = "ranking"
+QUERY_INTENT_KEY = "query_intent"
+SCORE_KEY = "score"
+THRESHOLD_KEY = "threshold"
+SEVERITY_KEY = "severity"
+NAME = "name"


### PR DESCRIPTION
**Proposed changes**:
- Refactors metadata attached to the prediction of the policy.
- Metadata looks like this now:

```
Metadata schema looks like this:

{
    "query_intent": <metadata of intent that was queried>,
    "ranking": <sorted list of metadata corresponding to all intents.
                Sorting is based on predicted similarities.>
}

Each metadata dictionary looks like this:

{
    "name": <name of intent>,
    "score": <predicted similarity score>,
    "threshold": <threshold used for intent>,
    "severity": <absolute difference between score and threshold>
}
```

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
