### PR TITLE
Remove deprecated `sorted_intent_examples` method from `TrainingData`

### DIFF
--- a/changelog/8872.removal.md
+++ b/changelog/8872.removal.md
@@ -1,0 +1,1 @@
+Remove deprecated `sorted_intent_examples` method from `TrainingData`

--- a/changelog/8872.removal.md
+++ b/changelog/8872.removal.md
@@ -1,1 +1,1 @@
-Remove deprecated `sorted_intent_examples` method from `TrainingData`
+Remove deprecated `sorted_intent_examples` method from `TrainingData`.

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -467,8 +467,8 @@ class TrainingData:
     def validate(self) -> None:
         """Ensures that the loaded training data is valid.
 
-        Checks that the data has a minimum of certain training examples."""
-
+        Checks that the data has a minimum of certain training examples.
+        """
         logger.debug("Validating training data...")
         if "" in self.intents:
             rasa.shared.utils.io.raise_warning(

--- a/rasa/shared/nlu/training_data/training_data.py
+++ b/rasa/shared/nlu/training_data/training_data.py
@@ -464,18 +464,6 @@ class TrainingData:
         ]
         return sorted(entity_examples, key=lambda e: e["entity"])
 
-    def sorted_intent_examples(self) -> List[Message]:
-        """Sorts the intent examples by the name of the intent and then response."""
-        rasa.shared.utils.io.raise_warning(
-            "`sorted_intent_examples` is deprecated and will be removed in Rasa "
-            "3.0.0.",
-            category=DeprecationWarning,
-        )
-        return sorted(
-            self.intent_examples,
-            key=lambda e: (e.get(INTENT), e.get(INTENT_RESPONSE_KEY)),
-        )
-
     def validate(self) -> None:
         """Ensures that the loaded training data is valid.
 


### PR DESCRIPTION
**Proposed changes**:
- fix #8872

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
