### PR TITLE
Update config.yml to eliminate UserWarnings on new projects

### DIFF
--- a/changelog/8945.improvement.md
+++ b/changelog/8945.improvement.md
@@ -1,0 +1,1 @@
+Set config.yml as source of truth for config settings, and update config settings to eliminate UserWarning messages.

--- a/rasa/cli/initial_project/config.yml
+++ b/rasa/cli/initial_project/config.yml
@@ -3,34 +3,37 @@
 language: en
 
 pipeline:
-# # No configuration for the NLU pipeline was provided. The following default pipeline was used to train your model.
-# # If you'd like to customize it, uncomment and adjust the pipeline.
+# # The following default pipeline was used to train your model.
 # # See https://rasa.com/docs/rasa/tuning-your-model for more information.
-#   - name: WhitespaceTokenizer
-#   - name: RegexFeaturizer
-#   - name: LexicalSyntacticFeaturizer
-#   - name: CountVectorsFeaturizer
-#   - name: CountVectorsFeaturizer
-#     analyzer: char_wb
-#     min_ngram: 1
-#     max_ngram: 4
-#   - name: DIETClassifier
-#     epochs: 100
-#   - name: EntitySynonymMapper
-#   - name: ResponseSelector
-#     epochs: 100
-#   - name: FallbackClassifier
-#     threshold: 0.3
-#     ambiguity_threshold: 0.1
+  - name: WhitespaceTokenizer
+  - name: RegexFeaturizer
+  - name: LexicalSyntacticFeaturizer
+  - name: CountVectorsFeaturizer
+  - name: CountVectorsFeaturizer
+    analyzer: char_wb
+    min_ngram: 1
+    max_ngram: 4
+  - name: DIETClassifier
+    model_confidence: linear_norm
+    constrain_similarities: True
+    epochs: 100
+  - name: EntitySynonymMapper
+  - name: ResponseSelector
+    model_confidence: linear_norm
+    constrain_similarities: True
+    epochs: 100
+  - name: FallbackClassifier
+    threshold: 0.3
+    ambiguity_threshold: 0.1
 
 # Configuration for Rasa Core.
 # https://rasa.com/docs/rasa/core/policies/
 policies:
-# # No configuration for policies was provided. The following default policies were used to train your model.
-# # If you'd like to customize them, uncomment and adjust the policies.
 # # See https://rasa.com/docs/rasa/policies for more information.
-#   - name: MemoizationPolicy
-#   - name: TEDPolicy
-#     max_history: 5
-#     epochs: 100
-#   - name: RulePolicy
+  - name: MemoizationPolicy
+  - name: TEDPolicy
+    model_confidence: linear_norm
+    constrain_similarities: True
+    max_history: 5
+    epochs: 100
+  - name: RulePolicy


### PR DESCRIPTION
This pull request is an attempt to address some of the issue describe in the more general bug described in #8975 , and this change is an attempt to directly address issue #8976

The current config.yml file that is created on `rasa init` has a few problems:

1.) The configurations are commented out, so you would have to go spelunking into the code and docs to find out what the actual configurations are for various bits.  Instead, the config.yml file should be live, and these should be the actual settings that are in operation for the pipeline.  This change will make `config.yml` the source of truth for configuration settings and I think it follows the [Rule of Least Surprise](https://homepage.cs.uri.edu/~thenry/resources/unix_art/ch11s01.html ) 

2.) The default config files 'out of the box' generate two UserWarnings: 

- The first one is the setting for "model_confidence" (set to softmax instead lf linear_norm).  
- After the fist UserWarning has been cleared, a second UserWarning is emitted, related to "constrain_similarities", which is set to False (somewhere, not in the config file...), so that  needs to be set to True to resolve this error.

This updated config.yml file allows the initial `rasa train` to run without any UserWarning messages, and makes all the settings live rather than commented out.

**Proposed changes**:
- Update the config.yml template file in `/rasa/cli/initial_project/config.yml` to 
- Uncomment all the settings
- Update settings to values that will not generate UserWarnings on a 'virgin' rasa init-ed project.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
