### PR TITLE
tag Maxime instead of enable-squad for docs dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       separator: "-"
     open-pull-requests-limit: 10
     reviewers:
-      - RasaHQ/enable-squad
+      - "m-vdb"
     labels:
       - type:dependencies
 


### PR DESCRIPTION
**Proposed changes**:
- tag Maxime instead of enable-squad for docs dependencies updates

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
