### PR TITLE
2.8.x: Remove experimental feature warning for story validation and entity roles and groups

### DIFF
--- a/changelog/8024.doc.md
+++ b/changelog/8024.doc.md
@@ -1,1 +1,2 @@
-The experimental feature warning for the story validation tool has been removed from the rasa docs.
+Removing the experimental feature warning for the `story validation` tool from the rasa docs. 
+The behaviour of the feature remains unchanged. 

--- a/changelog/8024.doc.md
+++ b/changelog/8024.doc.md
@@ -1,0 +1,1 @@
+The experimental feature warning for the story validation tool has been removed from the rasa docs.

--- a/changelog/8791.doc.md
+++ b/changelog/8791.doc.md
@@ -1,1 +1,3 @@
-The experimental feature warning for entity roles and groups has been removed from the rasa docs, and from the code where it used to appear as a print statement. 
+Removing the experimental feature warning for `entity roles and groups` from the rasa docs, 
+and from the code where it previously appeared as a print statement. 
+The behaviour of the feature remains otherwise unchanged. 

--- a/changelog/8791.doc.md
+++ b/changelog/8791.doc.md
@@ -1,0 +1,1 @@
+The experimental feature warning for entity roles and groups has been removed from the rasa docs, and from the code where it used to appear as a print statement. 

--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -408,13 +408,6 @@ To interrupt validation even for minor issues such as unused intents or response
 The `rasa data validate stories` command assumes that all your story names are unique!
 :::
 
-:::caution experimental feature
-The `rasa data validate stories` command is an experimental feature. We introduce experimental 
-features to get feedback from our community, so we encourage you to try it out! However, the functionality 
-might be changed or removed in the future. If you have feedback (positive or negative) please share 
-it with us on the [Rasa Forum](https://forum.rasa.com/).
-:::
-
 You can use `rasa data validate` with additional arguments, e.g. to specify the location of your data and 
 domain files:
 

--- a/docs/docs/nlu-training-data.mdx
+++ b/docs/docs/nlu-training-data.mdx
@@ -168,14 +168,6 @@ When using lookup tables with `RegexFeaturizer`, provide enough examples for the
 
 ## Entities Roles and Groups
 
-:::caution
-This feature is experimental.
-We introduce experimental features to get feedback from our community, so we encourage you to try it out!
-However, the functionality might be changed or removed in the future.
-If you have feedback (positive or negative) please share it with us on the [Rasa Forum](https://forum.rasa.com).
-
-:::
-
 Annotating words as custom entities allows you to define certain concepts in your training data.
 For example, you can identify cities by annotating them:
 

--- a/rasa/nlu/train.py
+++ b/rasa/nlu/train.py
@@ -108,10 +108,6 @@ async def train(
         training_data = load_data(data, nlu_config.language)
 
     training_data.print_stats()
-    if training_data.entity_roles_groups_used():
-        rasa.shared.utils.common.mark_as_experimental_feature(
-            "Entity Roles and Groups feature"
-        )
 
     interpreter = trainer.train(training_data, **kwargs)
 

--- a/rasa/nlu/train.py
+++ b/rasa/nlu/train.py
@@ -2,7 +2,6 @@ import logging
 import typing
 from typing import Any, Optional, Text, Tuple, Union, Dict
 
-import rasa.shared.utils.common
 from rasa.nlu import config, utils
 from rasa.nlu.components import ComponentBuilder
 from rasa.nlu.config import RasaNLUModelConfig


### PR DESCRIPTION
**Proposed changes**:

We are moving two features from experimental to fully integrated. This pull request removes the experimental feature warning messages from the **rasa docs** and the **code**. The behaviour of the features remains unchanged.  

1. **Entity roles and groups** (see: #8791). I removed the experimental feature warning from:
    - The rasa docs
    - The code, where it only appeared as a print statement
   
2. **Story validation tool** (see #8024). I removed the experimental feature warning from:
   - The rasa docs only (I could not find a warning in the code)
   
**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
