### PR TITLE
Deprecate `linear_norm` as a possible value for `model_confidence`

### DIFF
--- a/changelog/9045.removal.md
+++ b/changelog/9045.removal.md
@@ -1,10 +1,10 @@
-Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source 3.0.0 .
+Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0` .
 
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
-parameter of machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
+parameter in machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
 Based on user feedback, we have identified multiple problems with this option and hence
 using `model_confidence=linear_norm` is now deprecated and
-will be removed in Rasa Open Source 3.0.0 . If you were using `model_confidence=linear_norm` for any of the mentioned components,
+will be removed in Rasa Open Source `3.0.0` . If you were using `model_confidence=linear_norm` for any of the mentioned components,
 it is recommended to revert it back to `model_confidence=softmax` and re-train the assistant. Post re-training,
 it is recommended to [tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks) as well.
 

--- a/changelog/9045.removal.md
+++ b/changelog/9045.removal.md
@@ -1,4 +1,4 @@
-Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0`.
+The option `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0`.
 
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
 parameter in machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
@@ -7,4 +7,3 @@ Therefore, `model_confidence=linear_norm` is now deprecated and
 will be removed in Rasa Open Source `3.0.0`. If you were using `model_confidence=linear_norm` for any of the mentioned components,
 we recommend to revert it back to `model_confidence=softmax` and re-train the assistant. After re-training,
 we also recommend to [re-tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks).
-

--- a/changelog/9045.removal.md
+++ b/changelog/9045.removal.md
@@ -1,0 +1,10 @@
+Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source 3.0.0 .
+
+Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
+parameter of machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
+Based on user feedback, we have identified multiple problems with this option and hence
+using `model_confidence=linear_norm` is now deprecated and
+will be removed in Rasa Open Source 3.0.0 . If you were using `model_confidence=linear_norm` for any of the mentioned components,
+it is recommended to revert it back to `model_confidence=softmax` and re-train the assistant. Post re-training,
+it is recommended to [tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks) as well.
+

--- a/changelog/9045.removal.md
+++ b/changelog/9045.removal.md
@@ -1,10 +1,10 @@
-Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0` .
+Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0`.
 
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
 parameter in machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
-Based on user feedback, we have identified multiple problems with this option and hence
-using `model_confidence=linear_norm` is now deprecated and
-will be removed in Rasa Open Source `3.0.0` . If you were using `model_confidence=linear_norm` for any of the mentioned components,
-it is recommended to revert it back to `model_confidence=softmax` and re-train the assistant. Post re-training,
-it is recommended to [tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks) as well.
+Based on user feedback, we have identified multiple problems with this option.
+Therefore, `model_confidence=linear_norm` is now deprecated and
+will be removed in Rasa Open Source `3.0.0`. If you were using `model_confidence=linear_norm` for any of the mentioned components,
+we recommend to revert it back to `model_confidence=softmax` and re-train the assistant. After re-training,
+we also recommend to [re-tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks).
 

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -1445,9 +1445,7 @@ Intent classifiers assign one of the intents defined in the domain file to incom
   * `model_confidence`:
     This parameter allows the user to configure how confidences are computed during inference. It can take two values:
     * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-    * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
-
-    Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to tune fallback thresholds for the [FallbackClassifier](./components.mdx#fallbackclassifier).
+    * `linear_norm` (deprecated): Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
 
 
 The above configuration parameters are the ones you should configure to fit your model to your data.
@@ -2717,9 +2715,7 @@ Selectors predict a bot response from a set of candidate responses.
   * `model_confidence`:
     This parameter allows the user to configure how confidences are computed during inference. It can take two values:
     * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-    * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
-
-    Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to tune fallback thresholds for the [FallbackClassifier](./components.mdx#fallbackclassifier).
+    * `linear_norm` (deprecated): Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
 
   The component can also be configured to train a response selector for a particular retrieval intent.
   The parameter `retrieval_intent` sets the name of the retrieval intent for which this response selector model is trained.

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -1442,11 +1442,6 @@ Intent classifiers assign one of the intents defined in the domain file to incom
     This helps in keeping similarities between input and negative labels to smaller values.
     This should help in better generalization of the model to real world test sets.
 
-  * `model_confidence`:
-    This parameter allows the user to configure how confidences are computed during inference. It can take two values:
-    * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-    * `linear_norm` (deprecated): Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
-
 
 The above configuration parameters are the ones you should configure to fit your model to your data.
 However, additional parameters exist that can be adapted.
@@ -2711,11 +2706,6 @@ Selectors predict a bot response from a set of candidate responses.
     This parameter when set to `True` applies a sigmoid cross entropy loss over all similarity terms.
     This helps in keeping similarities between input and negative labels to smaller values.
     This should help in better generalization of the model to real world test sets.
-
-  * `model_confidence`:
-    This parameter allows the user to configure how confidences are computed during inference. It can take two values:
-    * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-    * `linear_norm` (deprecated): Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
 
   The component can also be configured to train a response selector for a particular retrieval intent.
   The parameter `retrieval_intent` sets the name of the retrieval intent for which this response selector model is trained.

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -43,6 +43,16 @@ pipeline:
   - name: "CountVectorsFeaturizer"
 ```
 
+### Machine Learning Components
+
+Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
+parameter of machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
+Based on user feedback, we have identified multiple problems with this option and hence
+using `model_confidence=linear_norm` is now deprecated and
+will be removed in Rasa Open Source 3.0.0. If you were using `model_confidence=linear_norm` for any of the components,
+it is recommended to revert it back to `model_confidence=softmax` and re-train the assistant. Post re-training,
+it is recommended to tune the fallback thresholds as well.
+
 
 ## Rasa 2.5 to 2.6
 

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -45,17 +45,15 @@ pipeline:
 
 ### Machine Learning Components
 
-Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0` .
+Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0`.
 
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
 parameter in machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
-Based on user feedback, we have identified multiple problems with this option and hence
-using `model_confidence=linear_norm` is now deprecated and
-will be removed in Rasa Open Source `3.0.0` . If you were using `model_confidence=linear_norm`
-for any of the mentioned components, it is recommended to revert it back to `model_confidence=softmax`
-and re-train the assistant. Post re-training, it is recommended to
-[tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks) as well.
-
+Based on user feedback, we have identified multiple problems with this option.
+Therefore, `model_confidence=linear_norm` is now deprecated and
+will be removed in Rasa Open Source `3.0.0`. If you were using `model_confidence=linear_norm` for any of the mentioned components,
+we recommend to revert it back to `model_confidence=softmax` and re-train the assistant. After re-training,
+we also recommend to [re-tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks).
 
 ## Rasa 2.5 to 2.6
 

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -45,13 +45,13 @@ pipeline:
 
 ### Machine Learning Components
 
-Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source 3.0.0 .
+Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0` .
 
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
-parameter of machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
+parameter in machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
 Based on user feedback, we have identified multiple problems with this option and hence
 using `model_confidence=linear_norm` is now deprecated and
-will be removed in Rasa Open Source 3.0.0 . If you were using `model_confidence=linear_norm`
+will be removed in Rasa Open Source `3.0.0` . If you were using `model_confidence=linear_norm`
 for any of the mentioned components, it is recommended to revert it back to `model_confidence=softmax`
 and re-train the assistant. Post re-training, it is recommended to
 [tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks) as well.

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -45,7 +45,7 @@ pipeline:
 
 ### Machine Learning Components
 
-Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0`.
+The option `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source `3.0.0`.
 
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
 parameter in machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -45,13 +45,16 @@ pipeline:
 
 ### Machine Learning Components
 
+Setting `model_confidence=linear_norm` is deprecated and will be removed in Rasa Open Source 3.0.0 .
+
 Rasa Open Source `2.3.0` introduced `linear_norm` as a possible value for `model_confidence`
 parameter of machine learning components such as `DIETClassifier`, `ResponseSelector` and `TEDPolicy`.
 Based on user feedback, we have identified multiple problems with this option and hence
 using `model_confidence=linear_norm` is now deprecated and
-will be removed in Rasa Open Source 3.0.0. If you were using `model_confidence=linear_norm` for any of the components,
-it is recommended to revert it back to `model_confidence=softmax` and re-train the assistant. Post re-training,
-it is recommended to tune the fallback thresholds as well.
+will be removed in Rasa Open Source 3.0.0 . If you were using `model_confidence=linear_norm`
+for any of the mentioned components, it is recommended to revert it back to `model_confidence=softmax`
+and re-train the assistant. Post re-training, it is recommended to
+[tune the thresholds for fallback components](./fallback-handoff.mdx#fallbacks) as well.
 
 
 ## Rasa 2.5 to 2.6

--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -205,9 +205,7 @@ If you want to fine-tune your model, start by modifying the following parameters
 * `model_confidence`:
   This parameter allows the user to configure how confidences are computed during inference. It can take two values:
   * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-  * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
-
-  Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to [handle actions predicted with low confidence](./fallback-handoff.mdx#handling-low-action-confidence).
+  * `linear_norm` (deprecated): Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
 
 The above configuration parameters are the ones you should configure to fit your model to your data.
 However, additional parameters exist that can be adapted.

--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -202,10 +202,6 @@ If you want to fine-tune your model, start by modifying the following parameters
   This helps in keeping similarities between input and negative labels to smaller values.
   This should help in better generalization of the model to real world test sets.
 
-* `model_confidence`:
-  This parameter allows the user to configure how confidences are computed during inference. It can take two values:
-  * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-  * `linear_norm` (deprecated): Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
 
 The above configuration parameters are the ones you should configure to fit your model to your data.
 However, additional parameters exist that can be adapted.

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -594,7 +594,7 @@ def _check_confidence_setting(component_config: Dict[Text, Any]) -> None:
     if component_config[MODEL_CONFIDENCE] not in [SOFTMAX, LINEAR_NORM, AUTO]:
         raise InvalidConfigException(
             f"{MODEL_CONFIDENCE}={component_config[MODEL_CONFIDENCE]} is not a valid "
-            f"setting. Possible values: `{SOFTMAX}`, `{LINEAR_NORM}`."
+            f"setting. Possible values: `{SOFTMAX}`, `{LINEAR_NORM}`(deprecated)."
         )
     if component_config[MODEL_CONFIDENCE] == SOFTMAX:
         if component_config[LOSS_TYPE] not in [SOFTMAX, CROSS_ENTROPY]:
@@ -613,11 +613,11 @@ def _check_confidence_setting(component_config: Dict[Text, Any]) -> None:
             )
     if component_config[MODEL_CONFIDENCE] == LINEAR_NORM:
         rasa.shared.utils.io.raise_deprecation_warning(
-            f"{MODEL_CONFIDENCE} is set to `{LINEAR_NORM}`. This option was "
-            f"introduced in Rasa Open Source `2.3.0` but based on "
-            f"user feedback we have identified multiple problems with this "
-            f"option. Hence, `{MODEL_CONFIDENCE}={LINEAR_NORM}` is now deprecated "
-            f"and will be removed in Rasa Open Source 3.0.0. "
+            f"{MODEL_CONFIDENCE} is set to `{LINEAR_NORM}`. We "
+            f"introduced this option in Rasa Open Source 2.3.0, "
+            f"but have identified multiple problems with it based "
+            f"on user feedback. Therefore, `{MODEL_CONFIDENCE}={LINEAR_NORM}` "
+            f"is now deprecated and will be removed in Rasa Open Source `3.0.0`."
             f"Please use `{MODEL_CONFIDENCE}={SOFTMAX}` instead."
         )
 

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -582,16 +582,14 @@ def _check_confidence_setting(component_config: Dict[Text, Any]) -> None:
             f"change the order of predicted labels. "
             f"Since this is not ideal, using `{MODEL_CONFIDENCE}={COSINE}` has been "
             f"removed in versions post `2.3.3`. "
-            f"Please use either `{SOFTMAX}` or `{LINEAR_NORM}` as possible values."
+            f"Please use `{MODEL_CONFIDENCE}={SOFTMAX}` instead."
         )
     if component_config[MODEL_CONFIDENCE] == INNER:
         raise InvalidConfigException(
             f"{MODEL_CONFIDENCE}={INNER} is deprecated as it produces an unbounded "
             f"range of confidences which can break the logic of assistants in various "
             f"other places. "
-            f"Please use `{MODEL_CONFIDENCE}={LINEAR_NORM}` which will produce a "
-            f"linearly normalized version of dot product similarities with each value "
-            f"in the range `[0,1]`."
+            f"Please use `{MODEL_CONFIDENCE}={SOFTMAX}` instead. "
         )
     if component_config[MODEL_CONFIDENCE] not in [SOFTMAX, LINEAR_NORM, AUTO]:
         raise InvalidConfigException(
@@ -599,12 +597,6 @@ def _check_confidence_setting(component_config: Dict[Text, Any]) -> None:
             f"setting. Possible values: `{SOFTMAX}`, `{LINEAR_NORM}`."
         )
     if component_config[MODEL_CONFIDENCE] == SOFTMAX:
-        rasa.shared.utils.io.raise_warning(
-            f"{MODEL_CONFIDENCE} is set to `softmax`. It is recommended "
-            f"to try using `{MODEL_CONFIDENCE}={LINEAR_NORM}` to make it easier to "
-            f"tune fallback thresholds.",
-            category=UserWarning,
-        )
         if component_config[LOSS_TYPE] not in [SOFTMAX, CROSS_ENTROPY]:
             raise InvalidConfigException(
                 f"{LOSS_TYPE}={component_config[LOSS_TYPE]} and "
@@ -619,6 +611,15 @@ def _check_confidence_setting(component_config: Dict[Text, Any]) -> None:
                 f"combination. You can use {MODEL_CONFIDENCE}={SOFTMAX} "
                 f"only with {SIMILARITY_TYPE}={INNER}."
             )
+    if component_config[MODEL_CONFIDENCE] == LINEAR_NORM:
+        rasa.shared.utils.io.raise_deprecation_warning(
+            f"{MODEL_CONFIDENCE} is set to `{LINEAR_NORM}`. This option was "
+            f"introduced in Rasa Open Source `2.3.0` but based on "
+            f"user feedback we have identified multiple problems with this "
+            f"option. Hence, `{MODEL_CONFIDENCE}={LINEAR_NORM}` is now deprecated "
+            f"and will be removed in Rasa Open Source 3.0.0. "
+            f"Please use `{MODEL_CONFIDENCE}={SOFTMAX}` instead."
+        )
 
 
 def _check_loss_setting(component_config: Dict[Text, Any]) -> None:

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -3,6 +3,8 @@ from typing import Any, Dict
 import numpy as np
 import pytest
 from typing import Text
+from pytest import LogCaptureFixture
+import logging
 
 import rasa.utils.train_utils as train_utils
 from rasa.nlu.constants import NUMBER_OF_SUB_TOKENS
@@ -155,6 +157,14 @@ def test_update_confidence_type(
 ):
     component_config = train_utils.update_confidence_type(component_config)
     assert component_config[MODEL_CONFIDENCE] == model_confidence
+
+
+def test_warn_deprecated_model_confidences():
+
+    component_config = {MODEL_CONFIDENCE: LINEAR_NORM}
+
+    with pytest.warns(FutureWarning):
+        train_utils._check_confidence_setting(component_config)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -3,8 +3,6 @@ from typing import Any, Dict
 import numpy as np
 import pytest
 from typing import Text
-from pytest import LogCaptureFixture
-import logging
 
 import rasa.utils.train_utils as train_utils
 from rasa.nlu.constants import NUMBER_OF_SUB_TOKENS


### PR DESCRIPTION
**Proposed changes**:
- Deprecate `linear_norm` as a possible value for `model_confidence`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
