### PR TITLE
fix circular import for YAMLStoryReader/Writer

### DIFF
--- a/rasa/shared/data.py
+++ b/rasa/shared/data.py
@@ -5,10 +5,6 @@ import uuid
 from pathlib import Path
 from typing import Text, Optional, Union, List, Callable, Set, Iterable
 
-from rasa.shared.core.training_data.story_reader.yaml_story_reader import (
-    YAMLStoryReader,
-)
-
 YAML_FILE_EXTENSIONS = [".yml", ".yaml"]
 JSON_FILE_EXTENSIONS = [".json"]
 TRAINING_DATA_EXTENSIONS = set(JSON_FILE_EXTENSIONS + YAML_FILE_EXTENSIONS)
@@ -52,6 +48,10 @@ def get_core_directory(paths: Optional[Union[Text, List[Text]]]) -> Text:
     Returns:
         Path to temporary directory containing all found Core training files.
     """
+    from rasa.shared.core.training_data.story_reader.yaml_story_reader import (
+        YAMLStoryReader,
+    )
+
     core_files = get_data_files(paths, YAMLStoryReader.is_stories_file)
     return _copy_files_to_new_dir(core_files)
 


### PR DESCRIPTION
**Proposed changes**:
- fix circular import when doing `from rasa.shared.core.training_data.story_writer.yaml_story_writer import YAMLStoryWriter`
- [see Slack](https://rasa-hq.slack.com/archives/C8LEHMTAM/p1631040070251200)

```
In [1]: from rasa.shared.core.training_data.story_writer.yaml_story_writer import YAMLStoryWriter
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-b1dfec1f0224> in <module>
----> 1 from rasa.shared.core.training_data.story_writer.yaml_story_writer import YAMLStoryWriter

~/Workspace/stack/rasa/shared/core/training_data/story_writer/yaml_story_writer.py in <module>
     26 )
     27
---> 28 from rasa.shared.core.training_data.story_reader.yaml_story_reader import (
     29     KEY_STORIES,
     30     KEY_STORY_NAME,

~/Workspace/stack/rasa/shared/core/training_data/story_reader/yaml_story_reader.py in <module>
      4 from typing import Dict, Text, List, Any, Optional, Union, Tuple
      5
----> 6 import rasa.shared.data
      7 from rasa.shared.core.slots import TextSlot, ListSlot
      8 from rasa.shared.exceptions import YamlException

~/Workspace/stack/rasa/shared/data.py in <module>
      6 from typing import Text, Optional, Union, List, Callable, Set, Iterable
      7
----> 8 from rasa.shared.core.training_data.story_reader.yaml_story_reader import (
      9     YAMLStoryReader,
     10 )

ImportError: cannot import name 'YAMLStoryReader' from partially initialized module 'rasa.shared.core.training_data.story_reader.yaml_story_reader' (most likely due to a circular import) (/Users/tobiaswochinger/Workspace/stack/rasa/shared/core/training_data/story_reader/yaml_story_reader.py)
```

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
