### PR TITLE
Skip checking intent is in domain for utterances with no intent.

### DIFF
--- a/changelog/7695.bugfix.md
+++ b/changelog/7695.bugfix.md
@@ -1,0 +1,1 @@
+Ignore checking that intent is in domain for E2E story utterances when running `rasa data validate`. Previously data validation would fail on E2E stories.

--- a/rasa/validator.py
+++ b/rasa/validator.py
@@ -118,7 +118,7 @@ class Validator:
             event.intent["name"]
             for story in self.story_graph.story_steps
             for event in story.events
-            if type(event) == UserUttered
+            if type(event) == UserUttered and event.intent_name is not None
         }
 
         for story_intent in stories_intents:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -8,6 +8,34 @@ from rasa.shared.importers.autoconfig import TrainingType
 from pathlib import Path
 
 
+async def test_verify_nlu_with_e2e_story(tmp_path: Path, nlu_data_path: Path):
+    print()
+    story_file_name = tmp_path / "stories.yml"
+    with open(story_file_name, "w") as file:
+        file.write(
+            """
+            stories:
+            - story: path 1
+              steps:
+              - user: |
+                  hello assistant! Can you help me today?
+              - action: utter_greet
+            - story: path 2
+              steps:
+              - intent: greet
+              - action: utter_greet
+            """
+        )
+    importer = RasaFileImporter(
+        config_file="data/test_moodbot/config.yml",
+        domain_path="data/test_moodbot/domain.yml",
+        training_data_paths=[story_file_name, nlu_data_path],
+        training_type=TrainingType.NLU,
+    )
+    validator = await Validator.from_importer(importer)
+    assert validator.verify_nlu()
+
+
 async def test_verify_intents_does_not_fail_on_valid_data(nlu_data_path: Text):
     importer = RasaFileImporter(
         domain_path="data/test_moodbot/domain.yml", training_data_paths=[nlu_data_path],


### PR DESCRIPTION
**Proposed changes**:
Skips checking that intent is in domain for E2E story utterances when running `rasa data validate`. This is a bug fix for [this on-point discussion](https://rasa-hq.slack.com/archives/C021ZTVSY77/p1628018843068000) targeting `2.7.x` but it could also be added to `main` for `3.0.x`.

**Status (please check what you already did)**:
- [X] added some tests for the functionality
- [ ] ~~updated the documentation~~
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
