### PR TITLE
`hide_rule_turn` should default to `False` when `ActionExecuted` is deserialised.

### DIFF
--- a/changelog/9490.bugfix.md
+++ b/changelog/9490.bugfix.md
@@ -1,0 +1,1 @@
+Fixes bug where `hide_rule_turn` was defaulting to `None` when ActionExecuted was deserialised.

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -1562,7 +1562,7 @@ class ActionExecuted(Event):
                 parameters.get("timestamp"),
                 parameters.get("metadata"),
                 parameters.get("action_text"),
-                parameters.get("hide_rule_turn"),
+                parameters.get("hide_rule_turn", False),
             )
         ]
 

--- a/tests/shared/core/test_events.py
+++ b/tests/shared/core/test_events.py
@@ -167,9 +167,7 @@ def test_json_parse_action_executed_with_no_hide_rule():
         "timestamp": None,
     }
     deserialised: ActionExecuted = Event.from_parameters(evt)
-    expected = ActionExecuted(
-        "action_listen",
-    )
+    expected = ActionExecuted("action_listen",)
     assert deserialised == expected
     assert deserialised.hide_rule_turn == expected.hide_rule_turn
 

--- a/tests/shared/core/test_events.py
+++ b/tests/shared/core/test_events.py
@@ -158,6 +158,22 @@ def test_json_parse_user():
     )
 
 
+def test_json_parse_action_executed_with_no_hide_rule():
+    evt = {
+        "event": "action",
+        "name": "action_listen",
+        "policy": None,
+        "confidence": None,
+        "timestamp": None,
+    }
+    deserialised: ActionExecuted = Event.from_parameters(evt)
+    expected = ActionExecuted(
+        "action_listen",
+    )
+    assert deserialised == expected
+    assert deserialised.hide_rule_turn == expected.hide_rule_turn
+
+
 def test_json_parse_bot():
     evt = {"event": "bot", "text": "Hey there!", "data": {}}
     assert Event.from_parameters(evt) == BotUttered("Hey there!", {})


### PR DESCRIPTION
**Proposed changes**:
fix #9490

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
