### PR TITLE
implement graph schema validation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3016,6 +3016,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "typing-utils"
+version = "0.1.0"
+description = "utils to inspect Python type annotations"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
 name = "tzlocal"
 version = "2.1"
 description = "tzinfo object for the local timezone"
@@ -3174,7 +3185,7 @@ transformers = ["transformers"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.9"
-content-hash = "bb6e68ce4ef6e2f7a55d38f4c65ef4bc5a1d642b2046e6439843fdedb4ffcb13"
+content-hash = "316f8a93caf495f1e4d5969d73981bc3218557557282d67d8e71593441bae522"
 
 [metadata.files]
 absl-py = [
@@ -5186,6 +5197,10 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
     {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
     {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+]
+typing-utils = [
+    {file = "typing_utils-0.1.0-py3-none-any.whl", hash = "sha256:6bd26f3d38a5dd526ca3a59f0a451ccb59bcee9dc829c872dd6c0aae4ec8bbef"},
+    {file = "typing_utils-0.1.0.tar.gz", hash = "sha256:8ff6b6705414b82575ad5ae0925ac414a9650fb8c5718289b1327dec61252f65"},
 ]
 tzlocal = [
     {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ aio-pika = "^6.7.1"
 pyTelegramBotAPI = "^3.7.3"
 dask = "2021.7.2"
 typing-extensions = "^3.7.4"
+typing-utils = "^0.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.10.0"

--- a/rasa/engine/exceptions.py
+++ b/rasa/engine/exceptions.py
@@ -8,3 +8,7 @@ class GraphComponentException(Exception):
 
 class GraphSchemaException(Exception):
     """Represents errors when dealing with `GraphSchema`s."""
+
+
+class GraphSchemaValidationException(Exception):
+    """Indicates that the given graph schema is invalid."""

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -8,7 +8,12 @@ from dataclasses import dataclass, field
 import logging
 from typing import Any, Callable, Dict, List, Optional, Text, Type, Tuple
 
-from rasa.engine.exceptions import GraphComponentException, GraphSchemaException
+from typing_extensions import runtime_checkable, Protocol
+
+from rasa.engine.exceptions import (
+    GraphComponentException,
+    GraphSchemaException,
+)
 import rasa.shared.utils.common
 from rasa.engine.storage.resource import Resource
 
@@ -17,6 +22,15 @@ if typing.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class Fingerprintable(Protocol):
+    """Protocol which each node output has to implement in the train graph."""
+
+    def fingerprint(self) -> Text:
+        """Returns a unique stable fingerprint for itself."""
+        ...
 
 
 @dataclass
@@ -147,14 +161,16 @@ class GraphComponent(ABC):
         """
         return cls.create(config, model_storage, resource, execution_context)
 
-    def supported_languages(self) -> Optional[List[Text]]:
+    @staticmethod
+    def supported_languages() -> Optional[List[Text]]:
         """Determines which languages this component can work with.
 
         Returns: A list of supported languages, or `None` to signify all are supported.
         """
         return None
 
-    def required_packages(self) -> List[Text]:
+    @staticmethod
+    def required_packages() -> List[Text]:
         """Any extra python dependencies required for this component to run."""
         return []
 

--- a/rasa/engine/validation.py
+++ b/rasa/engine/validation.py
@@ -121,7 +121,7 @@ def _validate_required_packages(node: SchemaNode, node_name: Text) -> None:
 
 def _get_parameter_information(
     node_name: Text, uses: Type[GraphComponent], method_name: Text
-) -> Tuple[Dict[Text, ParameterInfo], Optional[Type]]:
+) -> Tuple[Dict[Text, ParameterInfo], TypeAnnotation]:
     fn = _get_fn(node_name, uses, method_name)
 
     type_hints = _get_type_hints(node_name, uses, fn)

--- a/rasa/engine/validation.py
+++ b/rasa/engine/validation.py
@@ -20,17 +20,20 @@ from rasa.engine.storage.resource import Resource
 from rasa.engine.storage.storage import ModelStorage
 
 
+TypeAnnotation = Union[TypeVar, Text, Type]
+
+
 @dataclasses.dataclass
 class ParameterInfo:
     """Stores metadata about a function parameter."""
 
-    type_annotation: Union[TypeVar, Text, Type]
+    type_annotation: TypeAnnotation
     # `True` if we have a parameter like `**kwargs`
     is_variable_length_keyword_arg: bool
     has_default: bool
 
 
-KEYWORDS_EXPECTED_TYPES: Dict[Text, Union[TypeVar, Text, Type]] = {
+KEYWORDS_EXPECTED_TYPES: Dict[Text, TypeAnnotation] = {
     "resource": Resource,
     "execution_context": ExecutionContext,
     "model_storage": ModelStorage,
@@ -146,7 +149,7 @@ def _get_parameter_information(
 
 def _get_type_hints(
     node_name: Text, uses: Type[GraphComponent], fn: Callable
-) -> Dict[Text, Union[TypeVar, Text, Type]]:
+) -> Dict[Text, TypeAnnotation]:
     try:
         return typing.get_type_hints(fn)
     except NameError as e:
@@ -183,7 +186,7 @@ def _validate_run_fn(
     node_name: Text,
     node: SchemaNode,
     run_fn_params: Dict[Text, ParameterInfo],
-    run_fn_return_type: Union[TypeVar, Text, Type],
+    run_fn_return_type: TypeAnnotation,
     is_train_graph: bool,
 ) -> None:
     _validate_types_of_reserved_keywords(run_fn_params, node_name, node, node.fn)
@@ -329,7 +332,7 @@ def _validate_parent_return_type(
     node: SchemaNode,
     parent_name: Text,
     parent: SchemaNode,
-    required_type: Union[TypeVar, Text, Type],
+    required_type: TypeAnnotation,
 ) -> None:
     _, parent_return_type = _get_parameter_information(
         parent_name, parent.uses, parent.fn

--- a/rasa/engine/validation.py
+++ b/rasa/engine/validation.py
@@ -1,0 +1,342 @@
+import inspect
+import logging
+import typing
+from typing import Optional, Callable, Text, Tuple, Dict, Type, Any, Set, Union, TypeVar
+
+import dataclasses
+
+import rasa.utils.common
+import typing_utils
+
+from rasa.engine.exceptions import GraphSchemaValidationException
+from rasa.engine.graph import (
+    GraphSchema,
+    GraphComponent,
+    SchemaNode,
+    Fingerprintable,
+    ExecutionContext,
+)
+from rasa.engine.storage.resource import Resource
+from rasa.engine.storage.storage import ModelStorage
+
+
+@dataclasses.dataclass
+class ParameterInfo:
+    """Stores metadata about a function parameter."""
+
+    type_annotation: Union[TypeVar, Text, Type]
+    # `True` if we have a parameter like `**kwargs`
+    is_variable_length_keyword_arg: bool
+    has_default: bool
+
+
+KEYWORDS_EXPECTED_TYPES: Dict[Text, Union[TypeVar, Text, Type]] = {
+    "resource": Resource,
+    "execution_context": ExecutionContext,
+    "model_storage": ModelStorage,
+    "config": Dict[Text, Any],
+}
+
+
+def validate(
+    schema: GraphSchema, language: Optional[Text], is_train_graph: bool
+) -> None:
+    """Validates a graph schema.
+
+    This tries to validate that the graph structure is correct (e.g. all nodes pass the
+    correct things into each other) as well as validates the individual graph
+    components.
+
+    Args:
+        schema: The schema which needs validating.
+        language: Used to validate if all components support the language the assistant
+            is used in. If the language is `None`, all components are assumed to be
+            compatible.
+        is_train_graph: Whether the graph is used for training.
+
+    Raises:
+        GraphSchemaValidationException: If the validation failed.
+    """
+    for node_name, node in schema.nodes.items():
+        _validate_interface_usage(node_name, node)
+        _validate_supported_languages(language, node, node_name)
+        _validate_required_packages(node, node_name)
+
+        run_fn_params, run_fn_return_type = _get_parameter_information(
+            node_name, node.uses, node.fn
+        )
+        _validate_run_fn(
+            node_name, node, run_fn_params, run_fn_return_type, is_train_graph
+        )
+
+        create_fn_params, _ = _get_parameter_information(
+            node_name, node.uses, node.constructor_name
+        )
+        _validate_constructor(node_name, node, create_fn_params)
+
+        _validate_needs(
+            node_name, node, schema, create_fn_params, run_fn_params,
+        )
+
+
+def _validate_interface_usage(node_name: Text, node: SchemaNode) -> None:
+    if not issubclass(node.uses, GraphComponent):
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' uses class '{node.uses.__name__}'. This class does "
+            f"not implement the '{GraphComponent.__name__}' interface and can "
+            f"hence not be used within the graph. Please use a different "
+            f"component or implement the '{GraphComponent}' interface for "
+            f"'{node.uses.__name__}'."
+        )
+
+
+def _validate_supported_languages(
+    language: Optional[Text], node: SchemaNode, node_name: Text
+) -> None:
+    supported_languages = node.uses.supported_languages()
+    if (
+        language
+        and supported_languages is not None
+        and language not in supported_languages
+    ):
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' does not support the currently specified "
+            f"language '{language}'."
+        )
+
+
+def _validate_required_packages(node: SchemaNode, node_name: Text) -> None:
+    missing_packages = rasa.utils.common.find_unavailable_packages(
+        node.uses.required_packages()
+    )
+    if missing_packages:
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' requires the following packages which are "
+            f"currently not installed: {', '.join(missing_packages)}."
+        )
+
+
+def _get_parameter_information(
+    node_name: Text, uses: Type[GraphComponent], method_name: Text
+) -> Tuple[Dict[Text, ParameterInfo], Optional[Type]]:
+    fn = _get_fn(node_name, uses, method_name)
+
+    type_hints = _get_type_hints(node_name, uses, fn)
+    return_type = type_hints.pop("return", inspect.Parameter.empty)
+
+    params = inspect.signature(fn).parameters
+
+    type_info = {}
+    for param_name, type_annotation in type_hints.items():
+        inspect_info = params[param_name]
+        if inspect_info.kind == inspect.Parameter.VAR_POSITIONAL:
+            # We always pass things using keywords so we can ignore the any variable
+            # length positional arguments
+            continue
+
+        type_info[param_name] = ParameterInfo(
+            type_annotation=type_annotation,
+            is_variable_length_keyword_arg=inspect_info.kind
+            == inspect.Parameter.VAR_KEYWORD,
+            has_default=inspect_info.default != inspect.Parameter.empty,
+        )
+
+    return type_info, return_type
+
+
+def _get_type_hints(
+    node_name: Text, uses: Type[GraphComponent], fn: Callable
+) -> Dict[Text, Union[TypeVar, Text, Type]]:
+    try:
+        return typing.get_type_hints(fn)
+    except NameError as e:
+        logging.debug(
+            f"Failed to retrieve type annotations for component "
+            f"'{uses.__name__}' due to error:\n{e}"
+        )
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' uses graph component '{uses.__name__}' which has "
+            f"type annotations in its method '{fn.__name__}' which failed to be "
+            f"retrieved. Please make sure remove any forward "
+            f"reference by removing the quotes around the type "
+            f"(e.g. 'def foo() -> \"int\"' becomes 'def foo() -> int'. and make sure "
+            f"all type annotations can be resolved during runtime. Note that you might "
+            f"need to do a 'from __future__ import annotations' to avoid forward "
+            f"references."
+        )
+
+
+def _get_fn(node_name: Text, uses: Type[GraphComponent], method_name: Text) -> Callable:
+    fn = getattr(uses, method_name, None)
+    if fn is None:
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' uses graph component '{uses.__name__}' which does not "
+            f"have the specified "
+            f"method '{method_name}'. Please make sure you're either using "
+            f"the right graph component or specifying a valid method "
+            f"for the 'fn' and 'constructor_name' options."
+        )
+    return fn
+
+
+def _validate_run_fn(
+    node_name: Text,
+    node: SchemaNode,
+    run_fn_params: Dict[Text, ParameterInfo],
+    run_fn_return_type: Union[TypeVar, Text, Type],
+    is_train_graph: bool,
+) -> None:
+    _validate_types_of_reserved_keywords(run_fn_params, node_name, node, node.fn)
+    _validate_run_fn_return_type(node_name, node, run_fn_return_type, is_train_graph)
+
+    for param_name in _required_args(run_fn_params):
+        if param_name not in node.needs:
+            raise GraphSchemaValidationException(
+                f"Node '{node_name}' uses a component '{node.uses.__name__}' which "
+                f"needs the param '{param_name}' to be provided to its method "
+                f"'{node.fn}'. Please make sure to specify the parameter in "
+                f"the node's 'needs' section."
+            )
+
+
+def _required_args(fn_params: Dict[Text, ParameterInfo]) -> Set[Text]:
+    keywords = set(KEYWORDS_EXPECTED_TYPES)
+    return {
+        param_name
+        for param_name, param in fn_params.items()
+        if not param.has_default
+        and not param.is_variable_length_keyword_arg
+        and param_name not in keywords
+    }
+
+
+def _validate_run_fn_return_type(
+    node_name: Text, node: SchemaNode, return_type: Type, is_training: bool
+) -> None:
+    if return_type == inspect.Parameter.empty:
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' uses a component '{node.uses.__name__}' whose "
+            f"method '{node.fn}' does not have a type annotation for "
+            f"its return value. Type annotations are required for all graph "
+            f"components to validate the graph's structure."
+        )
+
+    if is_training and not isinstance(return_type, Fingerprintable):
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' uses a component '{node.uses.__name__}' whose method "
+            f"'{node.fn}' does not return a fingerprintable "
+            f"output. This is required for caching. Please make sure you're "
+            f"using a return type which implements the "
+            f"'{Fingerprintable.__name__}' protocol."
+        )
+
+
+def _validate_types_of_reserved_keywords(
+    params: Dict[Text, ParameterInfo], node_name: Text, node: SchemaNode, fn_name: Text
+) -> None:
+    for param_name, param in params.items():
+        if param_name in KEYWORDS_EXPECTED_TYPES:
+            if not typing_utils.issubtype(
+                param.type_annotation, KEYWORDS_EXPECTED_TYPES[param_name]
+            ):
+                raise GraphSchemaValidationException(
+                    f"Node '{node_name}' uses a graph component "
+                    f"'{node.uses.__name__}' which has an incompatible type "
+                    f"'{param.type_annotation}' for the '{param_name}' parameter in "
+                    f"its '{fn_name}' method. Expected type "
+                    f"'{ KEYWORDS_EXPECTED_TYPES[param_name]}'."
+                )
+
+
+def _validate_constructor(
+    node_name: Text, node: SchemaNode, create_fn_params: Dict[Text, ParameterInfo],
+) -> None:
+    _validate_types_of_reserved_keywords(
+        create_fn_params, node_name, node, node.constructor_name
+    )
+
+    required_args = _required_args(create_fn_params)
+
+    if required_args and node.eager:
+        raise GraphSchemaValidationException(
+            f"Node '{node_name}' has a constructor which has required "
+            f"required parameters ('{', '.join(required_args)}'). "
+            f"Extra parameters can only supplied to be the constructor if the node "
+            f"is being run in lazy mode."
+        )
+
+    for param_name in _required_args(create_fn_params):
+        if not node.eager and param_name not in node.needs:
+            raise GraphSchemaValidationException(
+                f"Node '{node_name}' uses a component '{node.uses.__name__}' which "
+                f"needs the param '{param_name}' to be provided to its method "
+                f"'{node.constructor_name}'. Please make sure to specify the "
+                f"parameter in the node's 'needs' section."
+            )
+
+
+def _validate_needs(
+    node_name: Text,
+    node: SchemaNode,
+    graph: GraphSchema,
+    create_fn_params: Dict[Text, ParameterInfo],
+    run_fn_params: Dict[Text, ParameterInfo],
+) -> None:
+    available_args, has_kwargs = _get_available_args(
+        node, create_fn_params, run_fn_params
+    )
+
+    for param_name, parent_name in node.needs.items():
+        if not has_kwargs and param_name not in available_args:
+            raise GraphSchemaValidationException(
+                f"Node '{node_name}' is configured to retrieve a value for the "
+                f"param '{param_name}' by its parent node '{parent_name}' although "
+                f"its method '{node.fn}' does not accept a parameter with this "
+                f"name. Please make sure your node's 'needs' section is "
+                f"correctly specified."
+            )
+
+        parent = graph.nodes[parent_name]
+
+        required_type = available_args.get(param_name)
+        needs_passed_to_kwargs = has_kwargs and required_type is None
+
+        if not needs_passed_to_kwargs:
+            _validate_parent_return_type(
+                node_name, node, parent_name, parent, required_type.type_annotation
+            )
+
+
+def _get_available_args(
+    node: SchemaNode,
+    create_fn_params: Dict[Text, ParameterInfo],
+    run_fn_params: Dict[Text, ParameterInfo],
+) -> Tuple[Dict[Text, ParameterInfo], bool]:
+    has_kwargs = any(
+        param.is_variable_length_keyword_arg for param in run_fn_params.values()
+    )
+    available_args = run_fn_params.copy()
+    if node.eager is False:
+        has_kwargs = has_kwargs or any(
+            param.is_variable_length_keyword_arg for param in create_fn_params.values()
+        )
+        available_args.update(create_fn_params)
+    return available_args, has_kwargs
+
+
+def _validate_parent_return_type(
+    node_name: Text,
+    node: SchemaNode,
+    parent_name: Text,
+    parent: SchemaNode,
+    required_type: Union[TypeVar, Text, Type],
+) -> None:
+    _, parent_return_type = _get_parameter_information(
+        parent_name, parent.uses, parent.fn
+    )
+    if not typing_utils.issubtype(parent_return_type, required_type):
+        raise GraphSchemaValidationException(
+            f"Parent of node '{node_name}' returns type "
+            f"'{parent_return_type}' but type '{required_type}' "
+            f"was expected by component '{node.uses.__name__}'."
+        )

--- a/rasa/nlu/components.py
+++ b/rasa/nlu/components.py
@@ -15,32 +15,12 @@ from rasa.shared.exceptions import InvalidConfigException
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.shared.nlu.training_data.message import Message
 import rasa.shared.utils.io
+import rasa.utils.common
 
 if typing.TYPE_CHECKING:
     from rasa.nlu.model import Metadata
 
 logger = logging.getLogger(__name__)
-
-
-def find_unavailable_packages(package_names: List[Text]) -> Set[Text]:
-    """Tries to import all package names and returns the packages where it failed.
-
-    Args:
-        package_names: The package names to import.
-
-    Returns:
-        Package names that could not be imported.
-    """
-
-    import importlib
-
-    failed_imports = set()
-    for package in package_names:
-        try:
-            importlib.import_module(package)
-        except ImportError:
-            failed_imports.add(package)
-    return failed_imports
 
 
 def validate_requirements(component_names: List[Optional[Text]]) -> None:
@@ -68,7 +48,7 @@ def validate_requirements(component_names: List[Optional[Text]]) -> None:
                 "the component."
             )
         component_class = registry.get_component_class(component_name)
-        unavailable_packages = find_unavailable_packages(
+        unavailable_packages = rasa.utils.common.find_unavailable_packages(
             component_class.required_packages()
         )
         if unavailable_packages:

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -16,6 +16,7 @@ from typing import (
     TypeVar,
     Union,
     ContextManager,
+    Set,
 )
 
 import rasa.utils.io
@@ -375,3 +376,25 @@ def copy_directory(source: Path, destination: Path) -> None:
             shutil.copytree(item, destination / item.name)
         else:
             shutil.copy2(item, destination / item.name)
+
+
+def find_unavailable_packages(package_names: List[Text]) -> Set[Text]:
+    """Tries to import all package names and returns the packages where it failed.
+
+    Args:
+        package_names: The package names to import.
+
+    Returns:
+        Package names that could not be imported.
+    """
+
+    import importlib
+
+    failed_imports = set()
+    for package in package_names:
+        try:
+            importlib.import_module(package)
+        except ImportError:
+            failed_imports.add(package)
+
+    return failed_imports

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -387,7 +387,6 @@ def find_unavailable_packages(package_names: List[Text]) -> Set[Text]:
     Returns:
         Package names that could not be imported.
     """
-
     import importlib
 
     failed_imports = set()

--- a/tests/engine/test_validation.py
+++ b/tests/engine/test_validation.py
@@ -1,0 +1,535 @@
+from typing import Any, Dict, Text, Type, Optional, List
+
+import pytest
+
+from rasa.engine import validation
+from rasa.engine.exceptions import GraphSchemaValidationException
+from rasa.engine.graph import GraphComponent, ExecutionContext, GraphSchema, SchemaNode
+from rasa.engine.storage.resource import Resource
+from rasa.engine.storage.storage import ModelStorage
+from rasa.shared.core.domain import Domain
+from rasa.shared.nlu.training_data.training_data import TrainingData
+
+
+class TestComponentWithoutRun(GraphComponent):
+    @classmethod
+    def create(
+        cls,
+        config: Dict[Text, Any],
+        model_storage: ModelStorage,
+        resource: Resource,
+        execution_context: ExecutionContext,
+    ) -> GraphComponent:
+        return cls()
+
+
+class TestComponentWithRun(TestComponentWithoutRun):
+    def run(self) -> TrainingData:
+        pass
+
+
+def create_test_schema(
+    uses: Type,  # The unspecified type is on purpose to enable testing of invalid cases
+    constructor_name: Text = "create",
+    run_fn: Text = "run",
+    needs: Optional[Dict[Text, Text]] = None,
+    eager: bool = True,
+    parent: Optional[Type[GraphComponent]] = None,
+) -> GraphSchema:
+    parent_node = {}
+    if parent:
+        parent_node = {
+            "parent": SchemaNode(
+                needs={}, uses=parent, constructor_name="create", fn="run", config={}
+            )
+        }
+    # noinspection PyTypeChecker
+    return GraphSchema(
+        {
+            "my_node": SchemaNode(
+                needs=needs or {},
+                uses=uses,
+                eager=eager,
+                constructor_name=constructor_name,
+                fn=run_fn,
+                config={},
+            ),
+            **parent_node,
+        }
+    )
+
+
+def test_graph_component_is_no_graph_component():
+    class MyComponent:
+        def other(self) -> TrainingData:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="implement .+ interface"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_component_fn_does_not_exist():
+    schema = create_test_schema(uses=TestComponentWithRun, run_fn="some_fn")
+
+    with pytest.raises(
+        GraphSchemaValidationException, match="specified method 'some_fn'"
+    ):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_output_is_not_fingerprintable_int():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> int:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="fingerprintable"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_predict_graph_output_is_not_fingerprintable():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> int:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    validation.validate(schema, language=None, is_train_graph=False)
+
+
+def test_graph_output_is_not_fingerprintable_any():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> Any:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="fingerprintable"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_output_is_not_fingerprintable_None():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> None:
+            pass
+
+    schema = create_test_schema(uses=MyComponent,)
+
+    with pytest.raises(GraphSchemaValidationException, match="fingerprintable"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_with_forward_referenced_output_type():
+    class MyComponent(TestComponentWithoutRun):
+        # The non imported type annotation is on purpose so we can provoke a error in
+        # the test
+        def run(self) -> "UserUttered":  # noqa: F821
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="forward reference"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_output_missing_type_annotation():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self):
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(
+        GraphSchemaValidationException, match="does not have a type annotation"
+    ):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_with_fingerprintable_output():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> TrainingData:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+class MyTrainingData(TrainingData):
+    pass
+
+
+def test_graph_with_fingerprintable_output_subclass():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> MyTrainingData:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_constructor_missing():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self) -> TrainingData:
+            pass
+
+    schema = create_test_schema(uses=MyComponent, constructor_name="invalid")
+
+    with pytest.raises(
+        GraphSchemaValidationException, match="specified method 'invalid'"
+    ):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_constructor_config_wrong_type():
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def create(
+            cls,
+            config: Dict[int, int],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="incompatible type"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_constructor_resource_wrong_type():
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def create(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Dict,
+            execution_context: ExecutionContext,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="incompatible type"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_constructor_model_storage_wrong_type():
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def create(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: Any,
+            resource: Resource,
+            execution_context: ExecutionContext,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="incompatible type"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_graph_constructor_execution_context_wrong_type():
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def create(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: Any,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="incompatible type"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+@pytest.mark.parametrize(
+    "current_language, supported_languages",
+    [("de", ["en"]), ("en", ["zh", "fi"]), ("us", [])],
+)
+def test_graph_constructor_execution_not_supported_language(
+    current_language: Text, supported_languages: Optional[List[Text]]
+):
+    class MyComponent(TestComponentWithRun):
+        @staticmethod
+        def supported_languages() -> Optional[List[Text]]:
+            return supported_languages
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(
+        GraphSchemaValidationException, match="does not support .* language"
+    ):
+        validation.validate(schema, language=current_language, is_train_graph=False)
+
+
+@pytest.mark.parametrize(
+    "current_language, supported_languages",
+    [(None, None), ("en", ["zh", "en"]), ("zh", None), (None, ["en"])],
+)
+def test_graph_constructor_execution_supported_language(
+    current_language: Optional[Text], supported_languages: Optional[List[Text]]
+):
+    class MyComponent(TestComponentWithRun):
+        @staticmethod
+        def supported_languages() -> Optional[List[Text]]:
+            return supported_languages
+
+    schema = create_test_schema(uses=MyComponent)
+
+    validation.validate(schema, language=current_language, is_train_graph=False)
+
+
+@pytest.mark.parametrize(
+    "required_packages", [["pytorch"], ["tensorflow", "kubernetes"]]
+)
+def test_graph_missing_package_requirements(required_packages: List[Text]):
+    class MyComponent(TestComponentWithRun):
+        @staticmethod
+        def required_packages() -> List[Text]:
+            """Any extra python dependencies required for this component to run."""
+            return required_packages
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="not installed"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+@pytest.mark.parametrize("required_packages", [["tensorflow"], ["tensorflow", "numpy"]])
+def test_graph_satisfied_package_requirements(required_packages: List[Text]):
+    class MyComponent(TestComponentWithRun):
+        @staticmethod
+        def required_packages() -> List[Text]:
+            """Any extra python dependencies required for this component to run."""
+            return required_packages
+
+    schema = create_test_schema(uses=MyComponent)
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_run_param_not_satisfied():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, some_param: TrainingData) -> TrainingData:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    with pytest.raises(GraphSchemaValidationException, match="needs the param"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_run_param_satifisfied_due_to_default():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, some_param: TrainingData = TrainingData()) -> TrainingData:
+            pass
+
+    schema = create_test_schema(uses=MyComponent)
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_too_many_supplied_params():
+    schema = create_test_schema(
+        uses=TestComponentWithRun, needs={"some_param": "parent"}
+    )
+
+    with pytest.raises(
+        GraphSchemaValidationException, match="does not accept a parameter"
+    ):
+        validation.validate(
+            schema, language=None, is_train_graph=True,
+        )
+
+
+def test_too_many_supplied_params_but_kwargs():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, **kwargs: Any) -> TrainingData:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent, needs={"some_param": "parent"}, parent=TestComponentWithRun
+    )
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_run_fn_with_variable_length_positional_param():
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, *args: Any, some_param: TrainingData) -> TrainingData:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent, needs={"some_param": "parent"}, parent=TestComponentWithRun
+    )
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_matching_params_due_to_constructor():
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def load(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+            some_param: TrainingData,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent,
+        needs={"some_param": "parent"},
+        eager=False,
+        constructor_name="load",
+        parent=TestComponentWithRun,
+    )
+
+    validation.validate(
+        schema, language=None, is_train_graph=True,
+    )
+
+
+def test_matching_params_due_to_constructor_but_eager():
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def load(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+            some_param: TrainingData,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent,
+        needs={"some_param": "parent"},
+        eager=True,
+        constructor_name="load",
+    )
+
+    with pytest.raises(GraphSchemaValidationException, match="lazy mode"):
+        validation.validate(
+            schema, language=None, is_train_graph=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "eager, error_message", [(True, "lazy mode"), (False, "needs the param")]
+)
+def test_unsatisfied_constructor(eager: bool, error_message: Text):
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def load(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+            some_param: TrainingData,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(uses=MyComponent, eager=eager, constructor_name="load",)
+
+    with pytest.raises(GraphSchemaValidationException, match=error_message):
+        validation.validate(
+            schema, language=None, is_train_graph=True,
+        )
+
+
+def test_parent_supplying_wrong_type():
+    class MyUnreliableParent(TestComponentWithoutRun):
+        def run(self) -> Domain:
+            pass
+
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, training_data: TrainingData) -> TrainingData:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent, parent=MyUnreliableParent, needs={"training_data": "parent"},
+    )
+
+    with pytest.raises(GraphSchemaValidationException, match="type .* expected"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_parent_supplying_wrong_type_to_constructor():
+    class MyUnreliableParent(TestComponentWithoutRun):
+        def run(self) -> Domain:
+            pass
+
+    class MyComponent(TestComponentWithRun):
+        @classmethod
+        def load(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+            some_param: TrainingData,
+        ) -> GraphComponent:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent,
+        eager=False,
+        constructor_name="load",
+        parent=MyUnreliableParent,
+        needs={"some_param": "parent"},
+    )
+
+    with pytest.raises(GraphSchemaValidationException, match="type .* expected"):
+        validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_parent_supplying_subtype():
+    class Parent(TestComponentWithoutRun):
+        def run(self) -> MyTrainingData:
+            pass
+
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, training_data: TrainingData) -> TrainingData:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent, parent=Parent, needs={"training_data": "parent"},
+    )
+
+    validation.validate(schema, language=None, is_train_graph=True)
+
+
+def test_child_accepting_any_type_from_parent():
+    class Parent(TestComponentWithoutRun):
+        def run(self) -> MyTrainingData:
+            pass
+
+    class MyComponent(TestComponentWithoutRun):
+        def run(self, training_data: Any) -> TrainingData:
+            pass
+
+    schema = create_test_schema(
+        uses=MyComponent, parent=Parent, needs={"training_data": "parent"},
+    )
+
+    validation.validate(schema, language=None, is_train_graph=True)

--- a/tests/nlu/test_components.py
+++ b/tests/nlu/test_components.py
@@ -7,7 +7,7 @@ from rasa.nlu import registry
 import rasa.nlu.train
 import rasa.nlu.components
 import rasa.shared.nlu.training_data.loading
-from rasa.nlu.components import Component, ComponentBuilder, find_unavailable_packages
+from rasa.nlu.components import Component, ComponentBuilder
 from rasa.nlu.config import RasaNLUModelConfig
 from rasa.shared.exceptions import InvalidConfigException
 from rasa.nlu.model import Interpreter, Metadata, Trainer
@@ -43,13 +43,6 @@ def test_all_required_components_can_be_satisfied(component_class: Type[Componen
         f"There is no required components {missing_components} "
         f"for '{component_class.name}'."
     )
-
-
-def test_find_unavailable_packages():
-    unavailable = find_unavailable_packages(
-        ["my_made_up_package_name", "io", "foo_bar", "foo_bar"]
-    )
-    assert unavailable == {"my_made_up_package_name", "foo_bar"}
 
 
 def test_builder_create_by_module_path(

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import rasa.utils.common
-from rasa.utils.common import RepeatedLogFilter
+from rasa.utils.common import RepeatedLogFilter, find_unavailable_packages
 import tests.conftest
 
 
@@ -115,3 +115,10 @@ def test_copy_directory_with_non_empty_destination(tmp_path: Path):
 
     with pytest.raises(ValueError):
         rasa.utils.common.copy_directory(tmp_path, destination)
+
+
+def test_find_unavailable_packages():
+    unavailable = find_unavailable_packages(
+        ["my_made_up_package_name", "io", "foo_bar", "foo_bar"]
+    )
+    assert unavailable == {"my_made_up_package_name", "foo_bar"}


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/9181
- Add validation for graph schemas
  - [x] The run and constructor methods exist
  - [x] The run function for each GraphComponent has all its required parameters provided by its parents.
  - [x] The constructor function for any non-eager GraphComponent has all its required parameters provided by its parents.
  - [x] The return value type of a node matches the function argument type of its children.
  - [x] All reserved parameter names are of the correct type. e.g. `resource` is a `Resource`.
  - [x] All return values for training graph implement `GraphComponentTrainingOutput`
  - [x] All required packages for the GraphComponent are installed.
  - [x] The components all support the language.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
