### PR TITLE
Removed RegexInterpreter as a Default when NLU Interpreter Created

### DIFF
--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -171,7 +171,9 @@ def _create_from_endpoint_config(
 ) -> rasa.shared.nlu.interpreter.NaturalLanguageInterpreter:
     """Instantiate a natural language interpreter based on its configuration."""
 
-    if endpoint_config.type is None or endpoint_config.type.lower() == "http":
+    if endpoint_config and (
+        endpoint_config.type is None or endpoint_config.type.lower() == "http"
+    ):
         return RasaNLUHttpInterpreter(endpoint_config=endpoint_config)
     else:
         return _load_from_module_name_in_endpoint_config(endpoint_config)

--- a/rasa/core/interpreter.py
+++ b/rasa/core/interpreter.py
@@ -171,9 +171,7 @@ def _create_from_endpoint_config(
 ) -> rasa.shared.nlu.interpreter.NaturalLanguageInterpreter:
     """Instantiate a natural language interpreter based on its configuration."""
 
-    if endpoint_config is None:
-        return rasa.shared.nlu.interpreter.RegexInterpreter()
-    elif endpoint_config.type is None or endpoint_config.type.lower() == "http":
+    if endpoint_config.type is None or endpoint_config.type.lower() == "http":
         return RasaNLUHttpInterpreter(endpoint_config=endpoint_config)
     else:
         return _load_from_module_name_in_endpoint_config(endpoint_config)


### PR DESCRIPTION
**Proposed changes**:
- Removed use of RegexInterpreter as the default interpreter when endpoint config is `None`
- Closes #9319  

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
