### PR TITLE
Use RASABOT_GITHUB_TOKEN to create issues in workflows

### DIFF
--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -519,7 +519,8 @@ jobs:
         if: steps.performance.outputs.is_dropped == 'true' && steps.issue-exists.outputs.result == 'false'
         uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293  # v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # do not use GITHUB_TOKEN here because it wouldn't trigger subsequent workflows
+          github-token: ${{ secrets.RASABOT_GITHUB_TOKEN }}
           script: |
             var issue = await github.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -38,7 +38,8 @@ jobs:
       uses: lazy-actions/gitrivy@6edf95fdc8b1fb841a974536316b209cd16f9000 # v3
       with:
         # Needs the token so it can create an issue once a vulnerability was found
-        token: ${{ secrets.GITHUB_TOKEN }}
+        # do not use GITHUB_TOKEN here because it wouldn't trigger subsequent workflows
+        token: ${{ secrets.RASABOT_GITHUB_TOKEN }}
         image: ${{ env.IMAGE_WITH_POETRY_LOCK }}
         ignore_unfixed: true
         issue_label: "tool:trivy,type:vulnerability"


### PR DESCRIPTION

**Proposed changes**:
- Use `RASABOT_GITHUB_TOKEN` to create issues in workflows so that subsequent workflows are triggered. (the behaviour is described [here](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token))


**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
