### PR TITLE
IntentTEDPolicy: Misc updates from QA

### DIFF
--- a/rasa/core/policies/intent_ted_policy.py
+++ b/rasa/core/policies/intent_ted_policy.py
@@ -101,6 +101,7 @@ from rasa.utils.tensorflow.model_data import (
 
 import rasa.utils.io as io_utils
 from rasa.core.exceptions import RasaCoreException
+from rasa.shared.utils.common import mark_as_experimental_feature
 
 if TYPE_CHECKING:
     from rasa.shared.nlu.training_data.features import Features
@@ -276,6 +277,8 @@ class IntentTEDPolicy(TEDPolicy):
         self.config[BILOU_FLAG] = False
         self.config[SIMILARITY_TYPE] = INNER
         self.config[LOSS_TYPE] = CROSS_ENTROPY
+
+        mark_as_experimental_feature("IntentTED Policy")
 
     @staticmethod
     def _standard_featurizer(max_history: Optional[int] = None) -> TrackerFeaturizer:

--- a/tests/core/policies/test_intent_ted_policy.py
+++ b/tests/core/policies/test_intent_ted_policy.py
@@ -687,8 +687,9 @@ class TestIntentTEDPolicy(TestTEDPolicy):
             tracker_without_action, default_domain, interpreter
         )
 
-        # If the weights didn't change then both trackers should result in same prediction.
-        # For `IntentTEDPolicy`, the real prediction is inside action metadata.
+        # If the weights didn't change then both trackers
+        # should result in same prediction. For `IntentTEDPolicy`, the real
+        # prediction is inside action metadata.
         assert (
             prediction_with_action.action_metadata
             == prediction_without_action.action_metadata

--- a/tests/core/policies/test_intent_ted_policy.py
+++ b/tests/core/policies/test_intent_ted_policy.py
@@ -604,6 +604,96 @@ class TestIntentTEDPolicy(TestTEDPolicy):
             "Skipping predictions for IntentTEDPolicy" in caplog.text
         ) == should_skip
 
+    @pytest.mark.parametrize(
+        "tracker_events_with_action, tracker_events_without_action",
+        [
+            (
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    ActionExecuted("action_unlikely_intent"),
+                    ActionExecuted("utter_greet"),
+                    UserUttered(text="sad", intent={"name": "thank_you"}),
+                ],
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    ActionExecuted("utter_greet"),
+                    UserUttered(text="sad", intent={"name": "thank_you"}),
+                ],
+            ),
+            (
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    EntitiesAdded(entities=[{"entity": "name", "value": "Peter"},]),
+                    ActionExecuted("action_unlikely_intent"),
+                    ActionExecuted("utter_greet"),
+                    UserUttered(text="sad", intent={"name": "thank_you"}),
+                ],
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    EntitiesAdded(entities=[{"entity": "name", "value": "Peter"},]),
+                    ActionExecuted("utter_greet"),
+                    UserUttered(text="sad", intent={"name": "thank_you"}),
+                ],
+            ),
+            (
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    ActionExecuted("action_unlikely_intent"),
+                    ActionExecuted("some_form"),
+                    ActiveLoop("some_form"),
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="default", intent={"name": "default"}),
+                    ActionExecuted("action_unlikely_intent"),
+                    UserUttered(text="sad", intent={"name": "thank_you"}),
+                ],
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    ActionExecuted("action_unlikely_intent"),
+                    ActionExecuted("some_form"),
+                    ActiveLoop("some_form"),
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="default", intent={"name": "default"}),
+                    UserUttered(text="sad", intent={"name": "thank_you"}),
+                ],
+            ),
+        ],
+    )
+    def test_ignore_action_unlikely_intent(
+        self,
+        trained_policy: IntentTEDPolicy,
+        default_domain: Domain,
+        tracker_events_with_action: List[Event],
+        tracker_events_without_action: List[Event],
+        tmp_path: Path,
+    ):
+        loaded_policy = self.persist_and_load_policy(trained_policy, tmp_path)
+        interpreter = RegexInterpreter()
+        tracker_with_action = DialogueStateTracker.from_events(
+            "test 1", evts=tracker_events_with_action
+        )
+        tracker_without_action = DialogueStateTracker.from_events(
+            "test 2", evts=tracker_events_without_action
+        )
+        prediction_with_action = loaded_policy.predict_action_probabilities(
+            tracker_with_action, default_domain, interpreter
+        )
+        prediction_without_action = loaded_policy.predict_action_probabilities(
+            tracker_without_action, default_domain, interpreter
+        )
+
+        # If the weights didn't change then both trackers should result in same prediction.
+        # For `IntentTEDPolicy`, the real prediction is inside action metadata.
+        assert (
+            prediction_with_action.action_metadata
+            == prediction_without_action.action_metadata
+        )
+
     def test_label_embedding_collection(self, trained_policy: IntentTEDPolicy):
         label_ids = tf.constant([[[2], [-1]], [[1], [2]], [[0], [-1]]], dtype=tf.int32)
 

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from typing import Text, List
+from typing import Text
 
 import pytest
 
-from rasa.core.policies.policy import PolicyPrediction
 from rasa.shared.constants import DEFAULT_NLU_FALLBACK_INTENT_NAME
 
 from rasa.core import training
@@ -37,13 +36,13 @@ from rasa.shared.core.events import (
     ActionExecutionRejected,
     LoopInterrupted,
     FollowupAction,
-    Event,
 )
 from rasa.shared.nlu.interpreter import RegexInterpreter
 from rasa.core.nlg import TemplatedNaturalLanguageGenerator
 from rasa.core.policies.rule_policy import RulePolicy, InvalidRule, RULES
 from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.shared.core.generator import TrackerWithCachedStates
+from tests.core.test_utils import assert_predicted_action
 
 UTTER_GREET_ACTION = "utter_greet"
 GREET_INTENT_NAME = "greet"
@@ -778,22 +777,6 @@ def test_faq_rule():
     )
 
     assert_predicted_action(prediction, domain, UTTER_GREET_ACTION)
-
-
-def assert_predicted_action(
-    prediction: PolicyPrediction,
-    domain: Domain,
-    expected_action_name: Text,
-    confidence: float = 1.0,
-    is_end_to_end_prediction: bool = False,
-    is_no_user_prediction: bool = False,
-) -> None:
-    assert prediction.max_confidence == confidence
-    index_of_predicted_action = prediction.max_confidence_index
-    prediction_action_name = domain.action_names_or_texts[index_of_predicted_action]
-    assert prediction_action_name == expected_action_name
-    assert prediction.is_end_to_end_prediction == is_end_to_end_prediction
-    assert prediction.is_no_user_prediction == is_no_user_prediction
 
 
 async def test_predict_form_action_if_in_form():

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -480,7 +480,8 @@ class TestTEDPolicy(PolicyTestCollection):
             tracker_without_action, default_domain, interpreter
         )
 
-        # If the weights didn't change then both trackers should result in same prediction.
+        # If the weights didn't change then both trackers
+        # should result in same prediction.
         assert (
             prediction_with_action.probabilities
             == prediction_without_action.probabilities

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -19,6 +19,9 @@ from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
     ActionExecuted,
     UserUttered,
+    Event,
+    EntitiesAdded,
+    ActiveLoop,
 )
 from rasa.shared.exceptions import RasaException, InvalidConfigException
 from rasa.utils.tensorflow.data_generator import RasaBatchDataGenerator
@@ -49,7 +52,6 @@ from rasa.shared.nlu.constants import ACTION_NAME
 from rasa.utils.tensorflow import model_data_utils
 from tests.core.test_policies import PolicyTestCollection
 from rasa.shared.constants import DEFAULT_SENDER_ID, DEFAULT_CORE_SUBDIRECTORY_NAME
-from rasa.shared.core.events import Event, EntitiesAdded, SlotSet, ActiveLoop
 
 UTTER_GREET_ACTION = "utter_greet"
 GREET_INTENT_NAME = "greet"

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -756,7 +756,8 @@ def test_rule_action_wins_over_action_unlikely_intent(
             UserUttered(text="goodbye", intent={"name": "goodbye"}),
         ],
     )
-    prediction = intent_ted_policy_moodbot_agent.policy_ensemble.probabilities_using_best_policy(
+    policy_ensemble = intent_ted_policy_moodbot_agent.policy_ensemble
+    prediction = policy_ensemble.probabilities_using_best_policy(
         tracker, domain, NaturalLanguageInterpreter()
     )
 
@@ -782,7 +783,8 @@ def test_ensemble_prevents_multiple_action_unlikely_intents(
         ],
     )
 
-    prediction = intent_ted_policy_moodbot_agent.policy_ensemble.probabilities_using_best_policy(
+    policy_ensemble = intent_ted_policy_moodbot_agent.policy_ensemble
+    prediction = policy_ensemble.probabilities_using_best_policy(
         tracker, domain, NaturalLanguageInterpreter()
     )
 

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from typing import List, Any, Text, Optional, Union
-
+from _pytest.monkeypatch import MonkeyPatch
 from _pytest.capture import CaptureFixture
 import pytest
 from _pytest.logging import LogCaptureFixture
 import logging
 import copy
+import numpy as np
 
 from rasa.core.exceptions import UnsupportedDialogueModelError
 from rasa.core.policies.memoization import MemoizationPolicy, AugmentedMemoizationPolicy
@@ -37,6 +38,26 @@ from rasa.shared.core.constants import (
     ACTION_RESTART_NAME,
     ACTION_DEFAULT_FALLBACK_NAME,
 )
+from rasa.core.agent import Agent
+from rasa.core.policies.intent_ted_policy import IntentTEDPolicy
+from tests.core.test_utils import assert_predicted_action
+
+
+def _action_unlikely_intent_for(intent_name: Text):
+    _original = IntentTEDPolicy.predict_action_probabilities
+
+    def predict_action_probabilities(
+        self, tracker, domain, interpreter, **kwargs,
+    ) -> PolicyPrediction:
+        latest_event = tracker.events[-1]
+        if (
+            isinstance(latest_event, UserUttered)
+            and latest_event.parse_data["intent"]["name"] == intent_name
+        ):
+            return PolicyPrediction.for_action_name(domain, "action_unlikely_intent")
+        return _original(self, tracker, domain, interpreter, **kwargs)
+
+    return predict_action_probabilities
 
 
 class WorkingPolicy(Policy):
@@ -711,4 +732,64 @@ def test_is_not_in_training_data(
     assert (
         SimplePolicyEnsemble.is_not_in_training_data(policy_name, confidence)
         == not_in_training_data
+    )
+
+
+def test_rule_action_wins_over_action_unlikely_intent(
+    monkeypatch: MonkeyPatch, tmp_path: Path, intent_ted_policy_moodbot_agent: Agent
+):
+    # The original training data consists of a rule for `goodbye` intent.
+    # We monkey-patch IntentTEDPolicy to always predict action_unlikely_intent
+    # if last user intent was goodbye. The predicted action from ensemble
+    # should be utter_goodbye and not action_unlikely_intent.
+    monkeypatch.setattr(
+        IntentTEDPolicy,
+        "predict_action_probabilities",
+        _action_unlikely_intent_for("goodbye"),
+    )
+
+    domain = Domain.load("data/test_moodbot/domain.yml")
+    tracker = DialogueStateTracker.from_events(
+        "rule triggering tracker",
+        evts=[
+            ActionExecuted(ACTION_LISTEN_NAME),
+            UserUttered(text="goodbye", intent={"name": "goodbye"}),
+        ],
+    )
+    prediction = intent_ted_policy_moodbot_agent.policy_ensemble.probabilities_using_best_policy(
+        tracker, domain, NaturalLanguageInterpreter()
+    )
+
+    assert_predicted_action(prediction, domain, "utter_goodbye")
+
+
+def test_ensemble_prevents_multiple_action_unlikely_intents(
+    monkeypatch: MonkeyPatch, tmp_path: Path, intent_ted_policy_moodbot_agent: Agent
+):
+    monkeypatch.setattr(
+        IntentTEDPolicy,
+        "predict_action_probabilities",
+        _action_unlikely_intent_for("greet"),
+    )
+
+    domain = Domain.load("data/test_moodbot/domain.yml")
+    tracker = DialogueStateTracker.from_events(
+        "rule triggering tracker",
+        evts=[
+            ActionExecuted(ACTION_LISTEN_NAME),
+            UserUttered(text="hello", intent={"name": "greet"}),
+            ActionExecuted("action_unlikely_intent"),
+        ],
+    )
+
+    prediction = intent_ted_policy_moodbot_agent.policy_ensemble.probabilities_using_best_policy(
+        tracker, domain, NaturalLanguageInterpreter()
+    )
+
+    # prediction cannot be action_unlikely_intent for sure because
+    # the last event is not of type UserUttered and that's the
+    # first condition for `IntentTEDPolicy` to make a prediction
+    assert (
+        domain.action_names_or_texts[np.argmax(prediction.probabilities)]
+        != "action_unlikely_intent"
     )

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -36,6 +36,7 @@ from rasa.shared.core.events import (
     ConversationPaused,
     Event,
     UserUttered,
+    EntitiesAdded,
 )
 from rasa.core.featurizers.single_state_featurizer import SingleStateFeaturizer
 from rasa.core.featurizers.tracker_featurizers import (
@@ -479,6 +480,62 @@ class TestMemoizationPolicy(PolicyTestCollection):
         for states in new_story_states:
             state_key = loaded_policy._create_feature_key(states)
             assert state_key in loaded_policy.lookup
+
+    @pytest.mark.parametrize(
+        "tracker_events_with_action, tracker_events_without_action",
+        [
+            (
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    ActionExecuted("action_unlikely_intent"),
+                ],
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                ],
+            ),
+            (
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    EntitiesAdded(entities=[{"entity": "name", "value": "Peter"},]),
+                    ActionExecuted("action_unlikely_intent"),
+                ],
+                [
+                    ActionExecuted("action_listen"),
+                    UserUttered(text="hello", intent={"name": "greet"}),
+                    EntitiesAdded(entities=[{"entity": "name", "value": "Peter"},]),
+                ],
+            ),
+        ],
+    )
+    def test_ignore_action_unlikely_intent(
+        self,
+        trained_policy: MemoizationPolicy,
+        default_domain: Domain,
+        tracker_events_with_action: List[Event],
+        tracker_events_without_action: List[Event],
+    ):
+        interpreter = RegexInterpreter()
+        tracker_with_action = DialogueStateTracker.from_events(
+            "test 1", evts=tracker_events_with_action
+        )
+        tracker_without_action = DialogueStateTracker.from_events(
+            "test 2", evts=tracker_events_without_action
+        )
+        prediction_with_action = trained_policy.predict_action_probabilities(
+            tracker_with_action, default_domain, interpreter
+        )
+        prediction_without_action = trained_policy.predict_action_probabilities(
+            tracker_without_action, default_domain, interpreter
+        )
+
+        # Memoization shouldn't be affected.
+        assert (
+            prediction_with_action.probabilities
+            == prediction_without_action.probabilities
+        )
 
 
 class TestAugmentedMemoizationPolicy(TestMemoizationPolicy):

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -11,6 +11,8 @@ import rasa.utils.io
 from rasa.constants import ENV_SANIC_WORKERS
 from rasa.core import utils
 from rasa.core.lock_store import LockStore, RedisLockStore, InMemoryLockStore
+from rasa.core.policies.policy import PolicyPrediction
+from rasa.shared.core.domain import Domain
 from rasa.utils.endpoints import EndpointConfig
 from tests.conftest import write_endpoint_config_to_yaml
 
@@ -189,3 +191,19 @@ def test_read_endpoints_from_wrong_path():
             available_endpoints.nlu,
         )
     )
+
+
+def assert_predicted_action(
+    prediction: PolicyPrediction,
+    domain: Domain,
+    expected_action_name: Text,
+    confidence: float = 1.0,
+    is_end_to_end_prediction: bool = False,
+    is_no_user_prediction: bool = False,
+) -> None:
+    assert prediction.max_confidence == confidence
+    index_of_predicted_action = prediction.max_confidence_index
+    prediction_action_name = domain.action_names_or_texts[index_of_predicted_action]
+    assert prediction_action_name == expected_action_name
+    assert prediction.is_end_to_end_prediction == is_end_to_end_prediction
+    assert prediction.is_no_user_prediction == is_no_user_prediction


### PR DESCRIPTION
**Proposed changes**:
- Add experimental label
- Integration test to check if `action_unlikely_intent` is ignored in all story based policies but is not ignored for RulePolicy.
- Integration test to check if ensemble prevents multiple predictions of `action_unlikely_intent`.
- Integration test to check to check that the ensemble does not pick `action_unlikely_intent` when rule is triggered.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
