### PR TITLE
Convert DIETClassifier to be a GraphComponent

### DIFF
--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -260,6 +260,7 @@ class ExecutionContext:
     model_id: Optional[Text] = None
     should_add_diagnostic_data: bool = False
     is_finetuning: bool = False
+    node_name: Optional[Text] = None
 
 
 class GraphNode:
@@ -322,7 +323,9 @@ class GraphNode:
         self._model_storage = model_storage
         self._existing_resource = resource
 
-        self._execution_context: ExecutionContext = execution_context
+        self._execution_context: ExecutionContext = dataclasses.replace(
+            execution_context, node_name=self._node_name
+        )
 
         self._hooks: List[GraphNodeHook] = hooks if hooks else []
 

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -260,6 +260,7 @@ class ExecutionContext:
     model_id: Optional[Text] = None
     should_add_diagnostic_data: bool = False
     is_finetuning: bool = False
+    # This is set by the `GraphNode` before it is passed to the `GraphComponent`.
     node_name: Optional[Text] = None
 
 

--- a/rasa/nlu/classifiers/_diet_classifier.py
+++ b/rasa/nlu/classifiers/_diet_classifier.py
@@ -1,9 +1,13 @@
-from __future__ import annotations
+# flake8: noqa
+# WARNING: This module will be dropped before Rasa Open Source 3.0 is released.
+#          Please don't do any changes in this module and rather adapt DIETClassifier2
+#          from the regular `rasa.nlu.classifiers.diet_classifier` module.
+#          This module is a workaround to defer breaking changes due to the architecture
+#          revamp in 3.0.
 import copy
 import logging
 from collections import defaultdict
 from pathlib import Path
-import typing
 
 import numpy as np
 import os
@@ -12,15 +16,14 @@ import tensorflow as tf
 
 from typing import Any, Dict, List, Optional, Text, Tuple, Union, Type
 
-from rasa.engine.graph import ExecutionContext, GraphComponent
-from rasa.engine.storage.resource import Resource
-from rasa.engine.storage.storage import ModelStorage
-from rasa.nlu.extractors.extractor import EntityExtractorMixin
 import rasa.shared.utils.io
 import rasa.utils.io as io_utils
 import rasa.nlu.utils.bilou_utils as bilou_utils
 from rasa.shared.constants import DIAGNOSTIC_DATA
-from rasa.nlu.extractors.extractor import EntityTagSpec
+from rasa.nlu.featurizers.featurizer import Featurizer
+from rasa.nlu.components import Component
+from rasa.nlu.classifiers.classifier import IntentClassifier
+from rasa.nlu.extractors.extractor import EntityExtractor, EntityTagSpec
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
 from rasa.utils import train_utils
 from rasa.utils.tensorflow import rasa_layers
@@ -32,7 +35,6 @@ from rasa.utils.tensorflow.model_data import (
 )
 from rasa.nlu.constants import TOKENS_NAMES
 from rasa.shared.nlu.constants import (
-    SPLIT_ENTITIES_BY_COMMA_DEFAULT_VALUE,
     TEXT,
     INTENT,
     INTENT_RESPONSE_KEY,
@@ -43,9 +45,11 @@ from rasa.shared.nlu.constants import (
     NO_ENTITY_TAG,
     SPLIT_ENTITIES_BY_COMMA,
 )
+from rasa.nlu.config import RasaNLUModelConfig
 from rasa.shared.exceptions import InvalidConfigException
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.shared.nlu.training_data.message import Message
+from rasa.nlu.model import Metadata
 from rasa.utils.tensorflow.constants import (
     LABEL,
     IDS,
@@ -103,11 +107,6 @@ from rasa.utils.tensorflow.constants import (
     SOFTMAX,
 )
 
-from rasa.nlu.classifiers._diet_classifier import DIETClassifier
-
-# This is a workaround around until we have all components migrated to `GraphComponent`.
-DIETClassifier = DIETClassifier
-
 logger = logging.getLogger(__name__)
 
 SPARSE = "sparse"
@@ -118,7 +117,7 @@ LABEL_SUB_KEY = IDS
 POSSIBLE_TAGS = [ENTITY_ATTRIBUTE_TYPE, ENTITY_ATTRIBUTE_ROLE, ENTITY_ATTRIBUTE_GROUP]
 
 
-class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
+class DIETClassifier(IntentClassifier, EntityExtractor):
     """A multi-task model for intent classification and entity extraction.
 
     DIET is Dual Intent and Entity Transformer.
@@ -131,139 +130,139 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
     similarities with negative samples.
     """
 
-    @staticmethod
-    def get_default_config() -> Dict[Text, Any]:
-        """The component's default config (see parent class for full docstring)."""
-        # please make sure to update the docs when changing a default parameter
-        return {
-            # ## Architecture of the used neural network
-            # Hidden layer sizes for layers before the embedding layers for user message
-            # and labels.
-            # The number of hidden layers is equal to the length of the corresponding
-            # list.
-            HIDDEN_LAYERS_SIZES: {TEXT: [], LABEL: []},
-            # Whether to share the hidden layer weights between user message and labels.
-            SHARE_HIDDEN_LAYERS: False,
-            # Number of units in transformer
-            TRANSFORMER_SIZE: 256,
-            # Number of transformer layers
-            NUM_TRANSFORMER_LAYERS: 2,
-            # Number of attention heads in transformer
-            NUM_HEADS: 4,
-            # If 'True' use key relative embeddings in attention
-            KEY_RELATIVE_ATTENTION: False,
-            # If 'True' use value relative embeddings in attention
-            VALUE_RELATIVE_ATTENTION: False,
-            # Max position for relative embeddings. Only in effect if key- or value
-            # relative attention are turned on
-            MAX_RELATIVE_POSITION: 5,
-            # Use a unidirectional or bidirectional encoder.
-            UNIDIRECTIONAL_ENCODER: False,
-            # ## Training parameters
-            # Initial and final batch sizes:
-            # Batch size will be linearly increased for each epoch.
-            BATCH_SIZES: [64, 256],
-            # Strategy used when creating batches.
-            # Can be either 'sequence' or 'balanced'.
-            BATCH_STRATEGY: BALANCED,
-            # Number of epochs to train
-            EPOCHS: 300,
-            # Set random seed to any 'int' to get reproducible results
-            RANDOM_SEED: None,
-            # Initial learning rate for the optimizer
-            LEARNING_RATE: 0.001,
-            # ## Parameters for embeddings
-            # Dimension size of embedding vectors
-            EMBEDDING_DIMENSION: 20,
-            # Dense dimension to use for sparse features.
-            DENSE_DIMENSION: {TEXT: 128, LABEL: 20},
-            # Default dimension to use for concatenating sequence and sentence features.
-            CONCAT_DIMENSION: {TEXT: 128, LABEL: 20},
-            # The number of incorrect labels. The algorithm will minimize
-            # their similarity to the user input during training.
-            NUM_NEG: 20,
-            # Type of similarity measure to use, either 'auto' or 'cosine' or 'inner'.
-            SIMILARITY_TYPE: AUTO,
-            # The type of the loss function, either 'cross_entropy' or 'margin'.
-            LOSS_TYPE: CROSS_ENTROPY,
-            # Number of top intents to normalize scores for. Applicable with
-            # loss type 'cross_entropy' and 'softmax' confidences. Set to 0
-            # to turn off normalization.
-            RANKING_LENGTH: 10,
-            # Indicates how similar the algorithm should try to make embedding vectors
-            # for correct labels.
-            # Should be 0.0 < ... < 1.0 for 'cosine' similarity type.
-            MAX_POS_SIM: 0.8,
-            # Maximum negative similarity for incorrect labels.
-            # Should be -1.0 < ... < 1.0 for 'cosine' similarity type.
-            MAX_NEG_SIM: -0.4,
-            # If 'True' the algorithm only minimizes maximum similarity over
-            # incorrect intent labels, used only if 'loss_type' is set to 'margin'.
-            USE_MAX_NEG_SIM: True,
-            # If 'True' scale loss inverse proportionally to the confidence
-            # of the correct prediction
-            SCALE_LOSS: False,
-            # ## Regularization parameters
-            # The scale of regularization
-            REGULARIZATION_CONSTANT: 0.002,
-            # The scale of how important is to minimize the maximum similarity
-            # between embeddings of different labels,
-            # used only if 'loss_type' is set to 'margin'.
-            NEGATIVE_MARGIN_SCALE: 0.8,
-            # Dropout rate for encoder
-            DROP_RATE: 0.2,
-            # Dropout rate for attention
-            DROP_RATE_ATTENTION: 0,
-            # Fraction of trainable weights in internal layers.
-            CONNECTION_DENSITY: 0.2,
-            # If 'True' apply dropout to sparse input tensors
-            SPARSE_INPUT_DROPOUT: True,
-            # If 'True' apply dropout to dense input tensors
-            DENSE_INPUT_DROPOUT: True,
-            # ## Evaluation parameters
-            # How often calculate validation accuracy.
-            # Small values may hurt performance.
-            EVAL_NUM_EPOCHS: 20,
-            # How many examples to use for hold out validation set
-            # Large values may hurt performance, e.g. model accuracy.
-            # Set to 0 for no validation.
-            EVAL_NUM_EXAMPLES: 0,
-            # ## Model config
-            # If 'True' intent classification is trained and intent predicted.
-            INTENT_CLASSIFICATION: True,
-            # If 'True' named entity recognition is trained and entities predicted.
-            ENTITY_RECOGNITION: True,
-            # If 'True' random tokens of the input message will be masked and the model
-            # should predict those tokens.
-            MASKED_LM: False,
-            # 'BILOU_flag' determines whether to use BILOU tagging or not.
-            # If set to 'True' labelling is more rigorous, however more
-            # examples per entity are required.
-            # Rule of thumb: you should have more than 100 examples per entity.
-            BILOU_FLAG: True,
-            # If you want to use tensorboard to visualize training and validation
-            # metrics, set this option to a valid output directory.
-            TENSORBOARD_LOG_DIR: None,
-            # Define when training metrics for tensorboard should be logged.
-            # Either after every epoch or for every training step.
-            # Valid values: 'epoch' and 'batch'
-            TENSORBOARD_LOG_LEVEL: "epoch",
-            # Perform model checkpointing
-            CHECKPOINT_MODEL: False,
-            # Specify what features to use as sequence and sentence features
-            # By default all features in the pipeline are used.
-            FEATURIZERS: [],
-            # Split entities by comma, this makes sense e.g. for a list of ingredients
-            # in a recipie, but it doesn't make sense for the parts of an address
-            SPLIT_ENTITIES_BY_COMMA: True,
-            # If 'True' applies sigmoid on all similarity terms and adds
-            # it to the loss function to ensure that similarity values are
-            # approximately bounded. Used inside softmax loss only.
-            CONSTRAIN_SIMILARITIES: False,
-            # Model confidence to be returned during inference. Possible values -
-            # 'softmax' and 'linear_norm'.
-            MODEL_CONFIDENCE: SOFTMAX,
-        }
+    @classmethod
+    def required_components(cls) -> List[Type[Component]]:
+        return [Featurizer]
+
+    # please make sure to update the docs when changing a default parameter
+    defaults = {
+        # ## Architecture of the used neural network
+        # Hidden layer sizes for layers before the embedding layers for user message
+        # and labels.
+        # The number of hidden layers is equal to the length of the corresponding list.
+        HIDDEN_LAYERS_SIZES: {TEXT: [], LABEL: []},
+        # Whether to share the hidden layer weights between user message and labels.
+        SHARE_HIDDEN_LAYERS: False,
+        # Number of units in transformer
+        TRANSFORMER_SIZE: 256,
+        # Number of transformer layers
+        NUM_TRANSFORMER_LAYERS: 2,
+        # Number of attention heads in transformer
+        NUM_HEADS: 4,
+        # If 'True' use key relative embeddings in attention
+        KEY_RELATIVE_ATTENTION: False,
+        # If 'True' use value relative embeddings in attention
+        VALUE_RELATIVE_ATTENTION: False,
+        # Max position for relative embeddings. Only in effect if key- or value relative
+        # attention are turned on
+        MAX_RELATIVE_POSITION: 5,
+        # Use a unidirectional or bidirectional encoder.
+        UNIDIRECTIONAL_ENCODER: False,
+        # ## Training parameters
+        # Initial and final batch sizes:
+        # Batch size will be linearly increased for each epoch.
+        BATCH_SIZES: [64, 256],
+        # Strategy used when creating batches.
+        # Can be either 'sequence' or 'balanced'.
+        BATCH_STRATEGY: BALANCED,
+        # Number of epochs to train
+        EPOCHS: 300,
+        # Set random seed to any 'int' to get reproducible results
+        RANDOM_SEED: None,
+        # Initial learning rate for the optimizer
+        LEARNING_RATE: 0.001,
+        # ## Parameters for embeddings
+        # Dimension size of embedding vectors
+        EMBEDDING_DIMENSION: 20,
+        # Dense dimension to use for sparse features.
+        DENSE_DIMENSION: {TEXT: 128, LABEL: 20},
+        # Default dimension to use for concatenating sequence and sentence features.
+        CONCAT_DIMENSION: {TEXT: 128, LABEL: 20},
+        # The number of incorrect labels. The algorithm will minimize
+        # their similarity to the user input during training.
+        NUM_NEG: 20,
+        # Type of similarity measure to use, either 'auto' or 'cosine' or 'inner'.
+        SIMILARITY_TYPE: AUTO,
+        # The type of the loss function, either 'cross_entropy' or 'margin'.
+        LOSS_TYPE: CROSS_ENTROPY,
+        # Number of top intents to normalize scores for. Applicable with
+        # loss type 'cross_entropy' and 'softmax' confidences. Set to 0
+        # to turn off normalization.
+        RANKING_LENGTH: 10,
+        # Indicates how similar the algorithm should try to make embedding vectors
+        # for correct labels.
+        # Should be 0.0 < ... < 1.0 for 'cosine' similarity type.
+        MAX_POS_SIM: 0.8,
+        # Maximum negative similarity for incorrect labels.
+        # Should be -1.0 < ... < 1.0 for 'cosine' similarity type.
+        MAX_NEG_SIM: -0.4,
+        # If 'True' the algorithm only minimizes maximum similarity over
+        # incorrect intent labels, used only if 'loss_type' is set to 'margin'.
+        USE_MAX_NEG_SIM: True,
+        # If 'True' scale loss inverse proportionally to the confidence
+        # of the correct prediction
+        SCALE_LOSS: False,
+        # ## Regularization parameters
+        # The scale of regularization
+        REGULARIZATION_CONSTANT: 0.002,
+        # The scale of how important is to minimize the maximum similarity
+        # between embeddings of different labels,
+        # used only if 'loss_type' is set to 'margin'.
+        NEGATIVE_MARGIN_SCALE: 0.8,
+        # Dropout rate for encoder
+        DROP_RATE: 0.2,
+        # Dropout rate for attention
+        DROP_RATE_ATTENTION: 0,
+        # Fraction of trainable weights in internal layers.
+        CONNECTION_DENSITY: 0.2,
+        # If 'True' apply dropout to sparse input tensors
+        SPARSE_INPUT_DROPOUT: True,
+        # If 'True' apply dropout to dense input tensors
+        DENSE_INPUT_DROPOUT: True,
+        # ## Evaluation parameters
+        # How often calculate validation accuracy.
+        # Small values may hurt performance.
+        EVAL_NUM_EPOCHS: 20,
+        # How many examples to use for hold out validation set
+        # Large values may hurt performance, e.g. model accuracy.
+        # Set to 0 for no validation.
+        EVAL_NUM_EXAMPLES: 0,
+        # ## Model config
+        # If 'True' intent classification is trained and intent predicted.
+        INTENT_CLASSIFICATION: True,
+        # If 'True' named entity recognition is trained and entities predicted.
+        ENTITY_RECOGNITION: True,
+        # If 'True' random tokens of the input message will be masked and the model
+        # should predict those tokens.
+        MASKED_LM: False,
+        # 'BILOU_flag' determines whether to use BILOU tagging or not.
+        # If set to 'True' labelling is more rigorous, however more
+        # examples per entity are required.
+        # Rule of thumb: you should have more than 100 examples per entity.
+        BILOU_FLAG: True,
+        # If you want to use tensorboard to visualize training and validation metrics,
+        # set this option to a valid output directory.
+        TENSORBOARD_LOG_DIR: None,
+        # Define when training metrics for tensorboard should be logged.
+        # Either after every epoch or for every training step.
+        # Valid values: 'epoch' and 'batch'
+        TENSORBOARD_LOG_LEVEL: "epoch",
+        # Perform model checkpointing
+        CHECKPOINT_MODEL: False,
+        # Specify what features to use as sequence and sentence features
+        # By default all features in the pipeline are used.
+        FEATURIZERS: [],
+        # Split entities by comma, this makes sense e.g. for a list of ingredients
+        # in a recipie, but it doesn't make sense for the parts of an address
+        SPLIT_ENTITIES_BY_COMMA: True,
+        # If 'True' applies sigmoid on all similarity terms and adds
+        # it to the loss function to ensure that similarity values are
+        # approximately bounded. Used inside softmax loss only.
+        CONSTRAIN_SIMILARITIES: False,
+        # Model confidence to be returned during inference. Possible values -
+        # 'softmax' and 'linear_norm'.
+        MODEL_CONFIDENCE: SOFTMAX,
+    }
 
     # init helpers
     def _check_masked_lm(self) -> None:
@@ -330,26 +329,21 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
 
     def __init__(
         self,
-        config: Dict[Text, Any],
-        model_storage: ModelStorage,
-        resource: Resource,
-        execution_context: ExecutionContext,
+        component_config: Optional[Dict[Text, Any]] = None,
         index_label_id_mapping: Optional[Dict[int, Text]] = None,
         entity_tag_specs: Optional[List[EntityTagSpec]] = None,
         model: Optional[RasaModel] = None,
+        finetune_mode: bool = False,
         sparse_feature_sizes: Optional[Dict[Text, Dict[Text, List[int]]]] = None,
     ) -> None:
         """Declare instance variables with default values."""
-        if EPOCHS not in config:
+        if component_config is not None and EPOCHS not in component_config:
             rasa.shared.utils.io.raise_warning(
                 f"Please configure the number of '{EPOCHS}' in your configuration file."
                 f" We will change the default value of '{EPOCHS}' in the future to 1. "
             )
 
-        self.component_config: Dict[Text, Any] = config
-        self._model_storage = model_storage
-        self._resource = resource
-        self._execution_context = execution_context
+        super().__init__(component_config)
 
         self._check_config_parameters()
 
@@ -367,12 +361,9 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
         self._label_data: Optional[RasaModelData] = None
         self._data_example: Optional[Dict[Text, Dict[Text, List[FeatureArray]]]] = None
 
-        self.split_entities_config = rasa.utils.train_utils.init_split_entities(
-            self.component_config[SPLIT_ENTITIES_BY_COMMA],
-            SPLIT_ENTITIES_BY_COMMA_DEFAULT_VALUE,
-        )
+        self.split_entities_config = self.init_split_entities()
 
-        self.finetune_mode = self._execution_context.is_finetuning
+        self.finetune_mode = finetune_mode
         self._sparse_feature_sizes = sparse_feature_sizes
 
         if not self.model and self.finetune_mode:
@@ -383,17 +374,6 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
                 f"needs an already instantiated and trained model "
                 f"to continue training in finetune mode."
             )
-
-    @classmethod
-    def create(
-        cls,
-        config: Dict[Text, Any],
-        model_storage: ModelStorage,
-        resource: Resource,
-        execution_context: ExecutionContext,
-    ) -> DIETClassifierGraphComponent:
-        """Creates a new untrained component (see parent class for full docstring)."""
-        return cls(config, model_storage, resource, execution_context)
 
     @property
     def label_key(self) -> Optional[Text]:
@@ -847,7 +827,12 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
     def _check_enough_labels(model_data: RasaModelData) -> bool:
         return len(np.unique(model_data.get(LABEL_KEY, LABEL_SUB_KEY))) >= 2
 
-    def train(self, training_data: TrainingData) -> Resource:
+    def train(
+        self,
+        training_data: TrainingData,
+        config: Optional[RasaNLUModelConfig] = None,
+        **kwargs: Any,
+    ) -> None:
         """Train the embedding intent classifier on a data set."""
         model_data = self.preprocess_train_data(training_data)
         if model_data.is_empty():
@@ -855,7 +840,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
                 f"Cannot train '{self.__class__.__name__}'. No data was provided. "
                 f"Skipping training of the classifier."
             )
-            return self._resource
+            return
         if self.component_config.get(INTENT_CLASSIFICATION):
             if not self._check_enough_labels(model_data):
                 logger.error(
@@ -863,7 +848,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
                     f"Need at least 2 different intent classes. "
                     f"Skipping training of classifier."
                 )
-                return self._resource
+                return
         if self.component_config.get(ENTITY_RECOGNITION):
             self.check_correct_entity_annotations(training_data)
 
@@ -908,10 +893,6 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             verbose=False,
             shuffle=False,  # we use custom shuffle inside data generator
         )
-
-        self.persist()
-
-        return self._resource
 
     # process helpers
     def _predict(
@@ -1009,139 +990,150 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
 
         return entities
 
-    def process(self, messages: List[Message]) -> List[Message]:
+    def process(self, message: Message, **kwargs: Any) -> None:
         """Augments the message with intents, entities, and diagnostic data."""
-        for message in messages:
-            out = self._predict(message)
+        out = self._predict(message)
 
-            if self.component_config[INTENT_CLASSIFICATION]:
-                label, label_ranking = self._predict_label(out)
+        if self.component_config[INTENT_CLASSIFICATION]:
+            label, label_ranking = self._predict_label(out)
 
-                message.set(INTENT, label, add_to_output=True)
-                message.set("intent_ranking", label_ranking, add_to_output=True)
+            message.set(INTENT, label, add_to_output=True)
+            message.set("intent_ranking", label_ranking, add_to_output=True)
 
-            if self.component_config[ENTITY_RECOGNITION]:
-                entities = self._predict_entities(out, message)
+        if self.component_config[ENTITY_RECOGNITION]:
+            entities = self._predict_entities(out, message)
 
-                message.set(ENTITIES, entities, add_to_output=True)
+            message.set(ENTITIES, entities, add_to_output=True)
 
-            if out and self._execution_context.should_add_diagnostic_data:
-                # TODO: JUZL: use node name
-                message.add_diagnostic_data(
-                    self.__class__.__name__, out.get(DIAGNOSTIC_DATA)
-                )
+        if out and DIAGNOSTIC_DATA in out:
+            message.add_diagnostic_data(self.unique_name, out.get(DIAGNOSTIC_DATA))
 
-        return messages
+    def persist(self, file_name: Text, model_dir: Text) -> Dict[Text, Any]:
+        """Persist this model into the passed directory.
 
-    def persist(self) -> None:
-        """Persist this model into the passed directory."""
+        Return the metadata necessary to load the model again.
+        """
         import shutil
 
         if self.model is None:
-            return None
+            return {"file": None}
 
-        with self._model_storage.write_to(self._resource) as model_path:
-            file_name = self.__class__.__name__
-            tf_model_file = model_path / f"{file_name}.tf_model"
+        model_dir_path = Path(model_dir)
+        tf_model_file = model_dir_path / f"{file_name}.tf_model"
 
-            rasa.shared.utils.io.create_directory_for_file(tf_model_file)
+        rasa.shared.utils.io.create_directory_for_file(tf_model_file)
 
-            if self.component_config[CHECKPOINT_MODEL]:
-                shutil.move(self.tmp_checkpoint_dir, model_path / "checkpoints")
-            self.model.save(str(tf_model_file))
+        if self.component_config[CHECKPOINT_MODEL]:
+            shutil.move(self.tmp_checkpoint_dir, model_dir_path / "checkpoints")
+        self.model.save(str(tf_model_file))
 
-            io_utils.pickle_dump(
-                model_path / f"{file_name}.data_example.pkl", self._data_example
-            )
-            io_utils.pickle_dump(
-                model_path / f"{file_name}.sparse_feature_sizes.pkl",
-                self._sparse_feature_sizes,
-            )
-            io_utils.pickle_dump(
-                model_path / f"{file_name}.label_data.pkl", dict(self._label_data.data)
-            )
-            io_utils.json_pickle(
-                model_path / f"{file_name}.index_label_id_mapping.json",
-                self.index_label_id_mapping,
-            )
+        io_utils.pickle_dump(
+            model_dir_path / f"{file_name}.data_example.pkl", self._data_example
+        )
+        io_utils.pickle_dump(
+            model_dir_path / f"{file_name}.sparse_feature_sizes.pkl",
+            self._sparse_feature_sizes,
+        )
+        io_utils.pickle_dump(
+            model_dir_path / f"{file_name}.label_data.pkl", dict(self._label_data.data)
+        )
+        io_utils.json_pickle(
+            model_dir_path / f"{file_name}.index_label_id_mapping.json",
+            self.index_label_id_mapping,
+        )
 
-            entity_tag_specs = (
-                [tag_spec._asdict() for tag_spec in self._entity_tag_specs]
-                if self._entity_tag_specs
-                else []
-            )
-            rasa.shared.utils.io.dump_obj_as_json_to_file(
-                model_path / f"{file_name}.entity_tag_specs.json", entity_tag_specs
-            )
+        entity_tag_specs = (
+            [tag_spec._asdict() for tag_spec in self._entity_tag_specs]
+            if self._entity_tag_specs
+            else []
+        )
+        rasa.shared.utils.io.dump_obj_as_json_to_file(
+            model_dir_path / f"{file_name}.entity_tag_specs.json", entity_tag_specs
+        )
+
+        return {"file": file_name}
 
     @classmethod
     def load(
         cls,
-        config: Dict[Text, Any],
-        model_storage: ModelStorage,
-        resource: Resource,
-        execution_context: ExecutionContext,
+        meta: Dict[Text, Any],
+        model_dir: Text,
+        model_metadata: Metadata = None,
+        cached_component: Optional["DIETClassifier"] = None,
+        should_finetune: bool = False,
         **kwargs: Any,
-    ) -> "DIETClassifierGraphComponent":
+    ) -> "DIETClassifier":
         """Loads the trained model from the provided directory."""
-        with model_storage.read_from(resource) as model_path:
-            (
-                index_label_id_mapping,
-                entity_tag_specs,
-                label_data,
-                data_example,
-                sparse_feature_sizes,
-            ) = cls._load_from_files(model_path)
-
-            config = train_utils.update_confidence_type(config)
-            config = train_utils.update_similarity_type(config)
-            config = train_utils.update_deprecated_loss_type(config)
-
-            model = cls._load_model(
-                entity_tag_specs,
-                label_data,
-                config,
-                data_example,
-                model_path,
-                finetune_mode=execution_context.is_finetuning,
+        if not meta.get("file"):
+            logger.debug(
+                f"Failed to load model for '{cls.__name__}'. "
+                f"Maybe you did not provide enough training data and no model was "
+                f"trained or the path '{os.path.abspath(model_dir)}' doesn't exist?"
             )
+            return cls(component_config=meta)
 
-            return cls(
-                config=config,
-                model_storage=model_storage,
-                resource=resource,
-                execution_context=execution_context,
-                index_label_id_mapping=index_label_id_mapping,
-                entity_tag_specs=entity_tag_specs,
-                model=model,
-                sparse_feature_sizes=sparse_feature_sizes,
-            )
+        (
+            index_label_id_mapping,
+            entity_tag_specs,
+            label_data,
+            meta,
+            data_example,
+            sparse_feature_sizes,
+        ) = cls._load_from_files(meta, model_dir)
+
+        meta = train_utils.override_defaults(cls.defaults, meta)
+        meta = train_utils.update_confidence_type(meta)
+        meta = train_utils.update_similarity_type(meta)
+        meta = train_utils.update_deprecated_loss_type(meta)
+
+        model = cls._load_model(
+            entity_tag_specs,
+            label_data,
+            meta,
+            data_example,
+            model_dir,
+            finetune_mode=should_finetune,
+        )
+
+        return cls(
+            component_config=meta,
+            index_label_id_mapping=index_label_id_mapping,
+            entity_tag_specs=entity_tag_specs,
+            model=model,
+            finetune_mode=should_finetune,
+            sparse_feature_sizes=sparse_feature_sizes,
+        )
 
     @classmethod
     def _load_from_files(
-        cls, model_path: Path
+        cls, meta: Dict[Text, Any], model_dir: Text
     ) -> Tuple[
         Dict[int, Text],
         List[EntityTagSpec],
         RasaModelData,
+        Dict[Text, Any],
         Dict[Text, Dict[Text, List[FeatureArray]]],
         Dict[Text, Dict[Text, List[int]]],
     ]:
-        file_name = cls.__name__
+        file_name = meta["file"]
+
+        model_dir_path = Path(model_dir)
 
         data_example = io_utils.pickle_load(
-            model_path / f"{file_name}.data_example.pkl"
+            model_dir_path / f"{file_name}.data_example.pkl"
         )
-        label_data = io_utils.pickle_load(model_path / f"{file_name}.label_data.pkl")
+        label_data = io_utils.pickle_load(
+            model_dir_path / f"{file_name}.label_data.pkl"
+        )
         label_data = RasaModelData(data=label_data)
         sparse_feature_sizes = io_utils.pickle_load(
-            model_path / f"{file_name}.sparse_feature_sizes.pkl"
+            model_dir_path / f"{file_name}.sparse_feature_sizes.pkl"
         )
         index_label_id_mapping = io_utils.json_unpickle(
-            model_path / f"{file_name}.index_label_id_mapping.json"
+            model_dir_path / f"{file_name}.index_label_id_mapping.json"
         )
         entity_tag_specs = rasa.shared.utils.io.read_json_file(
-            model_path / f"{file_name}.entity_tag_specs.json"
+            model_dir_path / f"{file_name}.entity_tag_specs.json"
         )
         entity_tag_specs = [
             EntityTagSpec(
@@ -1166,6 +1158,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             index_label_id_mapping,
             entity_tag_specs,
             label_data,
+            meta,
             data_example,
             sparse_feature_sizes,
         )
@@ -1175,16 +1168,16 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
         cls,
         entity_tag_specs: List[EntityTagSpec],
         label_data: RasaModelData,
-        config: Dict[Text, Any],
+        meta: Dict[Text, Any],
         data_example: Dict[Text, Dict[Text, List[FeatureArray]]],
-        model_path: Path,
+        model_dir: Text,
         finetune_mode: bool = False,
     ) -> "RasaModel":
-        file_name = cls.__name__
-        tf_model_file = os.path.join(model_path, file_name + ".tf_model")
+        file_name = meta["file"]
+        tf_model_file = os.path.join(model_dir, file_name + ".tf_model")
 
-        label_key = LABEL_KEY if config[INTENT_CLASSIFICATION] else None
-        label_sub_key = LABEL_SUB_KEY if config[INTENT_CLASSIFICATION] else None
+        label_key = LABEL_KEY if meta[INTENT_CLASSIFICATION] else None
+        label_sub_key = LABEL_SUB_KEY if meta[INTENT_CLASSIFICATION] else None
 
         model_data_example = RasaModelData(
             label_key=label_key, label_sub_key=label_sub_key, data=data_example
@@ -1195,7 +1188,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             model_data_example,
             label_data,
             entity_tag_specs,
-            config,
+            meta,
             finetune_mode=finetune_mode,
         )
 
@@ -1208,7 +1201,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
         model_data_example: RasaModelData,
         label_data: RasaModelData,
         entity_tag_specs: List[EntityTagSpec],
-        config: Dict[Text, Any],
+        meta: Dict[Text, Any],
         finetune_mode: bool,
     ) -> "RasaModel":
 
@@ -1228,7 +1221,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             data_signature=model_data_example.get_signature(),
             label_data=label_data,
             entity_tag_specs=entity_tag_specs,
-            config=copy.deepcopy(config),
+            config=copy.deepcopy(meta),
             finetune_mode=finetune_mode,
         )
 

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
-import os
 import scipy.sparse
 import tensorflow as tf
 
@@ -282,7 +281,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
                 f" We will change the default value of '{EPOCHS}' in the future to 1. "
             )
 
-        self.component_config: Dict[Text, Any] = config
+        self.component_config = config
         self._model_storage = model_storage
         self._resource = resource
         self._execution_context = execution_context
@@ -1025,7 +1024,6 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
                 message.set(ENTITIES, entities, add_to_output=True)
 
             if out and self._execution_context.should_add_diagnostic_data:
-                # TODO: JUZL: use node name
                 message.add_diagnostic_data(
                     self._execution_context.node_name, out.get(DIAGNOSTIC_DATA)
                 )
@@ -1201,7 +1199,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
         finetune_mode: bool = False,
     ) -> "RasaModel":
         file_name = cls.__name__
-        tf_model_file = os.path.join(model_path, file_name + ".tf_model")
+        tf_model_file = model_path / f"{file_name}.tf_model"
 
         label_key = LABEL_KEY if config[INTENT_CLASSIFICATION] else None
         label_sub_key = LABEL_SUB_KEY if config[INTENT_CLASSIFICATION] else None

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1027,7 +1027,7 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             if out and self._execution_context.should_add_diagnostic_data:
                 # TODO: JUZL: use node name
                 message.add_diagnostic_data(
-                    self.__class__.__name__, out.get(DIAGNOSTIC_DATA)
+                    self._execution_context.node_name, out.get(DIAGNOSTIC_DATA)
                 )
 
         return messages

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -377,11 +377,6 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             self.component_config
         )
 
-    @staticmethod
-    def required_packages() -> List[Text]:
-        """Any extra python dependencies required for this component to run."""
-        return ["tensorflow"]
-
     @classmethod
     def create(
         cls,

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -378,9 +378,9 @@ class DIETClassifierGraphComponent(GraphComponent, EntityExtractorMixin):
             self.component_config
         )
 
-    # package safety checks
-    @classmethod
-    def required_packages(cls) -> List[Text]:
+    @staticmethod
+    def required_packages() -> List[Text]:
+        """Any extra python dependencies required for this component to run."""
         return ["tensorflow"]
 
     @classmethod

--- a/rasa/nlu/extractors/_extractor.py
+++ b/rasa/nlu/extractors/_extractor.py
@@ -1,11 +1,17 @@
-import abc
-from typing import Any, Dict, List, NamedTuple, Text, Tuple, Optional
+# flake8: noqa
+# WARNING: This module will be dropped before Rasa Open Source 3.0 is released.
+#          Please don't do any changes in this module and rather adapt
+#          EntityExtractorMixin from the regular
+#          `rasa.nlu.extractors.extractor` module. This module is a workaround to defer
+#          breaking changes due to the architecture revamp in 3.0.
+from typing import Any, Dict, List, Text, Tuple, Optional, NamedTuple
 
 import rasa.shared.utils.io
 from rasa.shared.constants import DOCS_URL_TRAINING_DATA_NLU
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.shared.nlu.training_data.message import Message
 from rasa.nlu.tokenizers.tokenizer import Token
+from rasa.nlu.components import Component
 from rasa.nlu.constants import (
     TOKENS_NAMES,
     ENTITY_ATTRIBUTE_CONFIDENCE_TYPE,
@@ -25,14 +31,10 @@ from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_ROLE,
     NO_ENTITY_TAG,
     SPLIT_ENTITIES_BY_COMMA,
+    SPLIT_ENTITIES_BY_COMMA_DEFAULT_VALUE,
     SINGLE_ENTITY_ALLOWED_INTERLEAVING_CHARSET,
 )
 import rasa.utils.train_utils
-
-from rasa.nlu.extractors._extractor import EntityExtractor
-
-# This is a workaround around until we have all components migrated to `GraphComponent`.
-EntityExtractor = EntityExtractor
 
 
 class EntityTagSpec(NamedTuple):
@@ -44,16 +46,12 @@ class EntityTagSpec(NamedTuple):
     num_tags: int
 
 
-class EntityExtractorMixin(abc.ABC):
+class EntityExtractor(Component):
     """Entity extractors are components which extract entities.
 
     They can be placed in the pipeline like other components, and can extract
     entities like a person's name, or a location.
     """
-
-    @property
-    def name(self):
-        return self.__class__.__name__
 
     def add_extractor_name(
         self, entities: List[Dict[Text, Any]]
@@ -85,6 +83,24 @@ class EntityExtractorMixin(abc.ABC):
             entity["processors"] = [self.name]
 
         return entity
+
+    def init_split_entities(self) -> Dict[Text, bool]:
+        """Initialises the behaviour for splitting entities by comma (or not).
+
+        Returns:
+            Defines desired behaviour for splitting specific entity types and
+            default behaviour for splitting any entity types for which no
+            behaviour is defined.
+        """
+        split_entities_config = self.component_config.get(
+            SPLIT_ENTITIES_BY_COMMA, SPLIT_ENTITIES_BY_COMMA_DEFAULT_VALUE
+        )
+        default_value = self.defaults.get(
+            SPLIT_ENTITIES_BY_COMMA, SPLIT_ENTITIES_BY_COMMA_DEFAULT_VALUE
+        )
+        return rasa.utils.train_utils.init_split_entities(
+            split_entities_config, default_value
+        )
 
     @staticmethod
     def filter_irrelevant_entities(extracted: list, requested_dimensions: set) -> list:
@@ -185,7 +201,7 @@ class EntityExtractorMixin(abc.ABC):
         last_token_end = -1
 
         for idx, token in enumerate(tokens):
-            current_entity_tag = EntityExtractorMixin.get_tag_for(
+            current_entity_tag = EntityExtractor.get_tag_for(
                 tags, ENTITY_ATTRIBUTE_TYPE, idx
             )
 
@@ -194,11 +210,11 @@ class EntityExtractorMixin(abc.ABC):
                 last_token_end = token.end
                 continue
 
-            current_group_tag = EntityExtractorMixin.get_tag_for(
+            current_group_tag = EntityExtractor.get_tag_for(
                 tags, ENTITY_ATTRIBUTE_GROUP, idx
             )
             current_group_tag = bilou_utils.tag_without_prefix(current_group_tag)
-            current_role_tag = EntityExtractorMixin.get_tag_for(
+            current_role_tag = EntityExtractor.get_tag_for(
                 tags, ENTITY_ATTRIBUTE_ROLE, idx
             )
             current_role_tag = bilou_utils.tag_without_prefix(current_role_tag)
@@ -240,7 +256,7 @@ class EntityExtractorMixin(abc.ABC):
 
             if new_tag_found:
                 # new entity found
-                entity = EntityExtractorMixin._create_new_entity(
+                entity = EntityExtractor._create_new_entity(
                     list(tags.keys()),
                     current_entity_tag,
                     current_group_tag,
@@ -250,7 +266,7 @@ class EntityExtractorMixin(abc.ABC):
                     confidences,
                 )
                 entities.append(entity)
-            elif EntityExtractorMixin._check_is_single_entity(
+            elif EntityExtractor._check_is_single_entity(
                 text, token, last_token_end, split_entities_config, current_entity_tag
             ):
                 # current token has the same entity tag as the token before and
@@ -259,7 +275,7 @@ class EntityExtractorMixin(abc.ABC):
                 # and a whitespace.
                 entities[-1][ENTITY_ATTRIBUTE_END] = token.end
                 if confidences is not None:
-                    EntityExtractorMixin._update_confidence_values(
+                    EntityExtractor._update_confidence_values(
                         entities, confidences, idx
                     )
 
@@ -268,7 +284,7 @@ class EntityExtractorMixin(abc.ABC):
                 # tokens are separated by at least 2 symbols (e.g. multiple spaces,
                 # a comma and a space, etc.) and also shouldn't be represented as a
                 # single entity
-                entity = EntityExtractorMixin._create_new_entity(
+                entity = EntityExtractor._create_new_entity(
                     list(tags.keys()),
                     current_entity_tag,
                     current_group_tag,

--- a/rasa/nlu/extractors/extractor.py
+++ b/rasa/nlu/extractors/extractor.py
@@ -52,7 +52,8 @@ class EntityExtractorMixin(abc.ABC):
     """
 
     @property
-    def name(self):
+    def name(self) -> Text:
+        """Returns the name of the class."""
         return self.__class__.__name__
 
     def add_extractor_name(

--- a/rasa/nlu/extractors/extractor.py
+++ b/rasa/nlu/extractors/extractor.py
@@ -45,10 +45,11 @@ class EntityTagSpec(NamedTuple):
 
 
 class EntityExtractorMixin(abc.ABC):
-    """Entity extractors are components which extract entities.
+    """Provides functionality for components that do entity extraction.
 
-    They can be placed in the pipeline like other components, and can extract
-    entities like a person's name, or a location.
+    Inheriting from this class will add utility functions for entity extraction.
+    Entity extraction is the process of identifying and extracting entities like a
+    person's name, or a location from a message.
     """
 
     @property

--- a/tests/engine/graph_components_test_classes.py
+++ b/tests/engine/graph_components_test_classes.py
@@ -123,8 +123,8 @@ class FileReader(GraphComponent):
 
 
 class ExecutionContextAware(GraphComponent):
-    def __init__(self, model_id: Text) -> None:
-        self.model_id = model_id
+    def __init__(self, execution_context: ExecutionContext) -> None:
+        self._execution_context = execution_context
 
     @classmethod
     def create(
@@ -135,10 +135,10 @@ class ExecutionContextAware(GraphComponent):
         execution_context: ExecutionContext,
         **kwargs: Any,
     ) -> ExecutionContextAware:
-        return cls(execution_context.model_id)
+        return cls(execution_context)
 
-    def get_model_id(self) -> Text:
-        return self.model_id
+    def get_execution_context(self) -> ExecutionContext:
+        return self._execution_context
 
 
 class PersistableTestComponent(GraphComponent):

--- a/tests/engine/runner/test_dask.py
+++ b/tests/engine/runner/test_dask.py
@@ -247,25 +247,26 @@ def test_can_use_alternate_constructor(default_model_storage: ModelStorage):
 def test_execution_context(default_model_storage: ModelStorage):
     graph_schema = GraphSchema(
         {
-            "model_id": SchemaNode(
+            "execution_context_aware": SchemaNode(
                 needs={},
                 uses=ExecutionContextAware,
-                fn="get_model_id",
+                fn="get_execution_context",
                 constructor_name="create",
                 config={},
                 is_target=True,
             ),
         }
     )
+    context = ExecutionContext(graph_schema=graph_schema, model_id="some_id")
     runner = DaskGraphRunner(
         graph_schema=graph_schema,
         model_storage=default_model_storage,
-        execution_context=ExecutionContext(
-            graph_schema=graph_schema, model_id="some_id"
-        ),
+        execution_context=context,
     )
-    results = runner.run()
-    assert results["model_id"] == "some_id"
+    context.model_id = "a_new_id"
+    result = runner.run()["execution_context_aware"]
+    assert result.model_id == "some_id"
+    assert result.node_name == "execution_context_aware"
 
 
 def test_loop(default_model_storage: ModelStorage):

--- a/tests/engine/test_graph_node.py
+++ b/tests/engine/test_graph_node.py
@@ -150,21 +150,25 @@ def test_non_eager_can_use_inputs_for_constructor(default_model_storage: ModelSt
 
 
 def test_execution_context(default_model_storage: ModelStorage):
+    context = ExecutionContext(GraphSchema({}), "some_id")
     node = GraphNode(
-        node_name="model_id",
+        node_name="execution_context_aware",
         component_class=ExecutionContextAware,
         constructor_name="create",
         component_config={},
-        fn_name="get_model_id",
+        fn_name="get_execution_context",
         inputs={},
         eager=False,
         model_storage=default_model_storage,
         resource=None,
-        execution_context=ExecutionContext(GraphSchema({}), "some_id"),
+        execution_context=context,
     )
 
-    result = node()
-    assert result == ("model_id", "some_id")
+    context.model_id = "a_new_id"
+
+    result = node()[1]
+    assert result.model_id == "some_id"
+    assert result.node_name == "execution_context_aware"
 
 
 def test_constructor_exception(default_model_storage: ModelStorage):

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -86,9 +86,6 @@ def create_diet(
 def create_train_load_and_process_diet(
     nlu_data_path: Text,
     create_diet: Callable[..., DIETClassifier],
-    default_model_storage: ModelStorage,
-    default_execution_context: ExecutionContext,
-    default_diet_resource: Resource,
     train_load_and_process_diet: Callable[..., Message],
 ) -> Callable[..., Message]:
     def inner(
@@ -112,11 +109,7 @@ def create_train_load_and_process_diet(
 
 @pytest.fixture()
 def train_load_and_process_diet(
-    nlu_data_path: Text,
-    create_diet: Callable[..., DIETClassifier],
-    default_model_storage: ModelStorage,
-    default_execution_context: ExecutionContext,
-    default_diet_resource: Resource,
+    nlu_data_path: Text, create_diet: Callable[..., DIETClassifier],
 ) -> Callable[..., Message]:
     def inner(
         diet: DIETClassifier,

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -632,7 +632,7 @@ async def test_process_gives_diagnostic_data(
         diagnostic_data = processed_message.get(DIAGNOSTIC_DATA)
 
         # DIETClassifier should add attention weights
-        name = "DIETClassifier"
+        name = "DIETClassifierGraphComponent"
         assert isinstance(diagnostic_data, dict)
         assert name in diagnostic_data
         assert "attention_weights" in diagnostic_data[name]

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -1,17 +1,20 @@
+import copy
 from pathlib import Path
 
 import numpy as np
 import pytest
 from unittest.mock import Mock
-from typing import List, Text, Dict, Any
+from typing import Callable, List, Optional, Text, Dict, Any
 from _pytest.monkeypatch import MonkeyPatch
 
-import rasa.model
+from rasa.engine.graph import ExecutionContext
+from rasa.engine.storage.resource import Resource
+from rasa.engine.storage.storage import ModelStorage
+from rasa.nlu import registry
 from rasa.shared.exceptions import InvalidConfigException
+from rasa.shared.importers.rasa import RasaFileImporter
 from rasa.shared.nlu.training_data.features import Features
-import rasa.nlu.train
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
-from rasa.nlu.config import RasaNLUModelConfig
 from rasa.shared.nlu.constants import (
     TEXT,
     INTENT,
@@ -37,16 +40,126 @@ from rasa.utils.tensorflow.constants import (
     MODEL_CONFIDENCE,
     LINEAR_NORM,
 )
-from rasa.nlu.components import ComponentBuilder
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
-from rasa.nlu.classifiers.diet_classifier import DIETClassifier
-from rasa.nlu.model import Interpreter
+from rasa.nlu.classifiers.diet_classifier import (
+    DIETClassifierGraphComponent as DIETClassifier,
+)
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.utils import train_utils
 from rasa.shared.constants import DIAGNOSTIC_DATA
 from rasa.shared.nlu.training_data.loading import load_data
 from rasa.utils.tensorflow.model_data_utils import FeatureArray
+
+
+@pytest.fixture()
+def default_diet_resource() -> Resource:
+    return Resource("DIET")
+
+
+@pytest.fixture()
+def create_diet(
+    default_model_storage: ModelStorage,
+    default_execution_context: ExecutionContext,
+    default_diet_resource: Resource,
+) -> Callable[..., DIETClassifier]:
+    def inner(config: Dict[Text, Any], load: bool = False) -> DIETClassifier:
+        if load:
+            constructor = DIETClassifier.load
+        else:
+            constructor = DIETClassifier.create
+        return constructor(
+            config={**DIETClassifier.get_default_config(), **config},
+            model_storage=default_model_storage,
+            execution_context=default_execution_context,
+            resource=default_diet_resource,
+        )
+
+    return inner
+
+
+@pytest.fixture()
+def create_train_load_and_process_diet(
+    nlu_data_path: Text,
+    create_diet: Callable[..., DIETClassifier],
+    default_model_storage: ModelStorage,
+    default_execution_context: ExecutionContext,
+    default_diet_resource: Resource,
+    train_load_and_process_diet: Callable[..., Message],
+) -> Callable[..., Message]:
+    def inner(
+        diet_config: Dict[Text, Any],
+        pipeline: Optional[List[Dict[Text, Any]]] = None,
+        training_data: str = nlu_data_path,
+        message_text: Text = "Rasa is great!",
+        expect_intent: bool = True,
+    ) -> Message:
+        diet = create_diet(diet_config)
+        return train_load_and_process_diet(
+            diet=diet,
+            pipeline=pipeline,
+            training_data=training_data,
+            message_text=message_text,
+            expect_intent=expect_intent,
+        )
+
+    return inner
+
+
+@pytest.fixture()
+def train_load_and_process_diet(
+    nlu_data_path: Text,
+    create_diet: Callable[..., DIETClassifier],
+    default_model_storage: ModelStorage,
+    default_execution_context: ExecutionContext,
+    default_diet_resource: Resource,
+) -> Callable[..., Message]:
+    def inner(
+        diet: DIETClassifier,
+        pipeline: Optional[List[Dict[Text, Any]]] = None,
+        training_data: str = nlu_data_path,
+        message_text: Text = "Rasa is great!",
+        expect_intent: bool = True,
+    ) -> Message:
+
+        if not pipeline:
+            pipeline = [
+                {"name": "WhitespaceTokenizer"},
+                {"name": "CountVectorsFeaturizer"},
+            ]
+
+        loaded_pipeline = [
+            registry.get_component_class(component.pop("name"))(component)
+            for component in copy.deepcopy(pipeline)
+        ]
+
+        importer = RasaFileImporter(training_data_paths=[training_data])
+        training_data = importer.get_nlu_data()
+
+        for component in loaded_pipeline:
+            component.train(training_data)
+
+        diet.train(training_data=training_data)
+
+        message = Message(data={TEXT: message_text})
+        for component in loaded_pipeline:
+            component.process(message)
+
+        message2 = copy.deepcopy(message)
+
+        classified_message = diet.process([message])[0]
+
+        if expect_intent:
+            assert classified_message.data["intent"]["name"]
+
+        loaded_diet = create_diet(diet.component_config, load=True)
+
+        classified_message2 = loaded_diet.process([message2])[0]
+
+        assert classified_message2.fingerprint() == classified_message.fingerprint()
+        return classified_message
+
+    return inner
 
 
 def test_compute_default_label_features():
@@ -65,20 +178,6 @@ def test_compute_default_label_features():
         assert isinstance(o, np.ndarray)
         assert o[0][i] == 1
         assert o.shape == (1, len(label_features))
-
-
-def get_checkpoint_dir_path(path: Path, model_dir: Path) -> Path:
-    """
-    Produce the path of the checkpoint directory for DIET.
-
-    This is coupled to the persist method of DIET.
-
-    Args:
-        model_dir: the model directory
-        path: the path passed to train for training output.
-
-    """
-    return path / model_dir / "checkpoints"
 
 
 @pytest.mark.parametrize(
@@ -128,9 +227,11 @@ def get_checkpoint_dir_path(path: Path, model_dir: Path) -> Path:
         ),
     ],
 )
-def test_check_labels_features_exist(messages, expected):
+def test_check_labels_features_exist(
+    messages: List[Message], expected: bool, create_diet: Callable[..., DIETClassifier],
+):
     attribute = TEXT
-    classifier = DIETClassifier()
+    classifier = create_diet({})
     assert classifier._check_labels_features_exist(messages, attribute) == expected
 
 
@@ -170,9 +271,11 @@ def test_check_labels_features_exist(messages, expected):
     ],
 )
 def test_model_data_signature_with_entities(
-    messages: List[Message], entity_expected: bool
+    messages: List[Message],
+    entity_expected: bool,
+    create_diet: Callable[..., DIETClassifier],
 ):
-    classifier = DIETClassifier({"BILOU_flag": False})
+    classifier = create_diet({"BILOU_flag": False})
     training_data = TrainingData(messages)
 
     # create tokens for entity parsing inside DIET
@@ -184,38 +287,10 @@ def test_model_data_signature_with_entities(
     assert entity_exists == entity_expected
 
 
-async def _train_persist_load_with_different_settings(
-    pipeline: List[Dict[Text, Any]],
-    component_builder: ComponentBuilder,
-    tmp_path: Path,
-    should_finetune: bool,
-):
-    _config = RasaNLUModelConfig({"pipeline": pipeline, "language": "en"})
-
-    (trainer, trained, persisted_path) = await rasa.nlu.train.train(
-        _config,
-        path=str(tmp_path),
-        data="data/examples/rasa/demo-rasa-multi-intent.yml",
-        component_builder=component_builder,
-    )
-
-    assert trainer.pipeline
-    assert trained.pipeline
-
-    loaded = Interpreter.load(
-        persisted_path,
-        component_builder,
-        new_config=_config if should_finetune else None,
-    )
-
-    assert loaded.pipeline
-    assert loaded.parse("Rasa is great!") == trained.parse("Rasa is great!")
-
-
 @pytest.mark.skip_on_windows
 @pytest.mark.timeout(120, func_only=True)
 async def test_train_persist_load_with_different_settings_non_windows(
-    component_builder: ComponentBuilder, tmp_path: Path
+    create_train_load_and_process_diet: Callable[..., Message]
 ):
     pipeline = [
         {
@@ -224,101 +299,35 @@ async def test_train_persist_load_with_different_settings_non_windows(
             "intent_split_symbol": "+",
         },
         {"name": "CountVectorsFeaturizer"},
-        {"name": "DIETClassifier", MASKED_LM: True, EPOCHS: 1},
     ]
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmp_path, should_finetune=False
-    )
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmp_path, should_finetune=True
-    )
+    create_train_load_and_process_diet({MASKED_LM: True, EPOCHS: 1}, pipeline)
 
 
 @pytest.mark.timeout(120, func_only=True)
-async def test_train_persist_load_with_different_settings(component_builder, tmpdir):
-    pipeline = [
-        {"name": "WhitespaceTokenizer"},
-        {"name": "CountVectorsFeaturizer"},
-        {"name": "DIETClassifier", LOSS_TYPE: "margin", EPOCHS: 1},
-    ]
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmpdir, should_finetune=False
-    )
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmpdir, should_finetune=True
-    )
+async def test_train_persist_load_with_different_settings(
+    create_train_load_and_process_diet: Callable[..., Message]
+):
+    create_train_load_and_process_diet({LOSS_TYPE: "margin", EPOCHS: 1})
 
 
 @pytest.mark.timeout(120, func_only=True)
 async def test_train_persist_load_with_only_entity_recognition(
-    component_builder, tmpdir
+    create_train_load_and_process_diet: Callable[..., Message]
 ):
-    pipeline = [
-        {"name": "WhitespaceTokenizer"},
-        {"name": "CountVectorsFeaturizer"},
-        {
-            "name": "DIETClassifier",
-            ENTITY_RECOGNITION: True,
-            INTENT_CLASSIFICATION: False,
-            EPOCHS: 1,
-        },
-    ]
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmpdir, should_finetune=False
-    )
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmpdir, should_finetune=True
+    create_train_load_and_process_diet(
+        {ENTITY_RECOGNITION: True, INTENT_CLASSIFICATION: False, EPOCHS: 1},
+        training_data="data/examples/rasa/demo-rasa-multi-intent.yml",
+        expect_intent=False,
     )
 
 
 @pytest.mark.timeout(120, func_only=True)
 async def test_train_persist_load_with_only_intent_classification(
-    component_builder, tmpdir
+    create_train_load_and_process_diet: Callable[..., Message]
 ):
-    pipeline = [
-        {"name": "WhitespaceTokenizer"},
-        {"name": "CountVectorsFeaturizer"},
-        {
-            "name": "DIETClassifier",
-            ENTITY_RECOGNITION: False,
-            INTENT_CLASSIFICATION: True,
-            EPOCHS: 1,
-        },
-    ]
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmpdir, should_finetune=False
+    create_train_load_and_process_diet(
+        {ENTITY_RECOGNITION: False, INTENT_CLASSIFICATION: True, EPOCHS: 1,}
     )
-    await _train_persist_load_with_different_settings(
-        pipeline, component_builder, tmpdir, should_finetune=True
-    )
-
-
-async def test_raise_error_on_incorrect_pipeline(
-    component_builder, tmp_path: Path, nlu_as_json_path: Text
-):
-    _config = RasaNLUModelConfig(
-        {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {"name": "DIETClassifier", EPOCHS: 1},
-            ],
-            "language": "en",
-        }
-    )
-
-    with pytest.raises(Exception) as e:
-        await rasa.nlu.train.train(
-            _config,
-            path=str(tmp_path),
-            data=nlu_as_json_path,
-            component_builder=component_builder,
-        )
-
-    assert "'DIETClassifier' requires 'Featurizer'" in str(e.value)
-
-
-def as_pipeline(*components):
-    return [{"name": c} for c in components]
 
 
 @pytest.mark.parametrize(
@@ -357,29 +366,17 @@ def as_pipeline(*components):
     ],
 )
 async def test_softmax_normalization(
-    component_builder,
-    tmp_path,
     classifier_params,
     data_path: Text,
     output_length,
     output_should_sum_to_1,
+    create_train_load_and_process_diet: Callable[..., Message],
 ):
-    pipeline = as_pipeline(
-        "WhitespaceTokenizer", "CountVectorsFeaturizer", "DIETClassifier"
-    )
-    assert pipeline[2]["name"] == "DIETClassifier"
-    pipeline[2].update(classifier_params)
 
-    _config = RasaNLUModelConfig({"pipeline": pipeline})
-    (trained_model, _, persisted_path) = await rasa.nlu.train.train(
-        _config,
-        path=str(tmp_path),
-        data=data_path,
-        component_builder=component_builder,
+    parsed_message = create_train_load_and_process_diet(
+        classifier_params, training_data=data_path
     )
-    loaded = Interpreter.load(persisted_path, component_builder)
-
-    parse_data = loaded.parse("hello")
+    parse_data = parsed_message.data
     intent_ranking = parse_data.get("intent_ranking")
     # check that the output was correctly truncated after normalization
     assert len(intent_ranking) == output_length
@@ -394,46 +391,21 @@ async def test_softmax_normalization(
     assert parse_data.get("intent") == intent_ranking[0]
 
 
-@pytest.mark.parametrize(
-    "classifier_params, data_path",
-    [
-        (
-            {
-                RANDOM_SEED: 42,
-                EPOCHS: 1,
-                MODEL_CONFIDENCE: LINEAR_NORM,
-                RANKING_LENGTH: -1,
-            },
-            "data/test_moodbot/data/nlu.yml",
-        ),
-    ],
-)
 async def test_inner_linear_normalization(
-    component_builder: ComponentBuilder,
-    tmp_path: Path,
-    classifier_params: Dict[Text, Any],
-    data_path: Text,
-    monkeypatch: MonkeyPatch,
+    monkeypatch: MonkeyPatch, create_train_load_and_process_diet: Callable[..., Message]
 ):
-    pipeline = as_pipeline(
-        "WhitespaceTokenizer", "CountVectorsFeaturizer", "DIETClassifier"
-    )
-    assert pipeline[2]["name"] == "DIETClassifier"
-    pipeline[2].update(classifier_params)
-
-    _config = RasaNLUModelConfig({"pipeline": pipeline})
-    (trained_model, _, persisted_path) = await rasa.nlu.train.train(
-        _config,
-        path=str(tmp_path),
-        data=data_path,
-        component_builder=component_builder,
-    )
-    loaded = Interpreter.load(persisted_path, component_builder)
-
     mock = Mock()
     monkeypatch.setattr(train_utils, "normalize", mock.normalize)
 
-    parse_data = loaded.parse("hello")
+    parsed_message = create_train_load_and_process_diet(
+        {
+            RANDOM_SEED: 42,
+            EPOCHS: 1,
+            MODEL_CONFIDENCE: LINEAR_NORM,
+            RANKING_LENGTH: -1,
+        },
+    )
+    parse_data = parsed_message.data
     intent_ranking = parse_data.get("intent_ranking")
 
     # check whether normalization had the expected effect
@@ -449,126 +421,85 @@ async def test_inner_linear_normalization(
     mock.normalize.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "classifier_params, output_length",
-    [({LOSS_TYPE: "margin", RANDOM_SEED: 42, EPOCHS: 1}, LABEL_RANKING_LENGTH)],
-)
 async def test_margin_loss_is_not_normalized(
-    monkeypatch, component_builder, tmpdir, classifier_params, output_length
+    monkeypatch: MonkeyPatch, create_train_load_and_process_diet: Callable[..., Message]
 ):
-    pipeline = as_pipeline(
-        "WhitespaceTokenizer", "CountVectorsFeaturizer", "DIETClassifier"
-    )
-    assert pipeline[2]["name"] == "DIETClassifier"
-    pipeline[2].update(classifier_params)
-
     mock = Mock()
     monkeypatch.setattr(train_utils, "normalize", mock.normalize)
 
-    _config = RasaNLUModelConfig({"pipeline": pipeline})
-    (trained_model, _, persisted_path) = await rasa.nlu.train.train(
-        _config,
-        path=str(tmpdir),
-        data="data/test/many_intents.yml",
-        component_builder=component_builder,
+    parsed_message = create_train_load_and_process_diet(
+        {LOSS_TYPE: "margin", RANDOM_SEED: 42, EPOCHS: 1},
+        training_data="data/test/many_intents.yml",
     )
-    loaded = Interpreter.load(persisted_path, component_builder)
-
-    parse_data = loaded.parse("hello")
+    parse_data = parsed_message.data
     intent_ranking = parse_data.get("intent_ranking")
 
     # check that the output was not normalized
     mock.normalize.assert_not_called()
 
     # check that the output was correctly truncated
-    assert len(intent_ranking) == output_length
+    assert len(intent_ranking) == LABEL_RANKING_LENGTH
 
     # make sure top ranking is reflected in intent prediction
     assert parse_data.get("intent") == intent_ranking[0]
 
 
 @pytest.mark.timeout(120, func_only=True)
-async def test_set_random_seed(component_builder, tmpdir, nlu_as_json_path: Text):
+async def test_set_random_seed(
+    create_train_load_and_process_diet: Callable[..., Message]
+):
     """test if train result is the same for two runs of tf embedding"""
 
-    # set fixed random seed
-    _config = RasaNLUModelConfig(
-        {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {"name": "CountVectorsFeaturizer"},
-                {"name": "DIETClassifier", RANDOM_SEED: 1, EPOCHS: 1},
-            ],
-            "language": "en",
-        }
-    )
+    parsed_message1 = create_train_load_and_process_diet({RANDOM_SEED: 1, EPOCHS: 1},)
 
-    # first run
-    (trained_a, _, persisted_path_a) = await rasa.nlu.train.train(
-        _config,
-        path=tmpdir.strpath + "_a",
-        data=nlu_as_json_path,
-        component_builder=component_builder,
-    )
-    # second run
-    (trained_b, _, persisted_path_b) = await rasa.nlu.train.train(
-        _config,
-        path=tmpdir.strpath + "_b",
-        data=nlu_as_json_path,
-        component_builder=component_builder,
-    )
+    parsed_message2 = create_train_load_and_process_diet({RANDOM_SEED: 1, EPOCHS: 1},)
 
-    loaded_a = Interpreter.load(persisted_path_a, component_builder)
-    loaded_b = Interpreter.load(persisted_path_b, component_builder)
-    result_a = loaded_a.parse("hello")["intent"]["confidence"]
-    result_b = loaded_b.parse("hello")["intent"]["confidence"]
+    # Different random seed
+    parsed_message3 = create_train_load_and_process_diet({RANDOM_SEED: 2, EPOCHS: 1},)
 
-    assert result_a == result_b
+    assert (
+        parsed_message1.data["intent"]["confidence"]
+        == parsed_message2.data["intent"]["confidence"]
+    )
+    assert (
+        parsed_message2.data["intent"]["confidence"]
+        != parsed_message3.data["intent"]["confidence"]
+    )
 
 
 @pytest.mark.parametrize("log_level", ["epoch", "batch"])
 async def test_train_tensorboard_logging(
     log_level: Text,
-    component_builder: ComponentBuilder,
     tmpdir: Path,
-    nlu_data_path: Text,
+    create_train_load_and_process_diet: Callable[..., Message],
 ):
     tensorboard_log_dir = Path(tmpdir / "tensorboard")
 
     assert not tensorboard_log_dir.exists()
 
-    _config = RasaNLUModelConfig(
+    pipeline = [
+        {"name": "WhitespaceTokenizer"},
         {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {
-                    "name": "CountVectorsFeaturizer",
-                    "analyzer": "char_wb",
-                    "min_ngram": 3,
-                    "max_ngram": 17,
-                    "max_features": 10,
-                    "min_df": 5,
-                },
-                {
-                    "name": "DIETClassifier",
-                    EPOCHS: 1,
-                    TENSORBOARD_LOG_LEVEL: log_level,
-                    TENSORBOARD_LOG_DIR: str(tensorboard_log_dir),
-                    MODEL_CONFIDENCE: "linear_norm",
-                    CONSTRAIN_SIMILARITIES: True,
-                    EVAL_NUM_EXAMPLES: 15,
-                    EVAL_NUM_EPOCHS: 1,
-                },
-            ],
-            "language": "en",
-        }
-    )
+            "name": "CountVectorsFeaturizer",
+            "analyzer": "char_wb",
+            "min_ngram": 3,
+            "max_ngram": 17,
+            "max_features": 10,
+            "min_df": 5,
+        },
+    ]
 
-    await rasa.nlu.train.train(
-        _config,
-        path=str(tmpdir),
-        data=nlu_data_path,
-        component_builder=component_builder,
+    create_train_load_and_process_diet(
+        {
+            EPOCHS: 1,
+            TENSORBOARD_LOG_LEVEL: log_level,
+            TENSORBOARD_LOG_DIR: str(tensorboard_log_dir),
+            MODEL_CONFIDENCE: "linear_norm",
+            CONSTRAIN_SIMILARITIES: True,
+            EVAL_NUM_EXAMPLES: 15,
+            EVAL_NUM_EPOCHS: 1,
+        },
+        pipeline,
     )
 
     assert tensorboard_log_dir.exists()
@@ -578,114 +509,58 @@ async def test_train_tensorboard_logging(
 
 
 async def test_train_model_checkpointing(
-    component_builder: ComponentBuilder, tmp_path: Path, nlu_data_path: Text,
+    default_model_storage: ModelStorage,
+    default_diet_resource: Resource,
+    create_train_load_and_process_diet: Callable[..., Message],
 ):
-    model_name = "nlu-checkpointed-model"
-    model_dir = tmp_path / model_name
-    checkpoint_dir = get_checkpoint_dir_path(tmp_path, model_dir)
-    assert not checkpoint_dir.is_dir()
-
-    _config = RasaNLUModelConfig(
-        {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {"name": "CountVectorsFeaturizer"},
-                {
-                    "name": "DIETClassifier",
-                    EPOCHS: 2,
-                    EVAL_NUM_EPOCHS: 1,
-                    EVAL_NUM_EXAMPLES: 10,
-                    CHECKPOINT_MODEL: True,
-                },
-            ],
-            "language": "en",
-        }
+    create_train_load_and_process_diet(
+        {EPOCHS: 2, EVAL_NUM_EPOCHS: 1, EVAL_NUM_EXAMPLES: 10, CHECKPOINT_MODEL: True},
     )
 
-    await rasa.nlu.train.train(
-        _config,
-        path=str(tmp_path),
-        data=nlu_data_path,
-        component_builder=component_builder,
-        fixed_model_name=model_name,
-    )
+    with default_model_storage.read_from(default_diet_resource) as model_dir:
+        checkpoint_dir = model_dir / "checkpoints"
 
-    assert checkpoint_dir.is_dir()
+        assert checkpoint_dir.is_dir()
 
-    """
-    Tricky to validate the *exact* number of files that should be there, however there
-    must be at least the following:
-        - metadata.json
-        - checkpoint
-        - component_1_CountVectorsFeaturizer (as per the pipeline above)
-        - component_2_DIETClassifier files (more than 1 file)
-    """
-    all_files = list(model_dir.rglob("*.*"))
-    assert len(all_files) > 4
+        """
+        Tricky to validate the *exact* number of files that should be there, however
+        there must be at least the following:
+            - metadata.json
+            - checkpoint
+            - component_1_CountVectorsFeaturizer (as per the pipeline above)
+            - component_2_DIETClassifier files (more than 1 file)
+        """
+        all_files = list(model_dir.rglob("*.*"))
+        assert len(all_files) > 4
 
 
 async def test_train_model_not_checkpointing(
-    component_builder: ComponentBuilder, tmp_path: Path, nlu_data_path: Text,
+    default_model_storage: ModelStorage,
+    default_diet_resource: Resource,
+    create_train_load_and_process_diet: Callable[..., Message],
 ):
-    model_name = "nlu-not-checkpointed-model"
-    checkpoint_dir = get_checkpoint_dir_path(tmp_path, tmp_path / model_name)
-    assert not checkpoint_dir.is_dir()
+    create_train_load_and_process_diet({EPOCHS: 2, CHECKPOINT_MODEL: False})
 
-    _config = RasaNLUModelConfig(
-        {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {"name": "CountVectorsFeaturizer"},
-                {"name": "DIETClassifier", EPOCHS: 2, CHECKPOINT_MODEL: False},
-            ],
-            "language": "en",
-        }
-    )
+    with default_model_storage.read_from(default_diet_resource) as model_dir:
+        checkpoint_dir = model_dir / "checkpoints"
 
-    await rasa.nlu.train.train(
-        _config,
-        path=str(tmp_path),
-        data=nlu_data_path,
-        component_builder=component_builder,
-        fixed_model_name=model_name,
-    )
-
-    assert not checkpoint_dir.is_dir()
+        assert not checkpoint_dir.is_dir()
 
 
 async def test_train_fails_with_zero_eval_num_epochs(
-    component_builder: ComponentBuilder, tmp_path: Path, nlu_data_path: Text,
+    create_diet: Callable[..., DIETClassifier]
 ):
-    model_name = "nlu-fail"
-    checkpoint_dir = get_checkpoint_dir_path(tmp_path, tmp_path / model_name)
-    assert not checkpoint_dir.is_dir()
-
-    _config = RasaNLUModelConfig(
-        {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {"name": "CountVectorsFeaturizer"},
+    with pytest.raises(InvalidConfigException):
+        with pytest.warns(UserWarning) as warning:
+            create_diet(
                 {
-                    "name": "DIETClassifier",
                     EPOCHS: 1,
                     CHECKPOINT_MODEL: True,
                     EVAL_NUM_EPOCHS: 0,
                     EVAL_NUM_EXAMPLES: 10,
-                },
-            ],
-            "language": "en",
-        }
-    )
-    with pytest.raises(InvalidConfigException):
-        with pytest.warns(UserWarning) as warning:
-            await rasa.nlu.train.train(
-                _config,
-                path=str(tmp_path),
-                data=nlu_data_path,
-                component_builder=component_builder,
-                fixed_model_name=model_name,
+                }
             )
-    assert not checkpoint_dir.is_dir()
+
     warn_text = (
         f"You have opted to save the best model, but the value of '{EVAL_NUM_EPOCHS}' "
         f"is not -1 or greater than 0. Training will fail."
@@ -694,44 +569,34 @@ async def test_train_fails_with_zero_eval_num_epochs(
 
 
 async def test_doesnt_checkpoint_with_zero_eval_num_examples(
-    component_builder: ComponentBuilder, tmp_path: Path, nlu_data_path: Text,
+    create_diet: Callable[..., DIETClassifier],
+    default_model_storage: ModelStorage,
+    default_diet_resource: Resource,
+    train_load_and_process_diet: Callable[..., Message],
 ):
-    model_name = "nlu-fail-checkpoint"
-    checkpoint_dir = get_checkpoint_dir_path(tmp_path, tmp_path / model_name)
-    assert not checkpoint_dir.is_dir()
-
-    _config = RasaNLUModelConfig(
-        {
-            "pipeline": [
-                {"name": "WhitespaceTokenizer"},
-                {"name": "CountVectorsFeaturizer"},
-                {
-                    "name": "DIETClassifier",
-                    EPOCHS: 2,
-                    CHECKPOINT_MODEL: True,
-                    EVAL_NUM_EXAMPLES: 0,
-                    EVAL_NUM_EPOCHS: 1,
-                },
-            ],
-            "language": "en",
-        }
-    )
     with pytest.warns(UserWarning) as warning:
-        await rasa.nlu.train.train(
-            _config,
-            path=str(tmp_path),
-            data=nlu_data_path,
-            component_builder=component_builder,
-            fixed_model_name=model_name,
+        classifier = create_diet(
+            {
+                EPOCHS: 2,
+                CHECKPOINT_MODEL: True,
+                EVAL_NUM_EXAMPLES: 0,
+                EVAL_NUM_EPOCHS: 1,
+            }
         )
 
-    assert not checkpoint_dir.is_dir()
     warn_text = (
         f"You have opted to save the best model, but the value of "
         f"'{EVAL_NUM_EXAMPLES}' is not greater than 0. No checkpoint model "
         f"will be saved."
     )
     assert len([w for w in warning if warn_text in str(w.message)]) == 1
+
+    train_load_and_process_diet(classifier)
+
+    with default_model_storage.read_from(default_diet_resource) as model_dir:
+        checkpoint_dir = model_dir / "checkpoints"
+
+        assert not checkpoint_dir.is_dir()
 
 
 @pytest.mark.parametrize(
@@ -743,52 +608,39 @@ async def test_doesnt_checkpoint_with_zero_eval_num_examples(
 )
 @pytest.mark.timeout(120, func_only=True)
 async def test_train_persist_load_with_composite_entities(
-    classifier_params, component_builder, tmpdir
+    classifier_params: Dict[Text, Any],
+    create_train_load_and_process_diet: Callable[..., Message],
 ):
-    pipeline = as_pipeline(
-        "WhitespaceTokenizer", "CountVectorsFeaturizer", "DIETClassifier"
-    )
-    assert pipeline[2]["name"] == "DIETClassifier"
-    pipeline[2].update(classifier_params)
-
-    _config = RasaNLUModelConfig({"pipeline": pipeline, "language": "en"})
-
-    (trainer, trained, persisted_path) = await rasa.nlu.train.train(
-        _config,
-        path=tmpdir.strpath,
-        data="data/test/demo-rasa-composite-entities.yml",
-        component_builder=component_builder,
+    create_train_load_and_process_diet(
+        classifier_params,
+        training_data="data/test/demo-rasa-composite-entities.yml",
+        message_text="I am looking for an italian restaurant",
     )
 
-    assert trainer.pipeline
-    assert trained.pipeline
 
-    loaded = Interpreter.load(persisted_path, component_builder)
-
-    assert loaded.pipeline
-    text = "I am looking for an italian restaurant"
-    assert loaded.parse(text) == trained.parse(text)
-
-
+@pytest.mark.parametrize("should_add_diagnostic_data", [True, False])
 async def test_process_gives_diagnostic_data(
-    response_selector_interpreter: Interpreter,
+    create_train_load_and_process_diet: Callable[..., Message],
+    default_execution_context: ExecutionContext,
+    should_add_diagnostic_data: bool,
 ):
-    """Tests if processing a message returns attention weights as numpy array."""
-    interpreter = response_selector_interpreter
-    message = Message(data={TEXT: "hello"})
-    for component in interpreter.pipeline:
-        component.process(message)
+    default_execution_context.should_add_diagnostic_data = should_add_diagnostic_data
+    processed_message = create_train_load_and_process_diet({EPOCHS: 1})
 
-    diagnostic_data = message.get(DIAGNOSTIC_DATA)
+    if should_add_diagnostic_data:
+        # Tests if processing a message returns attention weights as numpy array.
+        diagnostic_data = processed_message.get(DIAGNOSTIC_DATA)
 
-    # The last component is DIETClassifier, which should add attention weights
-    name = f"component_{len(interpreter.pipeline) - 2}_DIETClassifier"
-    assert isinstance(diagnostic_data, dict)
-    assert name in diagnostic_data
-    assert "attention_weights" in diagnostic_data[name]
-    assert isinstance(diagnostic_data[name].get("attention_weights"), np.ndarray)
-    assert "text_transformed" in diagnostic_data[name]
-    assert isinstance(diagnostic_data[name].get("text_transformed"), np.ndarray)
+        # DIETClassifier should add attention weights
+        name = "DIETClassifier"
+        assert isinstance(diagnostic_data, dict)
+        assert name in diagnostic_data
+        assert "attention_weights" in diagnostic_data[name]
+        assert isinstance(diagnostic_data[name].get("attention_weights"), np.ndarray)
+        assert "text_transformed" in diagnostic_data[name]
+        assert isinstance(diagnostic_data[name].get("text_transformed"), np.ndarray)
+    else:
+        assert DIAGNOSTIC_DATA not in processed_message.data
 
 
 @pytest.mark.parametrize(
@@ -815,16 +667,20 @@ def test_removing_label_sparse_feature_sizes(
     label_attribute: Text,
 ):
     """Tests if label attribute is removed from sparse feature sizes collection."""
-    sparse_feature_sizes = DIETClassifier._remove_label_sparse_feature_sizes(
+    feature_sizes = DIETClassifier._remove_label_sparse_feature_sizes(
         sparse_feature_sizes=initial_sparse_feature_sizes,
         label_attribute=label_attribute,
     )
-    assert sparse_feature_sizes == final_sparse_feature_sizes
+    assert feature_sizes == final_sparse_feature_sizes
 
 
 @pytest.mark.timeout(120)
 async def test_adjusting_layers_incremental_training(
-    component_builder: ComponentBuilder, tmpdir: Path
+    create_diet: Callable[..., DIETClassifier],
+    train_load_and_process_diet: Callable[..., Message],
+    default_model_storage: ModelStorage,
+    default_execution_context: ExecutionContext,
+    default_diet_resource: Resource,
 ):
     """Tests adjusting sparse layers of `DIETClassifier` to increased sparse
        feature sizes during incremental training.
@@ -847,27 +703,20 @@ async def test_adjusting_layers_incremental_training(
             "min_ngram": 1,
             "max_ngram": 4,
         },
-        {"name": "DIETClassifier", EPOCHS: 1},
     ]
-    _config = RasaNLUModelConfig({"pipeline": pipeline, "language": "en"})
+    classifier = create_diet({EPOCHS: 1})
+    processed_message = train_load_and_process_diet(
+        classifier, pipeline=pipeline, training_data=iter1_data_path,
+    )
 
-    (_, trained, persisted_path) = await rasa.nlu.train.train(
-        _config,
-        path=str(tmpdir),
-        data=iter1_data_path,
-        component_builder=component_builder,
+    old_data_signature = classifier.model.data_signature
+    old_predict_data_signature = classifier.model.predict_data_signature
+    old_sparse_feature_sizes = processed_message.get_sparse_feature_sizes(
+        attribute=TEXT
     )
-    assert trained.pipeline
-    old_data_signature = trained.pipeline[-1].model.data_signature
-    old_predict_data_signature = trained.pipeline[-1].model.predict_data_signature
-    message = Message.build(text="Rasa is great!")
-    trained.featurize_message(message)
-    old_sparse_feature_sizes = message.get_sparse_feature_sizes(attribute=TEXT)
-    initial_diet_layers = (
-        trained.pipeline[-1]
-        .model._tf_layers["sequence_layer.text"]
-        ._tf_layers["feature_combining"]
-    )
+    initial_diet_layers = classifier.model._tf_layers["sequence_layer.text"]._tf_layers[
+        "feature_combining"
+    ]
     initial_diet_sequence_layer = initial_diet_layers._tf_layers[
         "sparse_dense.sequence"
     ]._tf_layers["sparse_to_dense"]
@@ -884,27 +733,20 @@ async def test_adjusting_layers_incremental_training(
         old_sparse_feature_sizes[FEATURE_TYPE_SENTENCE]
     )
 
-    loaded = Interpreter.load(persisted_path, component_builder, new_config=_config,)
-    assert loaded.pipeline
-    assert loaded.parse("Rasa is great!") == trained.parse("Rasa is great!")
-    (_, trained, _) = await rasa.nlu.train.train(
-        _config,
-        path=str(tmpdir),
-        data=iter2_data_path,
-        component_builder=component_builder,
-        model_to_finetune=loaded,
+    default_execution_context.is_finetuning = True
+    finetune_classifier = create_diet({EPOCHS: 1}, load=True)
+    assert finetune_classifier.finetune_mode
+    processed_message_finetuned = train_load_and_process_diet(
+        finetune_classifier, pipeline=pipeline, training_data=iter2_data_path,
     )
-    assert trained.pipeline
 
-    message = Message.build(text="Rasa is great!")
-    trained.featurize_message(message)
-    new_sparse_feature_sizes = message.get_sparse_feature_sizes(attribute=TEXT)
-
-    final_diet_layers = (
-        trained.pipeline[-1]
-        .model._tf_layers["sequence_layer.text"]
-        ._tf_layers["feature_combining"]
+    new_sparse_feature_sizes = processed_message_finetuned.get_sparse_feature_sizes(
+        attribute=TEXT
     )
+
+    final_diet_layers = finetune_classifier.model._tf_layers[
+        "sequence_layer.text"
+    ]._tf_layers["feature_combining"]
     final_diet_sequence_layer = final_diet_layers._tf_layers[
         "sparse_dense.sequence"
     ]._tf_layers["sparse_to_dense"]
@@ -921,8 +763,8 @@ async def test_adjusting_layers_incremental_training(
         new_sparse_feature_sizes[FEATURE_TYPE_SENTENCE]
     )
     # check if the data signatures were correctly updated
-    new_data_signature = trained.pipeline[-1].model.data_signature
-    new_predict_data_signature = trained.pipeline[-1].model.predict_data_signature
+    new_data_signature = finetune_classifier.model.data_signature
+    new_predict_data_signature = finetune_classifier.model.predict_data_signature
     iter2_data = load_data(iter2_data_path)
     expected_sequence_lengths = len(iter2_data.training_examples)
 
@@ -993,8 +835,9 @@ async def test_sparse_feature_sizes_decreased_incremental_training(
     iter1_path: Text,
     iter2_path: Text,
     should_raise_exception: bool,
-    component_builder: ComponentBuilder,
-    tmpdir: Path,
+    create_diet: Callable[..., DIETClassifier],
+    train_load_and_process_diet: Callable[..., Message],
+    default_execution_context: ExecutionContext,
 ):
     pipeline = [
         {"name": "WhitespaceTokenizer"},
@@ -1007,34 +850,25 @@ async def test_sparse_feature_sizes_decreased_incremental_training(
             "min_ngram": 1,
             "max_ngram": 4,
         },
-        {"name": "DIETClassifier", EPOCHS: 1},
     ]
-    _config = RasaNLUModelConfig({"pipeline": pipeline, "language": "en"})
 
-    (_, trained, persisted_path) = await rasa.nlu.train.train(
-        _config, path=str(tmpdir), data=iter1_path, component_builder=component_builder,
+    classifier = create_diet({EPOCHS: 1})
+    assert not classifier.finetune_mode
+    train_load_and_process_diet(
+        classifier, pipeline=pipeline, training_data=iter1_path,
     )
-    assert trained.pipeline
 
-    loaded = Interpreter.load(persisted_path, component_builder, new_config=_config,)
-    assert loaded.pipeline
-    assert loaded.parse("Rasa is great!") == trained.parse("Rasa is great!")
+    default_execution_context.is_finetuning = True
+    finetune_classifier = create_diet({EPOCHS: 1}, load=True)
+    assert finetune_classifier.finetune_mode
+
     if should_raise_exception:
         with pytest.raises(Exception) as exec_info:
-            (_, trained, _) = await rasa.nlu.train.train(
-                _config,
-                path=str(tmpdir),
-                data=iter2_path,
-                component_builder=component_builder,
-                model_to_finetune=loaded,
+            train_load_and_process_diet(
+                finetune_classifier, pipeline=pipeline, training_data=iter2_path,
             )
         assert "Sparse feature sizes have decreased" in str(exec_info.value)
     else:
-        (_, trained, _) = await rasa.nlu.train.train(
-            _config,
-            path=str(tmpdir),
-            data=iter2_path,
-            component_builder=component_builder,
-            model_to_finetune=loaded,
+        train_load_and_process_diet(
+            finetune_classifier, pipeline=pipeline, training_data=iter2_path,
         )
-        assert trained.pipeline

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -625,6 +625,7 @@ async def test_process_gives_diagnostic_data(
     should_add_diagnostic_data: bool,
 ):
     default_execution_context.should_add_diagnostic_data = should_add_diagnostic_data
+    default_execution_context.node_name = "DIETClassifier_node_name"
     processed_message = create_train_load_and_process_diet({EPOCHS: 1})
 
     if should_add_diagnostic_data:
@@ -632,7 +633,7 @@ async def test_process_gives_diagnostic_data(
         diagnostic_data = processed_message.get(DIAGNOSTIC_DATA)
 
         # DIETClassifier should add attention weights
-        name = "DIETClassifierGraphComponent"
+        name = "DIETClassifier_node_name"
         assert isinstance(diagnostic_data, dict)
         assert name in diagnostic_data
         assert "attention_weights" in diagnostic_data[name]
@@ -678,9 +679,7 @@ def test_removing_label_sparse_feature_sizes(
 async def test_adjusting_layers_incremental_training(
     create_diet: Callable[..., DIETClassifier],
     train_load_and_process_diet: Callable[..., Message],
-    default_model_storage: ModelStorage,
     default_execution_context: ExecutionContext,
-    default_diet_resource: Resource,
 ):
     """Tests adjusting sparse layers of `DIETClassifier` to increased sparse
        feature sizes during incremental training.

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -97,7 +97,6 @@ def create_train_load_and_process_diet(
         training_data: str = nlu_data_path,
         message_text: Text = "Rasa is great!",
         expect_intent: bool = True,
-        load_in_finetune_mode: bool = False,
     ) -> Message:
         diet = create_diet(diet_config)
         return train_load_and_process_diet(
@@ -106,7 +105,6 @@ def create_train_load_and_process_diet(
             training_data=training_data,
             message_text=message_text,
             expect_intent=expect_intent,
-            load_in_finetune_mode=load_in_finetune_mode,
         )
 
     return inner
@@ -126,7 +124,6 @@ def train_load_and_process_diet(
         training_data: str = nlu_data_path,
         message_text: Text = "Rasa is great!",
         expect_intent: bool = True,
-        load_in_finetune_mode: bool = False,
     ) -> Message:
 
         if not pipeline:
@@ -159,9 +156,7 @@ def train_load_and_process_diet(
         if expect_intent:
             assert classified_message.data["intent"]["name"]
 
-        loaded_diet = create_diet(
-            diet.component_config, load=True, finetune=load_in_finetune_mode
-        )
+        loaded_diet = create_diet(diet.component_config, load=True)
 
         classified_message2 = loaded_diet.process([message2])[0]
 
@@ -298,9 +293,9 @@ def test_model_data_signature_with_entities(
 
 @pytest.mark.skip_on_windows
 @pytest.mark.timeout(120, func_only=True)
-@pytest.mark.parametrize("finetune", [True, False])
 async def test_train_persist_load_with_different_settings_non_windows(
-    create_train_load_and_process_diet: Callable[..., Message], finetune: bool
+    create_train_load_and_process_diet: Callable[..., Message],
+    create_diet: Callable[..., DIETClassifier],
 ):
     pipeline = [
         {
@@ -310,43 +305,44 @@ async def test_train_persist_load_with_different_settings_non_windows(
         },
         {"name": "CountVectorsFeaturizer"},
     ]
-    create_train_load_and_process_diet(
-        {MASKED_LM: True, EPOCHS: 1}, pipeline, load_in_finetune_mode=finetune
-    )
+    config = {MASKED_LM: True, EPOCHS: 1}
+    create_train_load_and_process_diet(config, pipeline)
+    create_diet(config, load=True, finetune=True)
 
 
 @pytest.mark.timeout(120, func_only=True)
-@pytest.mark.parametrize("finetune", [True, False])
 async def test_train_persist_load_with_different_settings(
-    create_train_load_and_process_diet: Callable[..., Message], finetune: bool
+    create_train_load_and_process_diet: Callable[..., Message],
+    create_diet: Callable[..., DIETClassifier],
 ):
-    create_train_load_and_process_diet(
-        {LOSS_TYPE: "margin", EPOCHS: 1}, load_in_finetune_mode=finetune
-    )
+    config = {LOSS_TYPE: "margin", EPOCHS: 1}
+    create_train_load_and_process_diet(config)
+    create_diet(config, load=True, finetune=True)
 
 
 @pytest.mark.timeout(120, func_only=True)
-@pytest.mark.parametrize("finetune", [True, False])
 async def test_train_persist_load_with_only_entity_recognition(
-    create_train_load_and_process_diet: Callable[..., Message], finetune: bool
+    create_train_load_and_process_diet: Callable[..., Message],
+    create_diet: Callable[..., DIETClassifier],
 ):
+    config = {ENTITY_RECOGNITION: True, INTENT_CLASSIFICATION: False, EPOCHS: 1}
     create_train_load_and_process_diet(
-        {ENTITY_RECOGNITION: True, INTENT_CLASSIFICATION: False, EPOCHS: 1},
+        config,
         training_data="data/examples/rasa/demo-rasa-multi-intent.yml",
         expect_intent=False,
-        load_in_finetune_mode=finetune,
     )
+    create_diet(config, load=True, finetune=True)
 
 
 @pytest.mark.timeout(120, func_only=True)
-@pytest.mark.parametrize("finetune", [True, False])
 async def test_train_persist_load_with_only_intent_classification(
-    create_train_load_and_process_diet: Callable[..., Message], finetune: bool,
+    create_train_load_and_process_diet: Callable[..., Message],
+    create_diet: Callable[..., DIETClassifier],
 ):
     create_train_load_and_process_diet(
         {ENTITY_RECOGNITION: False, INTENT_CLASSIFICATION: True, EPOCHS: 1,},
-        load_in_finetune_mode=finetune,
     )
+    create_diet({MASKED_LM: True, EPOCHS: 1}, load=True, finetune=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -4,7 +4,7 @@ import pytest
 
 from rasa.shared.nlu.constants import TEXT, SPLIT_ENTITIES_BY_COMMA
 from rasa.shared.nlu.training_data.message import Message
-from rasa.nlu.extractors.extractor import EntityExtractor
+from rasa.nlu.extractors.extractor import EntityExtractorMixin as EntityExtractor
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.shared.nlu.training_data.formats import MarkdownReader
 

--- a/tests/nlu/selectors/test_selectors.py
+++ b/tests/nlu/selectors/test_selectors.py
@@ -40,7 +40,10 @@ from rasa.shared.constants import DIAGNOSTIC_DATA
 from rasa.nlu.selectors.response_selector import ResponseSelector
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data.training_data import TrainingData
-from tests.nlu.classifiers.test_diet_classifier import as_pipeline
+
+
+def as_pipeline(*components):
+    return [{"name": c} for c in components]
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -131,7 +131,7 @@ def test_find_unavailable_packages():
     [
         (Path, "pathlib.Path"),
         (Agent, "rasa.core.agent.Agent"),
-        (DIETClassifier, "rasa.nlu.classifiers.diet_classifier.DIETClassifier"),
+        (DIETClassifier, "rasa.nlu.classifiers._diet_classifier.DIETClassifier"),
     ],
 )
 def test_module_path_from_class(clazz: Type, module_path: Text):


### PR DESCRIPTION
**Proposed changes**:
fix #9275 

This the equivalent of #9306 but for the `DIETClassifier`

Adapted classes:
* ~`Component` -> `NLUGraphComponent`~
  * ~New graph component interface for nlu components~
  * ~Lots of code is deleted~
  * ~Methods changed to match `GraphComponent` interface~
* ~`IntentClassifier` -> `IntentClassifierGraphComponent`~
  * ~New (empty) base class for all intent classifiers~
* `EntityExtractor` -> ~`EntityExtractorGraphComponent`~ `EntityExtractorMixin`
  * ~New base class for all entity classifiers~ Now just a container for some shared functionality.
  * only small changes
* `DIETClassifier` -> `DIETClassifierGraphComponent`
  * adapt `create` and `load` functions to new signatures 
  * adapt default config
  * adapt `required_packages` and `supported_languages`  
  * adapt persistence
  * support multiple messages in `process` (**make sure to handle empty messages**)

- All the tests in `test_diet_classifier.py` had to be changed so as to not use the component_builder/train methods. Helper fixtures are added to do the pre-processing required (tokenizing and featurization).

**Things you shouldn't have a look at** ⛔ 
- please don't have a look at the modules prefixed with `_` as they only contain the old but duplicated code
