### PR TITLE
Porting GH template to latest release branch

### DIFF
--- a/.github/PULL_REQUEST_AUTOMATIC_TEMPLATE.md
+++ b/.github/PULL_REQUEST_AUTOMATIC_TEMPLATE.md
@@ -1,0 +1,6 @@
+:auto_rickshaw: This PR should be merged automatically once it has been approved. If it doesn't happen:
+- [ ] Handle merge conflicts
+- [ ] Fix build errors
+
+
+:bulb: It has been opened automatically after changes were merged in a feature branch.


### PR DESCRIPTION
**Proposed changes**:
- This template already exists on `main` but it's needed in `2.8.x` so that the automatic backmerge workflows succeed,
- Example failure [here](https://github.com/RasaHQ/rasa/runs/3372722142?check_suite_focus=true)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
