### PR TITLE
Add AWS CI to telemetry CI checks

### DIFF
--- a/changelog/8694.misc.md
+++ b/changelog/8694.misc.md
@@ -1,0 +1,1 @@
+Add AWS CodeBuild environment variables to `telemetry.py` check for CI pipelines.

--- a/rasa/telemetry.py
+++ b/rasa/telemetry.py
@@ -72,6 +72,9 @@ CI_ENVIRONMENT_TELL = [
     "JENKINS_URL",
     "TEAMCITY_VERSION",
     "TRAVIS",
+    "CODEBUILD_BUILD_ARN",
+    "CODEBUILD_BUILD_ID",
+    "CODEBUILD_BATCH_BUILD_IDENTIFIER",
 ]
 
 # If updating or creating a new event, remember to update


### PR DESCRIPTION
**Proposed changes**:
- As a result of findings for issue #8694, I added [AWS CI environment variables](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html) to the `telemetry` module to improve tracking of all CI pipelines.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [X] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
