### PR TITLE
remove deprecations from `Domain`

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1314,7 +1314,7 @@ https://github.com/RasaHQ/rasa/tree/main/changelog/ . -->
   Rasa Open Source will continue to be able to read and process old `form_validation`
   events.
 - [#6658](https://github.com/rasahq/rasa/issues/6658): `SklearnPolicy` was deprecated. `TEDPolicy` is the preferred machine-learning policy for dialogue models.
-- [#6809](https://github.com/rasahq/rasa/issues/6809): [Slots](domain.mdx#slots) of type [`unfeaturized`](domain.mdx#unfeaturized-slot) are
+- [#6809](https://github.com/rasahq/rasa/issues/6809): [Slots](domain.mdx#slots) of type `unfeaturized` are
   now deprecated and will be removed in Rasa Open Source 3.0. Instead you should use
   the property `influence_conversation: false` for every slot type as described in the
   [migration guide](migration-guide.mdx#unfeaturized-slots).

--- a/changelog/8868.removal.md
+++ b/changelog/8868.removal.md
@@ -1,2 +1,3 @@
 Follow through on deprecation warnings for the `Domain`. Most importantly this will
 enforce the schema of the [`forms` section](forms.mdx) in the domain file.
+This further includes the removal of the `UnfeaturizedSlot` type.

--- a/changelog/8868.removal.md
+++ b/changelog/8868.removal.md
@@ -1,0 +1,2 @@
+Follow through on deprecation warnings for the `Domain`. Most importantly this will
+enforce the schema of the [`forms` section](forms.mdx) in the domain file.

--- a/data/test_domains/default_with_slots.yml
+++ b/data/test_domains/default_with_slots.yml
@@ -33,6 +33,7 @@ responses:
 
 forms:
   some_form:
-    name:
-    - type: from_entity
-      entity: name
+    required_slots:
+      name:
+      - type: from_entity
+        entity: name

--- a/data/test_domains/form.yml
+++ b/data/test_domains/form.yml
@@ -28,4 +28,4 @@ responses:
     - text: should I continue?
 
 forms:
-  - some_form
+  some_form: {}

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -441,36 +441,6 @@ stories:
   - action: action_explain_table_limit
 ```
 
-#### Unfeaturized Slot
-
-:::caution deprecated
-The slot type `unfeaturized` is deprecated. Please use the property
-`influence_conversation` as described
-[here](domain.mdx#slots-and-conversation-behavior) or the slot type
-[`any`](domain.mdx#any-slot) instead.
-
-:::
-
-* **Type**
-
-  `unfeaturized`
-
-* **Use For**
-
-  Data you want to store which shouldn't influence the dialogue flow.
-
-* **Example**
-
-  ```yaml-rasa
-  slots:
-    internal_user_id:
-      type: unfeaturized
-  ```
-
-* **Description**
-
-  Slots of this type will never influence the conversation.
-
 ### Slot Auto-fill
 
 The slot will be set automatically if your NLU model picks up an entity, and your domain

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -897,7 +897,7 @@ response_selector_output.get("default")
 
 ### Unfeaturized Slots
 
-[Slots](domain.mdx#slots) of type [unfeaturized](domain.mdx#unfeaturized-slot) are
+[Slots](domain.mdx#slots) of type `unfeaturized` are
 deprecated and will be removed in version 3.0. To ignore slot values during
 a conversation, set the `influence_conversation` property of the slot to `false`.
 

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -701,7 +701,6 @@ class Domain:
         for form_name, form_data in forms.items():
             if form_data is not None and REQUIRED_SLOTS_KEY not in form_data:
                 forms[form_name] = {REQUIRED_SLOTS_KEY: form_data}
-        # dict with slot mappings
         return list(forms.keys()), forms, []
 
     def __hash__(self) -> int:

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -757,21 +757,6 @@ class Domain:
         return self.user_actions + self.form_names
 
     @rasa.shared.utils.common.lazy_property
-    def action_names(self) -> List[Text]:
-        """Returns action names or texts."""
-        # Raise `DeprecationWarning` instead of `FutureWarning` as we only want to
-        # notify developers about the deprecation (e.g. developers who are using the
-        # Python API or writing custom policies). End users can't change anything
-        # about this warning except making their developers change any custom code
-        # which calls this.
-        rasa.shared.utils.io.raise_warning(
-            f"{Domain.__name__}.{Domain.action_names.__name__} "
-            f"is deprecated and will be removed version 3.0.0.",
-            category=DeprecationWarning,
-        )
-        return self.action_names_or_texts
-
-    @rasa.shared.utils.common.lazy_property
     def num_actions(self) -> int:
         """Returns the number of available actions."""
         # noinspection PyTypeChecker
@@ -781,17 +766,6 @@ class Domain:
     def num_states(self) -> int:
         """Number of used input states for the action prediction."""
         return len(self.input_states)
-
-    @rasa.shared.utils.common.lazy_property
-    def retrieval_intent_templates(self) -> Dict[Text, List[Dict[Text, Any]]]:
-        """Return only the responses which are defined for retrieval intents."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            "The terminology 'template' is deprecated and replaced by "
-            "'response', call `retrieval_intent_responses` instead of "
-            "`retrieval_intent_templates`.",
-            docs=f"{DOCS_URL_MIGRATION_GUIDE}#rasa-23-to-rasa-24",
-        )
-        return self.retrieval_intent_responses
 
     @rasa.shared.utils.common.lazy_property
     def retrieval_intent_responses(self) -> Dict[Text, List[Dict[Text, Any]]]:
@@ -804,35 +778,6 @@ class Domain:
                 self.responses.items(),
             )
         )
-
-    @rasa.shared.utils.common.lazy_property
-    def templates(self) -> Dict[Text, List[Dict[Text, Any]]]:
-        """Temporary property before templates become completely deprecated."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            "The terminology 'template' is deprecated and replaced by 'response'. "
-            "Instead of using the `templates` property, "
-            "please use the `responses` property instead.",
-            docs=f"{DOCS_URL_MIGRATION_GUIDE}#rasa-23-to-rasa-24",
-        )
-        return self.responses
-
-    @staticmethod
-    def is_retrieval_intent_template(
-        response: Tuple[Text, List[Dict[Text, Any]]]
-    ) -> bool:
-        """Check if the response is for a retrieval intent.
-
-        These templates have a `/` symbol in their name. Use that to filter them from
-        the rest.
-        """
-        rasa.shared.utils.io.raise_deprecation_warning(
-            "The terminology 'template' is deprecated "
-            "and replaced by 'response', "
-            "call `is_retrieval_intent_response` "
-            "instead of `is_retrieval_intent_template`.",
-            docs=f"{DOCS_URL_MIGRATION_GUIDE}#rasa-23-to-rasa-24",
-        )
-        return rasa.shared.nlu.constants.RESPONSE_IDENTIFIER_DELIMITER in response[0]
 
     @staticmethod
     def is_retrieval_intent_response(
@@ -861,16 +806,6 @@ class Domain:
         for slot in [s for s in self.slots if isinstance(s, CategoricalSlot)]:
             slot.add_default_value()
 
-    def add_categorical_slot_default_value(self) -> None:
-        """See `_add_categorical_slot_default_value` for docstring."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            f"'{self.add_categorical_slot_default_value.__name__}' is deprecated and "
-            f"will be removed in Rasa Open Source 3.0.0. This method is now "
-            f"automatically called when the Domain is created which makes a manual "
-            f"call superfluous."
-        )
-        self._add_categorical_slot_default_value()
-
     def _add_requested_slot(self) -> None:
         """Add a slot called `requested_slot` to the list of slots.
 
@@ -886,16 +821,6 @@ class Domain:
                     influence_conversation=False,
                 )
             )
-
-    def add_requested_slot(self) -> None:
-        """See `_add_categorical_slot_default_value` for docstring."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            f"'{self.add_requested_slot.__name__}' is deprecated and "
-            f"will be removed in Rasa Open Source 3.0.0. This method is now "
-            f"automatically called when the Domain is created which makes a manual "
-            f"call superfluous."
-        )
-        self._add_requested_slot()
 
     def _add_knowledge_base_slots(self) -> None:
         """Add slots for the knowledge base action to slots.
@@ -924,16 +849,6 @@ class Domain:
             for slot in knowledge_base_slots:
                 if slot not in slot_names:
                     self.slots.append(TextSlot(slot, influence_conversation=False))
-
-    def add_knowledge_base_slots(self) -> None:
-        """See `_add_categorical_slot_default_value` for docstring."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            f"'{self.add_knowledge_base_slots.__name__}' is deprecated and "
-            f"will be removed in Rasa Open Source 3.0.0. This method is now "
-            f"automatically called when the Domain is created which makes a manual "
-            f"call superfluous."
-        )
-        self._add_knowledge_base_slots()
 
     def _add_session_metadata_slot(self) -> None:
         self.slots.append(
@@ -965,32 +880,6 @@ class Domain:
             f"action for this domain. "
             f"Available actions are: \n{action_names}"
         )
-
-    def random_template_for(self, utter_action: Text) -> Optional[Dict[Text, Any]]:
-        """Returns a random response for an action name.
-
-        Args:
-            utter_action: The name of the utter action.
-
-        Returns:
-            A response for an utter action.
-        """
-        import numpy as np
-
-        # Raise `DeprecationWarning` instead of `FutureWarning` as we only want to
-        # notify developers about the deprecation (e.g. developers who are using the
-        # Python API or writing custom policies). End users can't change anything
-        # about this warning except making their developers change any custom code
-        # which calls this.
-        rasa.shared.utils.io.raise_warning(
-            f"'{Domain.__name__}.{Domain.random_template_for.__class__}' "
-            f"is deprecated and will be removed version 3.0.0.",
-            category=DeprecationWarning,
-        )
-        if utter_action in self.responses:
-            return np.random.choice(self.responses[utter_action])
-        else:
-            return None
 
     # noinspection PyTypeChecker
     @rasa.shared.utils.common.lazy_property
@@ -1811,17 +1700,6 @@ class Domain:
                     incorrect_mappings,
                 )
             )
-
-    def check_missing_templates(self) -> None:
-        """Warn user of utterance names which have no specified response."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            "The terminology 'template' is deprecated "
-            "and replaced by 'response'. "
-            "Please use `check_missing_responses` "
-            "instead of `check_missing_templates`.",
-            docs=f"{DOCS_URL_MIGRATION_GUIDE}#rasa-23-to-rasa-24",
-        )
-        self.check_missing_responses()
 
     def check_missing_responses(self) -> None:
         """Warn user of utterance names which have no specified response."""

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -26,7 +26,6 @@ from rasa.shared.constants import (
     DOMAIN_SCHEMA_FILE,
     DOCS_URL_DOMAINS,
     DOCS_URL_FORMS,
-    DOCS_URL_MIGRATION_GUIDE,
     LATEST_TRAINING_DATA_FORMAT_VERSION,
     DOCS_URL_RESPONSES,
     REQUIRED_SLOTS_KEY,
@@ -684,15 +683,12 @@ class Domain:
 
     @staticmethod
     def _initialize_forms(
-        forms: Union[Dict[Text, Any], List[Text]]
+        forms: Dict[Text, Any]
     ) -> Tuple[List[Text], Dict[Text, Any], List[Text]]:
         """Retrieves the initial values for the Domain's form fields.
 
         Args:
-            forms: Form names (if forms are a list) or a form dictionary. Forms
-                provided in dictionary format have the form names as keys, and either
-                empty dictionaries as values, or objects containing
-                `SlotMapping`s.
+            forms: Parsed content of the `forms` section in the domain.
 
         Returns:
             The form names, a mapping of form names and slot mappings, and custom
@@ -702,35 +698,11 @@ class Domain:
             for it. This can e.g. be used to run the deprecated Rasa Open Source 1
             `FormAction` which is implemented in the Rasa SDK.
         """
-        if isinstance(forms, dict):
-            for form_name, form_data in forms.items():
-                if form_data is not None and REQUIRED_SLOTS_KEY not in form_data:
-                    forms[form_name] = {REQUIRED_SLOTS_KEY: form_data}
-            # dict with slot mappings
-            return list(forms.keys()), forms, []
-
-        if isinstance(forms, list) and (not forms or isinstance(forms[0], str)):
-            # list of form names (Rasa Open Source 1 format)
-            rasa.shared.utils.io.raise_warning(
-                "The `forms` section in the domain used the old Rasa Open Source 1 "
-                "list format to define forms. Rasa Open Source will be configured to "
-                "use the deprecated `FormAction` within the Rasa SDK. If you want to "
-                "use the new Rasa Open Source 2 `FormAction` adapt your `forms` "
-                "section as described in the documentation. Support for the "
-                "deprecated `FormAction` in the Rasa SDK will be removed in Rasa Open "
-                "Source 3.0.",
-                docs=rasa.shared.constants.DOCS_URL_FORMS,
-                category=FutureWarning,
-            )
-            return forms, {form_name: {} for form_name in forms}, forms
-
-        rasa.shared.utils.io.raise_warning(
-            f"The `forms` section in the domain needs to contain a dictionary. "
-            f"Instead found an object of type '{type(forms)}'.",
-            docs=DOCS_URL_FORMS,
-        )
-
-        return [], {}, []
+        for form_name, form_data in forms.items():
+            if form_data is not None and REQUIRED_SLOTS_KEY not in form_data:
+                forms[form_name] = {REQUIRED_SLOTS_KEY: form_data}
+        # dict with slot mappings
+        return list(forms.keys()), forms, []
 
     def __hash__(self) -> int:
         """Returns a unique hash for the domain."""
@@ -1838,16 +1810,6 @@ class SlotMapping(Enum):
 
 
 def _validate_slot_mappings(forms: Union[Dict, List]) -> None:
-    if isinstance(forms, list):
-        if not all(isinstance(form_name, str) for form_name in forms):
-            raise InvalidDomain(
-                f"If you use the deprecated list syntax for forms, "
-                f"all form names have to be strings. Please see "
-                f"{DOCS_URL_FORMS} for more information."
-            )
-
-        return
-
     if not isinstance(forms, dict):
         raise InvalidDomain("Forms have to be specified as dictionary.")
 
@@ -1871,17 +1833,7 @@ def _validate_slot_mappings(forms: Union[Dict, List]) -> None:
                 f"for more information."
             )
 
-        if REQUIRED_SLOTS_KEY in form_data:
-            slots = forms[form_name].get(REQUIRED_SLOTS_KEY)
-        else:
-            rasa.shared.utils.io.raise_deprecation_warning(
-                f"The definition of slot mappings in your form "
-                f"should always be preceded by the keyword `{REQUIRED_SLOTS_KEY}`. "
-                f"The lack of this keyword will be deprecated in "
-                f"Rasa Open Source 3.0.0. Please see {DOCS_URL_FORMS} "
-                f"for more information.",
-            )
-            slots = form_data
+        slots = forms[form_name].get(REQUIRED_SLOTS_KEY, {})
 
         if not isinstance(slots, Dict):
             raise InvalidDomain(

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -277,6 +277,8 @@ class ListSlot(Slot):
 
 
 class CategoricalSlot(Slot):
+    """Slot type which can be used to branch conversations based on its value."""
+
     type_name = "categorical"
 
     def __init__(

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -290,6 +290,7 @@ class CategoricalSlot(Slot):
         auto_fill: bool = True,
         influence_conversation: bool = True,
     ) -> None:
+        """Creates a `Categorical  Slot` (see parent class for detailed docstring)."""
         super().__init__(
             name, initial_value, value_reset_delay, auto_fill, influence_conversation
         )

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -276,58 +276,6 @@ class ListSlot(Slot):
         super(ListSlot, self.__class__).value.fset(self, value)
 
 
-class UnfeaturizedSlot(Slot):
-    """Deprecated slot type to represent slots which don't influence conversations."""
-
-    type_name = "unfeaturized"
-
-    def __init__(
-        self,
-        name: Text,
-        initial_value: Any = None,
-        value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
-        influence_conversation: bool = False,
-    ) -> None:
-        """Creates unfeaturized slot.
-
-        Args:
-            name: The name of the slot.
-            initial_value: Its initial value.
-            value_reset_delay: After how many turns the slot should be reset to the
-                initial_value. This is behavior is currently not implemented.
-            auto_fill: `True` if it should be auto-filled by entities with the same
-                name.
-            influence_conversation: `True` if it should be featurized. Only `False`
-                is allowed. Any other value will lead to a `InvalidSlotConfigError`.
-        """
-        if influence_conversation:
-            raise InvalidSlotConfigError(
-                f"An {UnfeaturizedSlot.__name__} cannot be featurized. "
-                f"Please use a different slot type for slot '{name}' instead. See the "
-                f"documentation for more information: {DOCS_URL_SLOTS}"
-            )
-
-        rasa.shared.utils.io.raise_warning(
-            f"{UnfeaturizedSlot.__name__} is deprecated "
-            f"and will be removed in Rasa Open Source "
-            f"3.0. Please change the type and configure the 'influence_conversation' "
-            f"flag for slot '{name}' instead.",
-            docs=DOCS_URL_SLOTS,
-            category=FutureWarning,
-        )
-
-        super().__init__(
-            name, initial_value, value_reset_delay, auto_fill, influence_conversation
-        )
-
-    def _as_feature(self) -> List[float]:
-        return []
-
-    def _feature_dimensionality(self) -> int:
-        return 0
-
-
 class CategoricalSlot(Slot):
     type_name = "categorical"
 

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -54,6 +54,8 @@ mapping:
             type: "map"
             required: False
             allowempty: True
+          ignored_intents:
+            type: any
   config:
     type: "map"
     allowempty: True

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -44,8 +44,16 @@ mapping:
     type: "map"
     allowempty: True
   forms:
-    type: "any"
+    type: "map"
     required: False
+    mapping:
+      regex;([A-Za-z]+):
+        type: "map"
+        mapping:
+          required_slots:
+            type: "map"
+            required: False
+            allowempty: True
   config:
     type: "map"
     allowempty: True

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -180,10 +180,11 @@ def test_validate_files_form_slots_not_matching(tmp_path: Path):
         version: "2.0"
         forms:
           name_form:
-             first_name:
-             - type: from_text
-             last_name:
-             - type: from_text
+            required_slots:
+              first_name:
+              - type: from_text
+              last_name:
+              - type: from_text
         slots:
              first_name:
                 type: text

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -84,7 +84,7 @@ async def test_activate_with_prefilled_slot():
             - type: from_text
     slots:
       {slot_name}:
-        type: unfeaturized
+        type: any
     """
     domain = Domain.from_yaml(domain)
     events = await action.run(
@@ -261,7 +261,7 @@ async def test_activate_and_immediate_deactivate():
               entity: {slot_name}
     slots:
       {slot_name}:
-        type: unfeaturized
+        type: any
     """
     domain = Domain.from_yaml(domain)
     events = await action.run(
@@ -340,7 +340,7 @@ async def test_action_rejection():
               entity: some_entity
     slots:
       {slot_to_fill}:
-        type: unfeaturized
+        type: any
     """
     domain = Domain.from_yaml(domain)
 
@@ -630,7 +630,7 @@ async def test_validate_slots_on_activation_with_other_action_after_user_utteran
     domain = f"""
     slots:
       {slot_name}:
-        type: unfeaturized
+        type: any
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
@@ -703,7 +703,7 @@ def test_temporary_tracker():
         version: "2.0"
         slots:
           {extra_slot}:
-            type: unfeaturized
+            type: any
         """
     )
 

--- a/tests/core/featurizers/test_single_state_featurizers.py
+++ b/tests/core/featurizers/test_single_state_featurizers.py
@@ -144,7 +144,7 @@ def test_single_state_featurizer_prepare_for_training():
         entities=["name"],
         slots=[Slot("name")],
         responses={},
-        forms=[],
+        forms={},
         action_names=["utter_greet", "action_check_weather"],
     )
 
@@ -515,7 +515,7 @@ def test_single_state_featurizer_uses_regex_interpreter(
     from rasa.core.agent import Agent
 
     domain = Domain(
-        intents=[], entities=[], slots=[], responses={}, forms=[], action_names=[],
+        intents=[], entities=[], slots=[], responses={}, forms={}, action_names=[],
     )
     f = SingleStateFeaturizer()
     # simulate that core was trained separately by passing

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -797,7 +797,7 @@ async def test_predict_form_action_if_in_form():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -842,7 +842,7 @@ async def test_predict_loop_action_if_in_loop_but_there_is_e2e_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {loop_name}: {{}}
         """
@@ -899,7 +899,7 @@ async def test_predict_form_action_if_multiple_turns():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1049,7 +1049,7 @@ async def test_predict_action_listen_after_form():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1096,7 +1096,7 @@ async def test_dont_predict_form_if_already_finished():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1147,7 +1147,7 @@ async def test_form_unhappy_path():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1192,7 +1192,7 @@ async def test_form_unhappy_path_from_general_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1250,7 +1250,7 @@ async def test_form_unhappy_path_from_in_form_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1326,7 +1326,7 @@ async def test_form_unhappy_path_from_story():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1401,7 +1401,7 @@ async def test_form_unhappy_path_no_validation_from_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1493,7 +1493,7 @@ async def test_form_unhappy_path_no_validation_from_story():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1563,7 +1563,7 @@ async def test_form_unhappy_path_without_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1608,7 +1608,7 @@ async def test_form_activation_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1648,7 +1648,7 @@ async def test_failing_form_activation_due_to_no_rule():
         - some-action
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1688,7 +1688,7 @@ def test_form_submit_rule():
         - {submit_action_name}
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -1742,9 +1742,9 @@ def test_immediate_submit():
         - {submit_action_name}
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
           {slot}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         entities:
@@ -2367,7 +2367,7 @@ def test_hide_rule_turn_with_loops():
         - {action_chitchat}
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
           {another_form_name}: {{}}
@@ -2465,7 +2465,7 @@ def test_do_not_hide_rule_turn_with_loops_in_stories():
         - {activate_form}
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """
@@ -2525,7 +2525,7 @@ def test_hide_rule_turn_with_loops_as_followup_action():
         - {UTTER_GREET_ACTION}
         slots:
           {REQUESTED_SLOT}:
-            type: unfeaturized
+            type: any
         forms:
           {form_name}: {{}}
         """

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -519,7 +519,7 @@ def test_incomplete_rules_due_to_loops():
         intents:
         - {GREET_INTENT_NAME}
         forms:
-          {some_form}:
+          {some_form}: {{}}
         """
     )
     policy = RulePolicy()
@@ -799,7 +799,7 @@ async def test_predict_form_action_if_in_form():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -844,7 +844,7 @@ async def test_predict_loop_action_if_in_loop_but_there_is_e2e_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {loop_name}:
+          {loop_name}: {{}}
         """
     )
     e2e_rule = TrackerWithCachedStates.from_events(
@@ -901,7 +901,7 @@ async def test_predict_form_action_if_multiple_turns():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1051,7 +1051,7 @@ async def test_predict_action_listen_after_form():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1098,7 +1098,7 @@ async def test_dont_predict_form_if_already_finished():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1149,7 +1149,7 @@ async def test_form_unhappy_path():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1194,7 +1194,7 @@ async def test_form_unhappy_path_from_general_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1252,7 +1252,7 @@ async def test_form_unhappy_path_from_in_form_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1328,7 +1328,7 @@ async def test_form_unhappy_path_from_story():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1403,7 +1403,7 @@ async def test_form_unhappy_path_no_validation_from_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1495,7 +1495,7 @@ async def test_form_unhappy_path_no_validation_from_story():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1565,7 +1565,7 @@ async def test_form_unhappy_path_without_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1610,7 +1610,7 @@ async def test_form_activation_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1650,7 +1650,7 @@ async def test_failing_form_activation_due_to_no_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1690,7 +1690,7 @@ def test_form_submit_rule():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -1746,7 +1746,7 @@ def test_immediate_submit():
           {slot}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         entities:
         - {entity}
         """
@@ -2369,8 +2369,8 @@ def test_hide_rule_turn_with_loops():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
-          {another_form_name}:
+          {form_name}: {{}}
+          {another_form_name}: {{}}
         """
     )
 
@@ -2467,7 +2467,7 @@ def test_do_not_hide_rule_turn_with_loops_in_stories():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 
@@ -2527,7 +2527,7 @@ def test_hide_rule_turn_with_loops_as_followup_action():
           {REQUESTED_SLOT}:
             type: unfeaturized
         forms:
-          {form_name}:
+          {form_name}: {{}}
         """
     )
 

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -24,7 +24,7 @@ from rasa.core.actions.action import (
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel, OutputChannel
 from rasa.core.nlg import NaturalLanguageGenerator
-from rasa.shared.constants import UTTER_PREFIX
+from rasa.shared.constants import UTTER_PREFIX, REQUIRED_SLOTS_KEY
 from rasa.shared.core.domain import (
     ActionNotFoundException,
     SessionConfig,
@@ -1046,15 +1046,15 @@ async def test_action_default_ask_rephrase(
 @pytest.mark.parametrize(
     "slot_mapping",
     [
-        """
-    my_slot:
-    - type:from_text
-    """,
-        "",
+        """my_slot:
+          - type: from_text
+        """,
+        "{}",
     ],
 )
 def test_get_form_action(slot_mapping: Text):
     form_action_name = "my_business_logic"
+
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
@@ -1062,31 +1062,14 @@ def test_get_form_action(slot_mapping: Text):
     - my_action
     forms:
       {form_action_name}:
-        {slot_mapping}
+        {REQUIRED_SLOTS_KEY}:
+          {slot_mapping}
     """
         )
     )
 
     actual = action.action_for_name_or_text(form_action_name, domain, None)
     assert isinstance(actual, FormAction)
-
-
-def test_get_form_action_with_rasa_open_source_1_forms():
-    form_action_name = "my_business_logic"
-    with pytest.warns(FutureWarning):
-        domain = Domain.from_yaml(
-            textwrap.dedent(
-                f"""
-        actions:
-        - my_action
-        forms:
-        - {form_action_name}
-        """
-            )
-        )
-
-    actual = action.action_for_name_or_text(form_action_name, domain, None)
-    assert isinstance(actual, RemoteAction)
 
 
 def test_overridden_form_action():
@@ -1098,7 +1081,7 @@ def test_overridden_form_action():
     - my_action
     - {form_action_name}
     forms:
-        {form_action_name}:
+        {form_action_name}: {{}}
     """
         )
     )

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -80,7 +80,7 @@ async def test_agent_train(trained_rasa_model: Text):
     assert loaded.domain.action_names_or_texts == domain.action_names_or_texts
     assert loaded.domain.intents == domain.intents
     assert loaded.domain.entities == domain.entities
-    assert loaded.domain.templates == domain.templates
+    assert loaded.domain.responses == domain.responses
     assert [s.name for s in loaded.domain.slots] == [s.name for s in domain.slots]
 
     # test policies

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -234,7 +234,7 @@ async def test_load_agent(trained_rasa_model: Text):
 def test_form_without_form_policy(policy_config: Dict[Text, List[Text]]):
     with pytest.raises(InvalidDomain) as execinfo:
         Agent(
-            domain=Domain.from_dict({"forms": ["restaurant_form"]}),
+            domain=Domain.from_dict({"forms": {"restaurant_form": {}}}),
             policies=PolicyEnsemble.from_dict(policy_config),
         )
     assert "neither added the 'RulePolicy' nor the 'FormPolicy'" in str(execinfo.value)
@@ -250,7 +250,7 @@ def test_form_without_form_policy(policy_config: Dict[Text, List[Text]]):
 def test_forms_with_suited_policy(policy_config: Dict[Text, List[Text]]):
     # Doesn't raise
     Agent(
-        domain=Domain.from_dict({"forms": ["restaurant_form"]}),
+        domain=Domain.from_dict({"forms": {"restaurant_form": {}}}),
         policies=PolicyEnsemble.from_dict(policy_config),
     )
 

--- a/tests/core/test_ensemble.py
+++ b/tests/core/test_ensemble.py
@@ -233,7 +233,7 @@ def test_fallback_mapping_restart():
 def test_mapping_wins_over_form(events: List[Event]):
     domain = """
     forms:
-    - test-form
+      test-form: {}
     """
     domain = Domain.from_yaml(domain)
     tracker = DialogueStateTracker.from_events("test", events, [])
@@ -279,7 +279,7 @@ def test_form_wins_over_everything_else(ensemble: SimplePolicyEnsemble):
     form_name = "test-form"
     domain = f"""
     forms:
-    - {form_name}
+      {form_name}: {{}}
     """
     domain = Domain.from_yaml(domain)
 

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1258,7 +1258,7 @@ def test_predict_next_action_with_hidden_rules():
         domain,
         tracker_store,
         lock_store,
-        TemplatedNaturalLanguageGenerator(domain.templates),
+        TemplatedNaturalLanguageGenerator(domain.responses),
     )
 
     tracker = DialogueStateTracker.from_events(

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -602,7 +602,7 @@ async def test_write_domain_to_file_with_form(tmp_path: Path):
         - utter_greet
         - utter_goodbye
         forms:
-          {form_name}:
+          {form_name}: {{}}
         intents:
         - greet
         """

--- a/tests/docs/test_docs_training_data.py
+++ b/tests/docs/test_docs_training_data.py
@@ -14,6 +14,13 @@ from rasa.shared.constants import DOMAIN_SCHEMA_FILE
 
 DOCS_BASE_DIR = Path("docs/")
 MDX_DOCS_FILES = list((DOCS_BASE_DIR / "docs").glob("**/*.mdx"))
+
+# Exclude the migration guide from this check as the migration guide might
+# contain training data which once was valid but is not valid anymore.
+# E.g. the migration guide for Rasa Open Source 2 defined a form schema which
+# is no longer valid since Rasa Open Source 3.
+MDX_DOCS_FILES.remove(Path("docs/docs/migration-guide.mdx"))
+
 # we're matching codeblocks with either `yaml-rasa` or `yml-rasa` types
 # we support title or no title (you'll get a nice error message if there is a title)
 TRAINING_DATA_CODEBLOCK_RE = re.compile(

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -194,19 +194,6 @@ def test_avoid_action_repetition(domain: Domain):
     assert len(domain.action_names_or_texts) == len(DEFAULT_ACTION_NAMES) + 1
 
 
-def test_responses():
-    domain_file = "data/test_moodbot/domain.yml"
-    domain = Domain.load(domain_file)
-    expected_response = {
-        "text": "Hey! How are you?",
-        "buttons": [
-            {"title": "great", "payload": "/mood_great"},
-            {"title": "super sad", "payload": "/mood_unhappy"},
-        ],
-    }
-    assert domain.random_template_for("utter_greet") == expected_response
-
-
 def test_custom_slot_type(tmpdir: Path):
     domain_path = str(tmpdir / "domain.yml")
     rasa.shared.utils.io.write_text_file(

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -782,6 +782,29 @@ def test_load_on_invalid_domain_duplicate_actions():
         Domain.load("data/test_domains/duplicate_actions.yml")
 
 
+def test_schema_error_with_forms_as_lists():
+    with pytest.raises(YamlException):
+        Domain.from_yaml(
+            """
+        version: '2.0'
+        forms: []
+        """
+        )
+
+
+def test_schema_error_with_forms_and_slots_but_without_required_slots_key():
+    with pytest.raises(YamlException):
+        Domain.from_yaml(
+            """
+        version: '2.0'
+        forms:
+          my_form:
+            cool_slot:
+            - type: from_text
+        """
+        )
+
+
 def test_load_on_invalid_domain_duplicate_responses():
     with pytest.raises(YamlSyntaxException):
         Domain.load("data/test_domains/duplicate_responses.yml")

--- a/tests/shared/core/test_slots.py
+++ b/tests/shared/core/test_slots.py
@@ -12,7 +12,6 @@ from rasa.shared.core.slots import (
     BooleanSlot,
     FloatSlot,
     ListSlot,
-    UnfeaturizedSlot,
     CategoricalSlot,
     bool_from_any,
     AnySlot,
@@ -214,27 +213,6 @@ class TestListSlot(SlotTestCollection):
         assert tracker.slots[slot.name].value == ["cat"]
 
 
-class TestUnfeaturizedSlot(SlotTestCollection):
-    def create_slot(self, influence_conversation: bool) -> Slot:
-        return UnfeaturizedSlot("test", influence_conversation=False)
-
-    @pytest.fixture(params=["there is nothing invalid, but we need to pass something"])
-    def invalid_value(self, request: SubRequest) -> Any:
-        return request.param
-
-    @pytest.fixture(params=[(None, []), ([23], []), (1, []), ("asd", [])])
-    def value_feature_pair(self, request: SubRequest) -> Tuple[Any, List[float]]:
-        return request.param
-
-    def test_exception_if_featurized(self):
-        with pytest.raises(InvalidSlotConfigError):
-            UnfeaturizedSlot("⛔️", influence_conversation=True)
-
-    def test_deprecation_warning(self):
-        with pytest.warns(FutureWarning):
-            self.create_slot(False)
-
-
 class TestCategoricalSlot(SlotTestCollection):
     def create_slot(self, influence_conversation: bool) -> Slot:
         return CategoricalSlot(
@@ -317,7 +295,7 @@ class TestAnySlot(SlotTestCollection):
 
     def test_exception_if_featurized(self):
         with pytest.raises(InvalidSlotConfigError):
-            UnfeaturizedSlot("⛔️", influence_conversation=True)
+            AnySlot("⛔️", influence_conversation=True)
 
 
 def test_raises_on_invalid_slot_type():

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -321,10 +321,11 @@ async def test_verify_form_slots_invalid_domain(tmp_path: Path):
         version: "2.0"
         forms:
           name_form:
-             first_name:
-             - type: from_text
-             last_name:
-             - type: from_text
+            required_slots:
+              first_name:
+              - type: from_text
+              last_name:
+              - type: from_text
         slots:
              first_name:
                 type: text
@@ -435,10 +436,11 @@ async def test_valid_form_slots_in_domain(tmp_path: Path):
         version: "2.0"
         forms:
           name_form:
-             first_name:
-             - type: from_text
-             last_name:
-             - type: from_text
+            required_slots:
+              first_name:
+              - type: from_text
+              last_name:
+              - type: from_text
         slots:
              first_name:
                 type: text


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/8868
- enforce `Domain` schema
- Exclude the migration guide from this check as the migration guide might contain training data which once was valid but is not valid anymore. E.g. the migration guide for Rasa Open Source 2 defined a form schema which is no longer valid since Rasa Open Source 3.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
