### PR TITLE
Adapt `slot.py` and `domain.py` to accept global slot mappings

### DIFF
--- a/data/test_domains/conditional_response_variations.yml
+++ b/data/test_domains/conditional_response_variations.yml
@@ -12,8 +12,12 @@ slots:
     values:
       - primary
       - secondary
+    mappings:
+      - type: from_text
   can_withdraw:
     type: bool
+    mappings:
+      - type: custom
 
 responses:
   utter_withdraw:

--- a/data/test_domains/conditional_response_variations.yml
+++ b/data/test_domains/conditional_response_variations.yml
@@ -13,7 +13,7 @@ slots:
       - primary
       - secondary
     mappings:
-      - type: from_text
+      - type: custom
   can_withdraw:
     type: bool
     mappings:

--- a/data/test_domains/default.yml
+++ b/data/test_domains/default.yml
@@ -6,8 +6,12 @@ intents:
 slots:
   cuisine:
     type: text
+    mappings:
+      - type: from_text
   location:
     type: text
+    mappings:
+      - type: from_text
 
 entities:
  - name

--- a/data/test_domains/default.yml
+++ b/data/test_domains/default.yml
@@ -7,14 +7,18 @@ slots:
   cuisine:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: cuisine
   location:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: location
 
 entities:
  - name
+ - cuisine
+ - location
 
 responses:
   utter_greet:

--- a/data/test_domains/default_with_mapping.yml
+++ b/data/test_domains/default_with_mapping.yml
@@ -9,14 +9,18 @@ slots:
   cuisine:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: cuisine
   location:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: location
 
 entities:
  - name
+ - cuisine
+ - location
 
 responses:
   utter_greet:

--- a/data/test_domains/default_with_mapping.yml
+++ b/data/test_domains/default_with_mapping.yml
@@ -8,8 +8,12 @@ intents:
 slots:
   cuisine:
     type: text
+    mappings:
+      - type: from_text
   location:
     type: text
+    mappings:
+      - type: from_text
 
 entities:
  - name

--- a/data/test_domains/default_with_slots.yml
+++ b/data/test_domains/default_with_slots.yml
@@ -37,6 +37,4 @@ responses:
 forms:
   some_form:
     required_slots:
-      name:
-      - type: from_entity
-        entity: name
+      - name

--- a/data/test_domains/default_with_slots.yml
+++ b/data/test_domains/default_with_slots.yml
@@ -17,6 +17,9 @@ entities:
 slots:
   name:
     type: text
+    mappings:
+      - type: from_entity
+        entity: name
 
 responses:
   utter_greet:

--- a/data/test_domains/domain_with_categorical_slot.yml
+++ b/data/test_domains/domain_with_categorical_slot.yml
@@ -4,6 +4,8 @@ slots:
     values:
       - value_one
       - value_two
+    mappings:
+      - type: from_text
 
 responses:
   utter_greet:

--- a/data/test_domains/domain_with_categorical_slot.yml
+++ b/data/test_domains/domain_with_categorical_slot.yml
@@ -5,7 +5,7 @@ slots:
       - value_one
       - value_two
     mappings:
-      - type: from_text
+      - type: custom
 
 responses:
   utter_greet:

--- a/data/test_domains/duplicate_actions.yml
+++ b/data/test_domains/duplicate_actions.yml
@@ -6,8 +6,12 @@ intents:
 slots:
   cuisine:
     type: text
+    mappings:
+      - type: from_text
   location:
     type: text
+    mappings:
+      - type: from_text
 
 entities:
  - name

--- a/data/test_domains/duplicate_actions.yml
+++ b/data/test_domains/duplicate_actions.yml
@@ -7,14 +7,18 @@ slots:
   cuisine:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: cuisine
   location:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: location
 
 entities:
  - name
+ - cuisine
+ - location
 
 responses:
   utter_greet:

--- a/data/test_domains/duplicate_entities.yml
+++ b/data/test_domains/duplicate_entities.yml
@@ -9,15 +9,19 @@ slots:
   cuisine:
     type: text
     mappings:
-    - type: from_text
+      - type: from_entity
+        entity: cuisine
   location:
     type: text
     mappings:
-    - type: from_text
+      - type: from_entity
+        entity: location
 
 entities:
  - name
  - name
+ - cuisine
+ - location
 
 responses:
   utter_greet:

--- a/data/test_domains/duplicate_entities.yml
+++ b/data/test_domains/duplicate_entities.yml
@@ -8,8 +8,12 @@ intents:
 slots:
   cuisine:
     type: text
+    mappings:
+    - type: from_text
   location:
     type: text
+    mappings:
+    - type: from_text
 
 entities:
  - name

--- a/data/test_domains/duplicate_intents.yml
+++ b/data/test_domains/duplicate_intents.yml
@@ -8,8 +8,12 @@ intents:
 slots:
   cuisine:
     type: text
+    mappings:
+      - type: from_text
   location:
     type: text
+    mappings:
+      - type: from_text
 
 entities:
  - name

--- a/data/test_domains/duplicate_intents.yml
+++ b/data/test_domains/duplicate_intents.yml
@@ -9,14 +9,18 @@ slots:
   cuisine:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: cuisine
   location:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: cuisine
 
 entities:
  - name
+ - cuisine
+ - location
 
 responses:
   utter_greet:

--- a/data/test_domains/test_domain_from_directory1/domain_valid.yml
+++ b/data/test_domains/test_domain_from_directory1/domain_valid.yml
@@ -8,14 +8,18 @@ slots:
   cuisine:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: cuisine
   location:
     type: text
     mappings:
-      - type: from_text
+      - type: from_entity
+        entity: location
 
 entities:
   - name
+  - cuisine
+  - location
 
 responses:
   utter_greet:

--- a/data/test_domains/test_domain_from_directory1/domain_valid.yml
+++ b/data/test_domains/test_domain_from_directory1/domain_valid.yml
@@ -7,8 +7,12 @@ intents:
 slots:
   cuisine:
     type: text
+    mappings:
+      - type: from_text
   location:
     type: text
+    mappings:
+      - type: from_text
 
 entities:
   - name

--- a/data/test_domains/travel_form.yml
+++ b/data/test_domains/travel_form.yml
@@ -31,7 +31,7 @@ slots:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
 
 responses:
   utter_ask_GPE_origin:

--- a/data/test_domains/travel_form.yml
+++ b/data/test_domains/travel_form.yml
@@ -17,11 +17,21 @@ entities:
 slots:
   GPE_origin:
     type: text
+    mappings:
+    - type: from_entity
+      entity: GPE
+      role: origin
   GPE_destination:
     type: text
+    mappings:
+    - type: from_entity
+      entity: GPE
+      role: destination
   requested_slot:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
 
 responses:
   utter_ask_GPE_origin:

--- a/docs/docs/business-logic.mdx
+++ b/docs/docs/business-logic.mdx
@@ -58,22 +58,35 @@ piece of required information. Slot mappings define both which
 slots are required, and how each slot can be filled:
 
 ```yaml-rasa title="domain.yml"
+entities:
+- cuisine
+- number
+slots:
+  cuisine:
+    type: text
+    mappings:
+    - type: from_entity
+      entity: cuisine
+  num_people:
+    type: float
+    mappings:
+    - type: from_entity
+      entity: number
+  outdoor_seating:
+    type: bool
+    mappings:
+    - type: from_intent
+      intent: affirm
+      value: true
+    - type: from_intent
+      intent: deny
+      value: false
 forms:
   restaurant_form:
     required_slots:
-        cuisine:
-          - type: from_entity
-            entity: cuisine
-        num_people:
-          - type: from_entity
-            entity: number
-        outdoor_seating:
-          - type: from_intent
-            intent: affirm
-            value: true
-          - type: from_intent
-            intent: deny
-            value: false
+        - cuisine
+        - num_people
+        - outdoor_seating
 ```
 
 For any slot filled `from_entity`, the entity needs to be added

--- a/docs/docs/business-logic.mdx
+++ b/docs/docs/business-logic.mdx
@@ -125,21 +125,18 @@ the conversation:
 slots:
   cuisine:
     type: text
-    auto_fill: false
     influence_conversation: false
     mappings:
     - type: from_entity
       entity: cuisine
   num_people:
     type: float
-    auto_fill: false
     influence_conversation: false
     mappings:
     - type: from_entity
       entity: number
   outdoor_seating:
     type: text
-    auto_fill: false
     influence_conversation: false
     mappings:
     - type: from_intent

--- a/docs/docs/business-logic.mdx
+++ b/docs/docs/business-logic.mdx
@@ -127,14 +127,27 @@ slots:
     type: text
     auto_fill: false
     influence_conversation: false
+    mappings:
+    - type: from_entity
+      entity: cuisine
   num_people:
     type: float
     auto_fill: false
     influence_conversation: false
+    mappings:
+    - type: from_entity
+      entity: number
   outdoor_seating:
     type: text
     auto_fill: false
     influence_conversation: false
+    mappings:
+    - type: from_intent
+      intent: affirm
+      value: true
+    - type: from_intent
+      intent: deny
+      value: false
 ```
 
 #### Validating Slots

--- a/docs/docs/contextual-conversations.mdx
+++ b/docs/docs/contextual-conversations.mdx
@@ -52,6 +52,8 @@ You define a slot and its type in the domain:
 slots:
   likes_music:
     type: bool
+    mappings:
+    - type: custom
 ```
 
 ### 2. Creating Stories

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -513,7 +513,6 @@ To disable auto-filling for a particular slot, you can set the
 slots:
   name:
     type: text
-    auto_fill: false
     mappings:
     - type: from_entity
       entity: name

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -182,6 +182,9 @@ information before it is able to predict the weather.
   slots:
      cuisine:
         type: text
+        mappings:
+        - type: from_entity
+          entity: cuisine
   ```
 
 * **Description**
@@ -221,6 +224,8 @@ information before it is able to predict the weather.
   slots:
      is_authenticated:
         type: bool
+        mappings:
+        - type: custom
   ```
 
 * **Description**
@@ -250,6 +255,8 @@ information before it is able to predict the weather.
         - low
         - medium
         - high
+      mappings:
+      - type: custom
   ```
 
 * **Description**
@@ -283,6 +290,8 @@ information before it is able to predict the weather.
       type: float
       min_value: -100.0
       max_value:  100.0
+      mappings:
+      - type: custom
   ```
 
 * **Defaults**
@@ -314,6 +323,8 @@ information before it is able to predict the weather.
   slots:
     shopping_items:
       type: list
+      mappings:
+      - type: custom
   ```
 
 * **Description**
@@ -338,6 +349,8 @@ information before it is able to predict the weather.
   slots:
     shopping_items:
       type: any
+      mappings:
+      - type: custom
   ```
 
 * **Description**
@@ -412,6 +425,8 @@ slots:
   people:
     type: addons.my_custom_slots.NumberOfPeopleSlot
     influence_conversation: true
+    mappings:
+    - type: custom
 ```
 
 Now that your custom slot class can be used by Rasa Open Source, add training stories that diverge based on the value of the `people` slot.
@@ -499,6 +514,9 @@ slots:
   name:
     type: text
     auto_fill: false
+    mappings:
+    - type: from_entity
+      entity: name
 ```
 
 ### Initial slot values
@@ -510,6 +528,8 @@ slots:
   num_fallbacks:
     type: float
     initial_value: 0
+    mappings:
+    - type: custom
 ```
 
 ## Responses

--- a/docs/docs/forms.mdx
+++ b/docs/docs/forms.mdx
@@ -30,15 +30,25 @@ The following example form `restaurant_form` will fill the slot
 `cuisine` from an extracted entity `cuisine` and slot `num_people` from entity `number`.
 
 ```yaml-rasa
+entities:
+- cuisine
+- number
+slots:
+  cuisine:
+    type: text
+    mappings:
+    - type: from_entity
+      entity: cuisine
+  num_people:
+    type: any
+    mappings:
+    - type: from_entity
+      entity: number
 forms:
   restaurant_form:
     required_slots:
-        cuisine:
-          - type: from_entity
-            entity: cuisine
-        num_people:
-          - type: from_entity
-            entity: number
+        - cuisine
+        - num_people
 ```
 
 You can define a list of intents to ignore for the whole form under the 
@@ -50,17 +60,27 @@ the intent is `chitchat`, then you would need to define the following (after the
 name and under the `ignored_intents` keyword):
 
 ```yaml-rasa
+entities:
+- cuisine
+- number
+slots:
+  cuisine:
+    type: text
+    mappings:
+    - type: from_entity
+      entity: cuisine
+  num_people:
+    type: any
+    mappings:
+    - type: from_entity
+      entity: number
 forms:
   restaurant_form:
     ignored_intents: 
     - chitchat
     required_slots:
-        cuisine:
-          - type: from_entity
-            entity: cuisine
-        num_people:
-          - type: from_entity
-            entity: number
+        - cuisine
+        - num_people
 ```
 
 Once the form action gets called for the first time, the form gets activated and will
@@ -140,16 +160,22 @@ apply if the intent of the message is `excluded_intent`. Note that you can
 also define lists of intents for the parameters `intent` and `not_intent`.
 
 ```yaml-rasa
+entities:
+- entity_name
+slots:
+  slot_name:
+    type: any
+    mappings:
+    - type: from_entity
+      entity: entity_name
+      role: role_name
+      group: group name
+      intent: intent_name
+      not_intent: excluded_intent
 forms:
   your_form:
     required_slots:
-        slot_name:
-        - type: from_entity
-          entity: entity_name
-          role: role_name
-          group: group name
-          intent: intent_name
-          not_intent: excluded_intent
+        - slot_name
 ```
 
 In `from_entity` mapping, when an extracted entity uniquely maps onto a slot,
@@ -157,24 +183,34 @@ the slot will be filled even if this slot wasn't requested by the form.
 The extracted entity will be ignored if the mapping is not unique.
 
 ```yaml-rasa
+slots:
+  departure_city:
+    type: text
+    mappings:
+    - type: from_entity
+      entity: city
+      role: from
+    - type: from_entity
+      entity: city
+  arrival_city:
+    type: text
+    mappings:
+    - type: from_entity
+      entity: city
+      role: to
+    - type: from_entity
+      entity: city
+  arrival_date:
+    type: any
+    mappings:
+    - type: from_entity
+      entity: date
 forms:
   your_form:
     required_slots:
-        departure_city:
-          - type: from_entity
-            entity: city
-            role: from
-          - type: from_entity
-            entity: city
-        arrival_city:
-          - type: from_entity
-            entity: city
-            role: to
-          - type: from_entity
-            entity: city
-        arrival_date:
-          - type: from_entity
-            entity: date
+        - departure_city
+        - arrival_city
+        - arrival_date
 ```
 
 In the example above, an entity `date` uniquely sets the slot `arrival_date`,
@@ -197,13 +233,17 @@ The slot mapping will not apply if the intent of the message is `excluded_intent
 Note that you can define lists of intents for the parameters `intent` and `not_intent`.
 
 ```yaml-rasa
+slots:
+  slot_name:
+    type: text
+    mappings:
+    - type: from_text
+      intent: intent_name
+      not_intent: excluded_intent
 forms:
   your_form:
     required_slots:
-        slot_name:
-        - type: from_text
-          intent: intent_name
-          not_intent: excluded_intent
+        - slot_name
 ```
 
 #### from_intent
@@ -220,14 +260,18 @@ mapping.
 :::
 
 ```yaml-rasa
+slots:
+  slot_name:
+    type: any
+    mappings:
+    - type: from_intent
+      value: my_value
+      intent: intent_name
+      not_intent: excluded_intent
 forms:
   your_form:
     required_slots:
-        slot_name:
-        - type: from_intent
-          value: my_value
-          intent: intent_name
-          not_intent: excluded_intent
+        - slot_name
 ```
 
 #### from_trigger_intent
@@ -239,14 +283,18 @@ The slot mapping will not apply if the intent of the message is
 also define lists of intents for the parameters `intent` and `not_intent`.
 
 ```yaml-rasa
+slots:
+  slot_name:
+    type: any
+    mappings:
+    - type: from_trigger_intent
+      value: my_value
+      intent: intent_name
+      not_intent: excluded_intent
 forms:
   your_form:
     required_slots:
-        slot_name:
-        - type: from_trigger_intent
-          value: my_value
-          intent: intent_name
-          not_intent: excluded_intent
+        - slot_name
 ```
 
 ### Writing Stories / Rules for Unhappy Form Paths

--- a/docs/docs/playground.mdx
+++ b/docs/docs/playground.mdx
@@ -151,11 +151,15 @@ You can do this in Rasa using a form. In the code block below, we added the
 <AssistantBuilder.Code>
 
 ```yaml-rasa live noResult assistantBuilder name=forms
+slots:
+  email:
+    type: text
+    mappings:
+    - type: from_text
 forms:
   newsletter_form:
     required_slots:
-      email:
-      - type: from_text
+      - email
 ```
 
 </AssistantBuilder.Code>

--- a/docs/docs/reaching-out-to-user.mdx
+++ b/docs/docs/reaching-out-to-user.mdx
@@ -121,6 +121,9 @@ slots:
   plant:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_entity
+      entity: plant
 ```
 
 #### 5. Add a Rule

--- a/docs/docs/responses.mdx
+++ b/docs/docs/responses.mdx
@@ -178,9 +178,13 @@ slots:
   logged_in:
     type: bool
     influence_conversation: False
+    mappings:
+    - type: custom
   name:
     type: text
     influence_conversation: False
+    mappings:
+    - type: custom
 
 responses:
   utter_greet:
@@ -247,9 +251,13 @@ slots:
   logged_in:
     type: bool
     influence_conversation: False
+    mappings:
+    - type: custom
   name:
     type: text
     influence_conversation: False
+    mappings:
+    - type: custom
 
 responses:
   utter_greet:

--- a/docs/docs/unexpected-input.mdx
+++ b/docs/docs/unexpected-input.mdx
@@ -66,6 +66,8 @@ slots:
       - preferences
       - feedback
     influence_conversation: true
+    mappings:
+    - {}
 ```
 
 This means that the dialogue model will pay attention to the value of the slot when making a prediction

--- a/docs/docs/unexpected-input.mdx
+++ b/docs/docs/unexpected-input.mdx
@@ -67,7 +67,7 @@ slots:
       - feedback
     influence_conversation: true
     mappings:
-    - {}
+    - type: custom
 ```
 
 This means that the dialogue model will pay attention to the value of the slot when making a prediction

--- a/examples/concertbot/domain.yml
+++ b/examples/concertbot/domain.yml
@@ -20,12 +20,18 @@ slots:
   concerts:
     type: list
     influence_conversation: false
+    mappings:
+    - type: custom
   venues:
     type: list
     influence_conversation: false
+    mappings:
+    - type: custom
   likes_music:
     type: bool
     influence_conversation: true
+    mappings:
+    - type: custom
 
 responses:
   utter_greet:

--- a/examples/formbot/domain.yml
+++ b/examples/formbot/domain.yml
@@ -120,32 +120,11 @@ forms:
     ignored_intents:
     - chitchat
     required_slots:
-      cuisine:
-      - type: from_entity
-        entity: cuisine
-      num_people:
-      - type: from_entity
-        entity: number
-        intent: [inform, request_restaurant]
-      outdoor_seating:
-      - type: from_entity
-        entity: seating
-      - type: from_intent
-        intent: affirm
-        value: true
-      - type: from_intent
-        intent: deny
-        value: false
-      preferences:
-      - type: from_intent
-        intent: deny
-        value: no additional preferences
-      - type: from_text
-        not_intent: affirm
-      feedback:
-      - type: from_entity
-        entity: feedback
-      - type: from_text
+      - cuisine
+      - num_people
+      - outdoor_seating
+      - preferences
+      - feedback
 
 session_config:
   session_expiration_time: 60  # value in minutes

--- a/examples/formbot/domain.yml
+++ b/examples/formbot/domain.yml
@@ -22,14 +22,12 @@ slots:
   cuisine:
     type: text
     influence_conversation: false
-    auto_fill: false
     mappings:
     - type: from_entity
       entity: cuisine
   num_people:
     type: float
     influence_conversation: false
-    auto_fill: false
     mappings:
     - type: from_entity
       entity: number
@@ -37,7 +35,6 @@ slots:
   outdoor_seating:
     type: text
     influence_conversation: false
-    auto_fill: false
     mappings:
     - type: from_entity
       entity: seating
@@ -50,7 +47,6 @@ slots:
   preferences:
     type: text
     influence_conversation: false
-    auto_fill: false
     mappings:
     - type: from_intent
       intent: deny
@@ -60,7 +56,6 @@ slots:
   feedback:
     type: text
     influence_conversation: false
-    auto_fill: false
     mappings:
     - type: from_entity
       entity: feedback

--- a/examples/formbot/domain.yml
+++ b/examples/formbot/domain.yml
@@ -23,25 +23,53 @@ slots:
     type: text
     influence_conversation: false
     auto_fill: false
+    mappings:
+    - type: from_entity
+      entity: cuisine
   num_people:
     type: float
     influence_conversation: false
     auto_fill: false
+    mappings:
+    - type: from_entity
+      entity: number
+      intent: [inform, request_restaurant]
   outdoor_seating:
     type: text
     influence_conversation: false
     auto_fill: false
+    mappings:
+    - type: from_entity
+      entity: seating
+    - type: from_intent
+      intent: affirm
+      value: true
+    - type: from_intent
+      intent: deny
+      value: false
   preferences:
     type: text
     influence_conversation: false
     auto_fill: false
+    mappings:
+    - type: from_intent
+      intent: deny
+      value: no additional preferences
+    - type: from_text
+      not_intent: affirm
   feedback:
     type: text
     influence_conversation: false
     auto_fill: false
+    mappings:
+    - type: from_entity
+      entity: feedback
+    - type: from_text
   requested_slot:
     type: text
     influence_conversation: false
+    mappings:
+      - type: from_text
 
 responses:
   utter_ask_cuisine:

--- a/examples/formbot/domain.yml
+++ b/examples/formbot/domain.yml
@@ -69,7 +69,7 @@ slots:
     type: text
     influence_conversation: false
     mappings:
-      - type: from_text
+    - type: from_text
 
 responses:
   utter_ask_cuisine:

--- a/examples/knowledgebasebot/domain.yml
+++ b/examples/knowledgebasebot/domain.yml
@@ -20,37 +20,37 @@ slots:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
   mention:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
   attribute:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
   hotel:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
   restaurant:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
   city:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
   cuisine:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: custom
 
 actions:
 - action_query_knowledge_base

--- a/examples/knowledgebasebot/domain.yml
+++ b/examples/knowledgebasebot/domain.yml
@@ -19,24 +19,38 @@ slots:
   object_type:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
   mention:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
   attribute:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
   hotel:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
   restaurant:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
   city:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
   cuisine:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
 
 actions:
 - action_query_knowledge_base

--- a/examples/reminderbot/domain.yml
+++ b/examples/reminderbot/domain.yml
@@ -19,6 +19,8 @@ slots:
   PERSON:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_text
 responses:
   utter_what_can_do:
   - text: What can I do for you?

--- a/examples/reminderbot/domain.yml
+++ b/examples/reminderbot/domain.yml
@@ -20,7 +20,8 @@ slots:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_text
+    - type: from_entity
+      entity: PERSON
 responses:
   utter_what_can_do:
   - text: What can I do for you?

--- a/examples/rules/domain.yml
+++ b/examples/rules/domain.yml
@@ -20,8 +20,13 @@ slots:
   some_slot:
     type: text
     influence_conversation: false
+    mappings:
+    - type: from_entity
+      entity: some_slot
   detailed_faq:
     type: bool
+    mappings:
+    - type: custom
 
 actions:
 - utter_explain_some_slot

--- a/examples/rules/domain.yml
+++ b/examples/rules/domain.yml
@@ -21,8 +21,21 @@ slots:
     type: text
     influence_conversation: false
     mappings:
-    - type: from_entity
-      entity: some_slot
+      # Slot mappings can be defined in the domain.
+      # You can also implement custom slot mappings in your validate function for the
+      # `Form` by returning the desired slot events.
+      # The slot mappings follow the same syntax as currently in the SDK implementation.
+      - type: from_entity
+        entity: some_slot
+      # Example of a slot mapping which extracts the slot value from the message text if
+      # the intent is `greet`.
+      # - type: from_text
+      #   intent: greet
+      # Example of a slot mapping which sets the slot to `my value` in case the message
+      # has an intent `greet`
+      # - type: from_intent
+      #   intent: greet
+      #   value: "my value"
   detailed_faq:
     type: bool
     mappings:
@@ -50,22 +63,7 @@ actions:
 forms:
   loop_q_form:
     required_slots:
-      some_slot:
-      # Slot mappings can be defined in the domain.
-      # You can also implement custom slot mappings in your validate function for the
-      # `Form` by returning the desired slot events.
-      # The slot mappings follow the same syntax as currently in the SDK implementation.
-      - type: from_entity
-        entity: some_slot
-      # Example of a slot mapping which extracts the slot value from the message text if
-      # the intent is `greet`.
-      # - type: from_text
-      #   intent: greet
-      # Example of a slot mapping which sets the slot to `my value` in case the message
-      # has an intent `greet`
-      # - type: from_intent
-      #   intent: greet
-      #   value: "my value"
+      - some_slot
 
 session_config:
   session_expiration_time: 60  # value in minutes

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1239,9 +1239,9 @@ class Domain:
                     for entity in entities
                     if any(
                         [
-                            entity.get("entity")
-                            == mapping.get("entity", "no_entity_found")
+                            entity.get("entity") == mapping.get("entity")
                             for mapping in slot.mappings
+                            if mapping.get("type") == "from_entity"
                         ]
                     )
                 ]
@@ -1755,15 +1755,6 @@ class Domain:
 
         return any(key in content for key in ALL_DOMAIN_KEYS)
 
-    def slot_mapping_for_form(self, form_name: Text) -> List[Text]:
-        """Deprecated method in 3.0."""
-        rasa.shared.utils.io.raise_deprecation_warning(
-            "Slot mappings defined in the form section of the domain have been "
-            "deprecated in 3.0.0.",
-            "4.0.0",
-        )
-        return self.required_slots_for_form(form_name)
-
     def required_slots_for_form(self, form_name: Text) -> List[Text]:
         """Retrieve the list of required slot names for a form defined in the domain.
 
@@ -1976,7 +1967,7 @@ def _validate_slot_mappings(domain_slots: Dict[Text, Any]) -> None:
     for slot_name, properties in domain_slots.items():
         if not isinstance(properties, dict):
             raise InvalidDomain(
-                f"The properties of slot {slot_name} were specified as "
+                f"The properties of slot '{slot_name}' were specified as "
                 f"'{type(properties)}'. They need to be specified as dictionary."
             )
         mappings = properties.get("mappings")

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -329,9 +329,6 @@ class Domain:
         slot_dict = copy.deepcopy(slot_dict)
         # Don't sort the slots, see https://github.com/RasaHQ/rasa-x/issues/3900
         for slot_name in slot_dict:
-            # remove auto_fill if it exists in the domain
-            slot_dict[slot_name].pop("auto_fill", None)
-
             slot_type = slot_dict[slot_name].pop("type", None)
             slot_class = Slot.resolve_by_type(slot_type)
 

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1224,19 +1224,17 @@ class Domain:
         if self.store_entities_as_slots:
             slot_events = []
             for slot in self.slots:
-                if slot.auto_fill:
-                    matching_entities = [
-                        entity.get("value")
-                        for entity in entities
-                        if entity.get("entity") == slot.name
-                    ]
-                    if matching_entities:
-                        if slot.type_name == "list":
-                            slot_events.append(SlotSet(slot.name, matching_entities))
-                        else:
-                            slot_events.append(
-                                SlotSet(slot.name, matching_entities[-1])
-                            )
+                # if slot.auto_fill:
+                matching_entities = [
+                    entity.get("value")
+                    for entity in entities
+                    if entity.get("entity") == slot.name
+                ]
+                if matching_entities:
+                    if slot.type_name == "list":
+                        slot_events.append(SlotSet(slot.name, matching_entities))
+                    else:
+                        slot_events.append(SlotSet(slot.name, matching_entities[-1]))
             return slot_events
         else:
             return []
@@ -1429,8 +1427,8 @@ class Domain:
         for slot in domain_data[KEY_SLOTS].values():
             if slot["initial_value"] is None:
                 del slot["initial_value"]
-            if slot["auto_fill"]:
-                del slot["auto_fill"]
+            # if slot["auto_fill"]:
+            del slot["auto_fill"]
             if slot["type"].startswith("rasa.shared.core.slots"):
                 slot["type"] = Slot.resolve_by_type(slot["type"]).type_name
 

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -790,6 +790,7 @@ class Domain:
             self.slots.append(
                 TextSlot(
                     rasa.shared.core.constants.REQUESTED_SLOT,
+                    mappings=[{}],
                     influence_conversation=False,
                 )
             )
@@ -820,11 +821,15 @@ class Domain:
             ]
             for slot in knowledge_base_slots:
                 if slot not in slot_names:
-                    self.slots.append(TextSlot(slot, influence_conversation=False))
+                    self.slots.append(
+                        TextSlot(slot, mappings=[{}], influence_conversation=False)
+                    )
 
     def _add_session_metadata_slot(self) -> None:
         self.slots.append(
-            AnySlot(rasa.shared.core.constants.SESSION_START_METADATA_SLOT,)
+            AnySlot(
+                rasa.shared.core.constants.SESSION_START_METADATA_SLOT, mappings=[{}]
+            )
         )
 
     def index_for_action(self, action_name: Text) -> int:

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -329,6 +329,9 @@ class Domain:
         slot_dict = copy.deepcopy(slot_dict)
         # Don't sort the slots, see https://github.com/RasaHQ/rasa-x/issues/3900
         for slot_name in slot_dict:
+            # remove auto_fill if it exists in the domain
+            slot_dict[slot_name].pop("auto_fill", None)
+
             slot_type = slot_dict[slot_name].pop("type", None)
             slot_class = Slot.resolve_by_type(slot_type)
 
@@ -1432,8 +1435,6 @@ class Domain:
         for slot in domain_data[KEY_SLOTS].values():
             if slot["initial_value"] is None:
                 del slot["initial_value"]
-            # if slot["auto_fill"]:
-            del slot["auto_fill"]
             if slot["type"].startswith("rasa.shared.core.slots"):
                 slot["type"] = Slot.resolve_by_type(slot["type"]).type_name
 
@@ -1956,6 +1957,14 @@ def _validate_slot_mappings(domain_slots: Dict[Text, Any]) -> None:
             f"Slots were specified as '{type(domain_slots)}'. "
             f"They need to be specified as dictionary."
         )
+
+    rasa.shared.utils.io.raise_warning(
+        "Slot auto-fill has been removed in 3.0 and replaced by a"
+        " new explicit mechanism to set slots. "
+        "Please refer to the docs to learn more.",
+        UserWarning,
+        DOCS_URL_SLOTS,
+    )
 
     for slot_name, properties in domain_slots.items():
         if not isinstance(properties, dict):

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1942,7 +1942,10 @@ def _validate_forms(forms: Union[Dict, List], domain_slots: Dict[Text, Any]) -> 
 
         for slot in form_slots:
             if slot not in domain_slots:
-                raise InvalidDomain(f"The slot '{slot}' is not mapped in domain slots.")
+                raise InvalidDomain(
+                    f"The slot '{slot}' in form '{form_name}' is not "
+                    f"mapped in domain slots."
+                )
 
 
 def _validate_slot_mappings(domain_slots: Dict[Text, Any]) -> None:

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1239,7 +1239,8 @@ class Domain:
                     for entity in entities
                     if any(
                         [
-                            entity.get("entity") == mapping.get("entity", None)
+                            entity.get("entity")
+                            == mapping.get("entity", "no_entity_found")
                             for mapping in slot.mappings
                         ]
                     )

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -30,6 +30,7 @@ from rasa.shared.constants import (
     DOCS_URL_RESPONSES,
     REQUIRED_SLOTS_KEY,
     IGNORED_INTENTS,
+    DOCS_URL_SLOTS,
 )
 import rasa.shared.core.constants
 from rasa.shared.exceptions import RasaException, YamlException, YamlSyntaxException
@@ -1799,7 +1800,7 @@ class SlotMapping(Enum):
             raise InvalidDomain(
                 f"Please make sure that the slot mappings for slot '{slot_name}' in "
                 f"your domain are valid dictionaries. Please see "
-                f"the documentation for more information."
+                f"{DOCS_URL_SLOTS} for more information."
             )
 
         validations = {
@@ -1817,7 +1818,7 @@ class SlotMapping(Enum):
             raise InvalidDomain(
                 f"Your domain uses an invalid slot mapping of type "
                 f"'{mapping_type}' for slot '{slot_name}'. Please see "
-                f"the documentation for more information."
+                f"{DOCS_URL_SLOTS} for more information."
             )
 
         for required_key in required_keys:
@@ -1825,8 +1826,8 @@ class SlotMapping(Enum):
                 raise InvalidDomain(
                     f"You need to specify a value for the key "
                     f"'{required_key}' in the slot mapping of type '{mapping_type}' "
-                    f"for slot '{slot_name}'. Please see the "
-                    f"documentation for more information."
+                    f"for slot '{slot_name}'. Please see "
+                    f"{DOCS_URL_SLOTS} for more information."
                 )
 
     @staticmethod
@@ -1848,8 +1849,9 @@ class SlotMapping(Enum):
                 IGNORED_INTENTS, []
             )
             if not isinstance(form_ignored_intents, list):
-                form_ignored_intents = [form_ignored_intents]
-            ignored_intents.extend(form_ignored_intents)
+                ignored_intents = [form_ignored_intents]
+            else:
+                ignored_intents = form_ignored_intents
 
         return ignored_intents
 

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -30,7 +30,7 @@ class Slot:
         mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
+        auto_fill: bool = False,
         influence_conversation: bool = True,
     ) -> None:
         """Create a Slot.
@@ -51,6 +51,15 @@ class Slot:
         self._value = initial_value
         self.initial_value = initial_value
         self._value_reset_delay = value_reset_delay
+        if auto_fill:
+            rasa.shared.utils.io.raise_deprecation_warning(
+                "Slot auto-fill has been deactivated in 3.0 and replaced by a"
+                " new explicit mechanism to specify slot mappings. "
+                "Please refer to the docs to learn more.",
+                "4.0.0",
+                docs=None,
+            )
+            auto_fill = False
         self.auto_fill = auto_fill
         self.influence_conversation = influence_conversation
         self._has_been_set = False
@@ -145,6 +154,7 @@ class Slot:
             )
 
     def persistence_info(self) -> Dict[str, Any]:
+        """Returns relevant information to persist this slot."""
         return {
             "type": rasa.shared.utils.common.module_path_from_instance(self),
             "initial_value": self.initial_value,
@@ -175,7 +185,7 @@ class FloatSlot(Slot):
         mappings: List[Dict[Text, Any]],
         initial_value: Optional[float] = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
+        auto_fill: bool = False,
         max_value: float = 1.0,
         min_value: float = 0.0,
         influence_conversation: bool = True,
@@ -316,7 +326,7 @@ class CategoricalSlot(Slot):
         values: Optional[List[Any]] = None,
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
+        auto_fill: bool = False,
         influence_conversation: bool = True,
     ) -> None:
         """Creates a `Categorical  Slot` (see parent class for detailed docstring)."""
@@ -407,8 +417,11 @@ class CategoricalSlot(Slot):
 
 
 class AnySlot(Slot):
-    """Slot which can be used to store any value. Users need to create a subclass of
-    `Slot` in case the information is supposed to get featurized."""
+    """Slot which can be used to store any value.
+
+    Users need to create a subclass of `Slot` in case
+    the information is supposed to get featurized.
+    """
 
     type_name = "any"
 
@@ -418,7 +431,7 @@ class AnySlot(Slot):
         mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
+        auto_fill: bool = False,
         influence_conversation: bool = False,
     ) -> None:
         """Creates an `Any  Slot` (see parent class for detailed docstring).

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -30,7 +30,6 @@ class Slot:
         mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
         influence_conversation: bool = True,
     ) -> None:
         """Create a Slot.
@@ -41,8 +40,6 @@ class Slot:
             mappings: List containing slot mappings.
             value_reset_delay: After how many turns the slot should be reset to the
                 initial_value. This is behavior is currently not implemented.
-            auto_fill: `True` if the slot should be filled automatically by entities
-                with the same name.
             influence_conversation: If `True` the slot will be featurized and hence
                 influence the predictions of the dialogue polices.
         """
@@ -51,16 +48,6 @@ class Slot:
         self._value = initial_value
         self.initial_value = initial_value
         self._value_reset_delay = value_reset_delay
-        if auto_fill:
-            rasa.shared.utils.io.raise_deprecation_warning(
-                "Slot auto-fill has been deactivated in 3.0 and replaced by a"
-                " new explicit mechanism to specify slot mappings. "
-                "Please refer to the docs to learn more.",
-                "4.0.0",
-                docs=DOCS_URL_SLOTS,
-            )
-            auto_fill = False
-        self.auto_fill = auto_fill
         self.influence_conversation = influence_conversation
         self._has_been_set = False
 
@@ -158,7 +145,6 @@ class Slot:
         return {
             "type": rasa.shared.utils.common.module_path_from_instance(self),
             "initial_value": self.initial_value,
-            "auto_fill": self.auto_fill,
             "influence_conversation": self.influence_conversation,
             "mappings": self.mappings,
         }
@@ -185,7 +171,6 @@ class FloatSlot(Slot):
         mappings: List[Dict[Text, Any]],
         initial_value: Optional[float] = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
         max_value: float = 1.0,
         min_value: float = 0.0,
         influence_conversation: bool = True,
@@ -197,12 +182,7 @@ class FloatSlot(Slot):
             UserWarning, if initial_value is outside the min-max range.
         """
         super().__init__(
-            name,
-            mappings,
-            initial_value,
-            value_reset_delay,
-            auto_fill,
-            influence_conversation,
+            name, mappings, initial_value, value_reset_delay, influence_conversation,
         )
         self.max_value = max_value
         self.min_value = min_value
@@ -326,17 +306,11 @@ class CategoricalSlot(Slot):
         values: Optional[List[Any]] = None,
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
         influence_conversation: bool = True,
     ) -> None:
         """Creates a `Categorical  Slot` (see parent class for detailed docstring)."""
         super().__init__(
-            name,
-            mappings,
-            initial_value,
-            value_reset_delay,
-            auto_fill,
-            influence_conversation,
+            name, mappings, initial_value, value_reset_delay, influence_conversation,
         )
         if values and None in values:
             rasa.shared.utils.io.raise_warning(
@@ -431,7 +405,6 @@ class AnySlot(Slot):
         mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = True,
         influence_conversation: bool = False,
     ) -> None:
         """Creates an `Any  Slot` (see parent class for detailed docstring).
@@ -449,12 +422,7 @@ class AnySlot(Slot):
             )
 
         super().__init__(
-            name,
-            mappings,
-            initial_value,
-            value_reset_delay,
-            auto_fill,
-            influence_conversation,
+            name, mappings, initial_value, value_reset_delay, influence_conversation,
         )
 
     def __eq__(self, other: Any) -> bool:
@@ -466,6 +434,5 @@ class AnySlot(Slot):
             self.name == other.name
             and self.initial_value == other.initial_value
             and self._value_reset_delay == other._value_reset_delay
-            and self.auto_fill == other.auto_fill
             and self.value == other.value
         )

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -30,7 +30,7 @@ class Slot:
         mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = False,
+        auto_fill: bool = True,
         influence_conversation: bool = True,
     ) -> None:
         """Create a Slot.
@@ -57,7 +57,7 @@ class Slot:
                 " new explicit mechanism to specify slot mappings. "
                 "Please refer to the docs to learn more.",
                 "4.0.0",
-                docs=None,
+                docs=DOCS_URL_SLOTS,
             )
             auto_fill = False
         self.auto_fill = auto_fill
@@ -185,7 +185,7 @@ class FloatSlot(Slot):
         mappings: List[Dict[Text, Any]],
         initial_value: Optional[float] = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = False,
+        auto_fill: bool = True,
         max_value: float = 1.0,
         min_value: float = 0.0,
         influence_conversation: bool = True,
@@ -326,7 +326,7 @@ class CategoricalSlot(Slot):
         values: Optional[List[Any]] = None,
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = False,
+        auto_fill: bool = True,
         influence_conversation: bool = True,
     ) -> None:
         """Creates a `Categorical  Slot` (see parent class for detailed docstring)."""
@@ -431,7 +431,7 @@ class AnySlot(Slot):
         mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
-        auto_fill: bool = False,
+        auto_fill: bool = True,
         influence_conversation: bool = False,
     ) -> None:
         """Creates an `Any  Slot` (see parent class for detailed docstring).

--- a/rasa/shared/core/slots.py
+++ b/rasa/shared/core/slots.py
@@ -27,6 +27,7 @@ class Slot:
     def __init__(
         self,
         name: Text,
+        mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
         auto_fill: bool = True,
@@ -37,6 +38,7 @@ class Slot:
         Args:
             name: The name of the slot.
             initial_value: The initial value of the slot.
+            mappings: List containing slot mappings.
             value_reset_delay: After how many turns the slot should be reset to the
                 initial_value. This is behavior is currently not implemented.
             auto_fill: `True` if the slot should be filled automatically by entities
@@ -45,6 +47,7 @@ class Slot:
                 influence the predictions of the dialogue polices.
         """
         self.name = name
+        self.mappings = mappings
         self._value = initial_value
         self.initial_value = initial_value
         self._value_reset_delay = value_reset_delay
@@ -147,6 +150,7 @@ class Slot:
             "initial_value": self.initial_value,
             "auto_fill": self.auto_fill,
             "influence_conversation": self.influence_conversation,
+            "mappings": self.mappings,
         }
 
     def fingerprint(self) -> Text:
@@ -168,6 +172,7 @@ class FloatSlot(Slot):
     def __init__(
         self,
         name: Text,
+        mappings: List[Dict[Text, Any]],
         initial_value: Optional[float] = None,
         value_reset_delay: Optional[int] = None,
         auto_fill: bool = True,
@@ -182,7 +187,12 @@ class FloatSlot(Slot):
             UserWarning, if initial_value is outside the min-max range.
         """
         super().__init__(
-            name, initial_value, value_reset_delay, auto_fill, influence_conversation
+            name,
+            mappings,
+            initial_value,
+            value_reset_delay,
+            auto_fill,
+            influence_conversation,
         )
         self.max_value = max_value
         self.min_value = min_value
@@ -302,6 +312,7 @@ class CategoricalSlot(Slot):
     def __init__(
         self,
         name: Text,
+        mappings: List[Dict[Text, Any]],
         values: Optional[List[Any]] = None,
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
@@ -310,7 +321,12 @@ class CategoricalSlot(Slot):
     ) -> None:
         """Creates a `Categorical  Slot` (see parent class for detailed docstring)."""
         super().__init__(
-            name, initial_value, value_reset_delay, auto_fill, influence_conversation
+            name,
+            mappings,
+            initial_value,
+            value_reset_delay,
+            auto_fill,
+            influence_conversation,
         )
         if values and None in values:
             rasa.shared.utils.io.raise_warning(
@@ -399,11 +415,17 @@ class AnySlot(Slot):
     def __init__(
         self,
         name: Text,
+        mappings: List[Dict[Text, Any]],
         initial_value: Any = None,
         value_reset_delay: Optional[int] = None,
         auto_fill: bool = True,
         influence_conversation: bool = False,
     ) -> None:
+        """Creates an `Any  Slot` (see parent class for detailed docstring).
+
+        Raises:
+            InvalidSlotConfigError, if slot is featurized.
+        """
         if influence_conversation:
             raise InvalidSlotConfigError(
                 f"An {AnySlot.__name__} cannot be featurized. "
@@ -414,7 +436,12 @@ class AnySlot(Slot):
             )
 
         super().__init__(
-            name, initial_value, value_reset_delay, auto_fill, influence_conversation
+            name,
+            mappings,
+            initial_value,
+            value_reset_delay,
+            auto_fill,
+            influence_conversation,
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -115,7 +115,7 @@ class AnySlotDict(dict):
     e.g. properly featurizing the slot."""
 
     def __missing__(self, key: Text) -> Slot:
-        value = self[key] = Slot(key)
+        value = self[key] = Slot(key, mappings=[{}])
         return value
 
     def __contains__(self, key: Text) -> bool:

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -43,6 +43,40 @@ mapping:
   slots:
     type: "map"
     allowempty: True
+    mapping:
+      regex;([A-Za-z]+):
+        type: "map"
+        mapping:
+          influence_conversation:
+            type: "bool"
+            required: False
+          type:
+            type: "any"
+            required: True
+          values:
+            type: "seq"
+            sequence:
+              - type: "any"
+            required: False
+          auto_fill:
+            type: "bool"
+            required: False
+          min_value:
+            type: "number"
+            required: False
+          max_value:
+            type: "number"
+            required: False
+          initial_value:
+            type: "any"
+            required: False
+          mappings:
+           type: "seq"
+           required: True
+           allowempty: False
+           sequence:
+              - type: "map"
+                allowempty: True
   forms:
     type: "map"
     required: False

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -58,9 +58,6 @@ mapping:
             sequence:
               - type: "any"
             required: False
-          auto_fill:
-            type: "bool"
-            required: False
           min_value:
             type: "number"
             required: False

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -74,6 +74,33 @@ mapping:
            sequence:
               - type: "map"
                 allowempty: True
+                mapping:
+                  type:
+                    type: "str"
+                  intent:
+                    type: "any"
+                  not_intent:
+                    type: "any"
+                  entity:
+                    type: "str"
+                  role:
+                    type: "str"
+                  group:
+                    type: "str"
+                  value:
+                    type: "any"
+                  action:
+                    type: "str"
+                  conditions:
+                    type: "seq"
+                    sequence:
+                      - type: "map"
+                        mapping:
+                          active_loop:
+                            type: "str"
+                            required: True
+                          requested_slot:
+                            type: "str"
   forms:
     type: "map"
     required: False

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -51,7 +51,9 @@ mapping:
         type: "map"
         mapping:
           required_slots:
-            type: "map"
+            type: "seq"
+            sequence:
+              - type: str
             required: False
             allowempty: True
           ignored_intents:

--- a/rasa/validator.py
+++ b/rasa/validator.py
@@ -313,8 +313,8 @@ class Validator:
         everything_is_alright = True
 
         for form in self.domain.form_names:
-            form_slots = self.domain.slot_mapping_for_form(form)
-            for slot in form_slots.keys():
+            form_slots = self.domain.required_slots_for_form(form)
+            for slot in form_slots:
                 if slot in domain_slot_names:
                     continue
                 else:

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -209,8 +209,12 @@ def test_validate_files_form_slots_not_matching(tmp_path: Path):
         slots:
              first_name:
                 type: text
+                mappings:
+                - type: from_text
              last_nam:
                 type: text
+                mappings:
+                - type: from_text
         """
     )
     args = {

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -202,10 +202,8 @@ def test_validate_files_form_slots_not_matching(tmp_path: Path):
         forms:
           name_form:
             required_slots:
-              first_name:
-              - type: from_text
-              last_name:
-              - type: from_text
+              - first_name
+              - last_name
         slots:
              first_name:
                 type: text

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -85,6 +85,9 @@ async def test_activate_with_prefilled_slot():
     slots:
       {slot_name}:
         type: any
+        mappings:
+        - type: from_entity
+          entity: {slot_name}
     """
     domain = Domain.from_yaml(domain)
     events = await action.run(
@@ -262,6 +265,9 @@ async def test_activate_and_immediate_deactivate():
     slots:
       {slot_name}:
         type: any
+        mappings:
+        - type: from_entity
+          entity: {slot_name}
     """
     domain = Domain.from_yaml(domain)
     events = await action.run(
@@ -300,6 +306,8 @@ async def test_set_slot_and_deactivate():
       {slot_name}:
         type: text
         influence_conversation: false
+        mappings:
+        - type: from_text
     """
     domain = Domain.from_yaml(domain)
 
@@ -341,6 +349,9 @@ async def test_action_rejection():
     slots:
       {slot_to_fill}:
         type: any
+        mappings:
+        - type: from_entity
+          entity: some_entity
     """
     domain = Domain.from_yaml(domain)
 
@@ -469,8 +480,13 @@ async def test_validate_slots(
     slots:
       {slot_name}:
         type: any
+        mappings:
+        - type: from_text
       num_tables:
         type: any
+        mappings:
+        - type: from_entity
+          entity: num_tables
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
@@ -509,8 +525,16 @@ async def test_request_correct_slots_after_unhappy_path_with_custom_required_slo
         slots:
           {slot_name_1}:
             type: any
+            mappings:
+            - type: from_intent
+              intent: some_intent
+              value: some_value
           {slot_name_2}:
             type: any
+            mappings:
+            - type: from_intent
+              intent: some_intent
+              value: some_value
         forms:
           {form_name}:
             {REQUIRED_SLOTS_KEY}:
@@ -589,6 +613,9 @@ async def test_no_slots_extracted_with_custom_slot_mappings(custom_events: List[
     slots:
       num_tables:
         type: any
+        mappings:
+        - type: from_entity
+          entity: num_tables
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
@@ -631,6 +658,8 @@ async def test_validate_slots_on_activation_with_other_action_after_user_utteran
     slots:
       {slot_name}:
         type: any
+        mappings:
+        - type: from_text
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
@@ -704,6 +733,8 @@ def test_temporary_tracker():
         slots:
           {extra_slot}:
             type: any
+            mappings:
+            - type: from_text
         """
     )
 
@@ -840,6 +871,9 @@ def test_extract_requested_slot_with_list_slot(
       {slot_name}:
         type: list
         influence_conversation: false
+        mappings:
+        - type: from_entity
+          entity: topping
 
     forms:
       {form_name}:
@@ -1390,6 +1424,9 @@ def test_extract_other_list_slot_from_entity(
       {slot_name}:
         type: list
         influence_conversation: false
+        mappings:
+        - type: from_entity
+          entity: topping
 
     forms:
       {form_name}:

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -40,12 +40,16 @@ async def test_activate():
     action = FormAction(form_name, None)
     slot_name = "num_people"
     domain = f"""
+slots:
+  {slot_name}:
+    type: float
+    mappings:
+    - type: from_entity
+      entity: number
 forms:
   {form_name}:
     {REQUIRED_SLOTS_KEY}:
-        {slot_name}:
-        - type: from_entity
-          entity: number
+        - {slot_name}
 responses:
     utter_ask_num_people:
     - text: "How many people?"
@@ -77,17 +81,18 @@ async def test_activate_with_prefilled_slot():
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_name}:
-            - type: from_entity
-              entity: {slot_name}
-            {next_slot_to_request}:
-            - type: from_text
+            - {slot_name}
+            - {next_slot_to_request}
     slots:
       {slot_name}:
         type: any
         mappings:
         - type: from_entity
           entity: {slot_name}
+      {next_slot_to_request}:
+        type: text
+        mappings:
+        - type: from_text
     """
     domain = Domain.from_yaml(domain)
     events = await action.run(
@@ -128,17 +133,19 @@ nlu:
   examples: |
     - start a return
     - I don't want my shoes anymore
+slots:
+ {slot_a}:
+   type: float
+   mappings:
+   - type: from_entity
+     entity: number
 forms:
   {form_1}:
     {REQUIRED_SLOTS_KEY}:
-        {slot_a}:
-        - type: from_entity
-          entity: number
+        - {slot_a}
   {form_2}:
     {REQUIRED_SLOTS_KEY}:
-        {slot_a}:
-        - type: from_entity
-          entity: number
+        - {slot_a}
 responses:
     utter_ask_{form_1}_{slot_a}:
     - text: {utter_ask_form_1}
@@ -259,9 +266,7 @@ async def test_activate_and_immediate_deactivate():
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_name}:
-            - type: from_entity
-              entity: {slot_name}
+            - {slot_name}
     slots:
       {slot_name}:
         type: any
@@ -300,8 +305,7 @@ async def test_set_slot_and_deactivate():
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_name}:
-            - type: from_text
+            - {slot_name}
     slots:
       {slot_name}:
         type: text
@@ -343,9 +347,7 @@ async def test_action_rejection():
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_to_fill}:
-            - type: from_entity
-              entity: some_entity
+            - {slot_to_fill}
     slots:
       {slot_to_fill}:
         type: any
@@ -490,11 +492,8 @@ async def test_validate_slots(
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_name}:
-            - type: from_text
-            num_tables:
-            - type: from_entity
-              entity: num_tables
+            - {slot_name}
+            - num_tables
     actions:
     - validate_{form_name}
     """
@@ -538,14 +537,8 @@ async def test_request_correct_slots_after_unhappy_path_with_custom_required_slo
         forms:
           {form_name}:
             {REQUIRED_SLOTS_KEY}:
-                {slot_name_1}:
-                - type: from_intent
-                  intent: some_intent
-                  value: some_value
-                {slot_name_2}:
-                - type: from_intent
-                  intent: some_intent
-                  value: some_value
+                - {slot_name_1}
+                - {slot_name_2}
         actions:
         - validate_{form_name}
         """
@@ -619,9 +612,7 @@ async def test_no_slots_extracted_with_custom_slot_mappings(custom_events: List[
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            num_tables:
-            - type: from_entity
-              entity: num_tables
+            - num_tables
     actions:
     - validate_{form_name}
     """
@@ -663,8 +654,7 @@ async def test_validate_slots_on_activation_with_other_action_after_user_utteran
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_name}:
-            - type: from_text
+            - {slot_name}
     actions:
     - validate_{form_name}
     """
@@ -708,11 +698,15 @@ def test_name_of_utterance(utterance_name: Text):
     slot_name = "num_people"
 
     domain = f"""
+    slots:
+      {slot_name}:
+        type: any
+        mappings:
+        - type: from_text
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-            {slot_name}:
-            - type: from_text
+            - {slot_name}
     responses:
         {utterance_name}:
         - text: "How many people?"
@@ -762,19 +756,19 @@ def test_extract_requested_slot_default():
 
     domain = Domain.from_dict(
         {
-            "forms": {
-                form_name: {
-                    REQUIRED_SLOTS_KEY: {
-                        "some_slot": [
-                            {
-                                "type": "from_entity",
-                                "entity": "some_slot",
-                                "value": "some_value",
-                            }
-                        ]
-                    }
+            "slots": {
+                "some_slot": {
+                    "type": "text",
+                    "mappings": [
+                        {
+                            "type": "from_entity",
+                            "entity": "some_slot",
+                            "value": "some_value",
+                        }
+                    ],
                 }
-            }
+            },
+            "forms": {form_name: {REQUIRED_SLOTS_KEY: ["some_slot"]}},
         }
     )
 
@@ -818,7 +812,10 @@ def test_extract_requested_slot_when_mapping_applies(
     form = FormAction(form_name, None)
 
     domain = Domain.from_dict(
-        {"forms": {form_name: {REQUIRED_SLOTS_KEY: {entity_name: [slot_mapping]}}}}
+        {
+            "slots": {entity_name: {"type": "text", "mappings": [slot_mapping]}},
+            "forms": {form_name: {REQUIRED_SLOTS_KEY: [entity_name]}},
+        }
     )
 
     tracker = DialogueStateTracker.from_events(
@@ -878,9 +875,7 @@ def test_extract_requested_slot_with_list_slot(
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-          {slot_name}:
-          - type: from_entity
-            entity: topping
+          - {slot_name}
     """
         )
     )
@@ -920,7 +915,10 @@ def test_extract_requested_slot_mapping_does_not_apply(slot_mapping: Dict):
     form = FormAction(form_name, None)
 
     domain = Domain.from_dict(
-        {"forms": {form_name: {REQUIRED_SLOTS_KEY: {entity_name: [slot_mapping]}}}}
+        {
+            "slots": {entity_name: {"type": "text", "mappings": [slot_mapping]}},
+            "forms": {form_name: {REQUIRED_SLOTS_KEY: [entity_name]}},
+        }
     )
 
     tracker = DialogueStateTracker.from_events(
@@ -965,20 +963,27 @@ async def test_trigger_slot_mapping_applies(
 
     domain = Domain.from_dict(
         {
+            "slots": {
+                entity_name: {
+                    "type": "text",
+                    "mappings": [
+                        {
+                            "type": "from_entity",
+                            "entity": entity_name,
+                            "intent": "some_intent",
+                        }
+                    ],
+                },
+                slot_filled_by_trigger_mapping: {
+                    "type": "text",
+                    "mappings": [trigger_slot_mapping],
+                },
+            },
             "forms": {
                 form_name: {
-                    REQUIRED_SLOTS_KEY: {
-                        entity_name: [
-                            {
-                                "type": "from_entity",
-                                "entity": entity_name,
-                                "intent": "some_intent",
-                            }
-                        ],
-                        slot_filled_by_trigger_mapping: [trigger_slot_mapping],
-                    }
+                    REQUIRED_SLOTS_KEY: [entity_name, slot_filled_by_trigger_mapping,]
                 }
-            }
+            },
         }
     )
 
@@ -1014,20 +1019,27 @@ async def test_trigger_slot_mapping_does_not_apply(trigger_slot_mapping: Dict):
 
     domain = Domain.from_dict(
         {
+            "slots": {
+                entity_name: {
+                    "type": "text",
+                    "mappings": [
+                        {
+                            "type": "from_entity",
+                            "entity": entity_name,
+                            "intent": "some_intent",
+                        }
+                    ],
+                },
+                slot_filled_by_trigger_mapping: {
+                    "type": "text",
+                    "mappings": [trigger_slot_mapping],
+                },
+            },
             "forms": {
                 form_name: {
-                    REQUIRED_SLOTS_KEY: {
-                        entity_name: [
-                            {
-                                "type": "from_entity",
-                                "entity": entity_name,
-                                "intent": "some_intent",
-                            }
-                        ],
-                        slot_filled_by_trigger_mapping: [trigger_slot_mapping],
-                    }
+                    REQUIRED_SLOTS_KEY: [entity_name, slot_filled_by_trigger_mapping,]
                 }
-            }
+            },
         }
     )
 
@@ -1182,7 +1194,10 @@ def test_extract_requested_slot_from_entity(
         not_intent=mapping_not_intent,
     )
     domain = Domain.from_dict(
-        {"forms": {form_name: {REQUIRED_SLOTS_KEY: {"some_slot": [mapping]}}}}
+        {
+            "slots": {"some_slot": {"type": "any", "mappings": [mapping],}},
+            "forms": {form_name: {REQUIRED_SLOTS_KEY: ["some_slot"]}},
+        }
     )
 
     tracker = DialogueStateTracker.from_events(
@@ -1368,14 +1383,16 @@ def test_extract_other_slots_with_entity(
 
     domain = Domain.from_dict(
         {
+            "slots": {
+                "some_other_slot": {
+                    "type": "any",
+                    "mappings": some_other_slot_mapping,
+                },
+                "some_slot": {"type": "any", "mappings": some_slot_mapping,},
+            },
             "forms": {
-                form_name: {
-                    REQUIRED_SLOTS_KEY: {
-                        "some_other_slot": some_other_slot_mapping,
-                        "some_slot": some_slot_mapping,
-                    }
-                }
-            }
+                form_name: {REQUIRED_SLOTS_KEY: ["some_other_slot", "some_slot"]}
+            },
         }
     )
 
@@ -1431,9 +1448,7 @@ def test_extract_other_list_slot_from_entity(
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
-          {slot_name}:
-          - type: from_entity
-            entity: topping
+          - {slot_name}
     """
         )
     )
@@ -1575,20 +1590,24 @@ def test_ignored_intents_with_slot_type_from_entity(
 
     domain = Domain.from_dict(
         {
+            "slots": {
+                entity_name: {
+                    "type": "any",
+                    "mappings": [
+                        {
+                            "type": "from_entity",
+                            "entity": entity_name,
+                            "not_intent": slot_not_intent,
+                        }
+                    ],
+                }
+            },
             "forms": {
                 form_name: {
                     IGNORED_INTENTS: ignored_intents,
-                    REQUIRED_SLOTS_KEY: {
-                        entity_name: [
-                            {
-                                "type": "from_entity",
-                                "entity": entity_name,
-                                "not_intent": slot_not_intent,
-                            }
-                        ],
-                    },
+                    REQUIRED_SLOTS_KEY: [entity_name],
                 }
-            }
+            },
         }
     )
 
@@ -1646,20 +1665,24 @@ def test_ignored_intents_with_slot_type_from_text(
 
     domain = Domain.from_dict(
         {
+            "slots": {
+                entity_name: {
+                    "type": "any",
+                    "mappings": [
+                        {
+                            "type": "from_text",
+                            "intent": "some_intent",
+                            "not_intent": slot_not_intent,
+                        }
+                    ],
+                }
+            },
             "forms": {
                 form_name: {
                     IGNORED_INTENTS: ignored_intents,
-                    REQUIRED_SLOTS_KEY: {
-                        entity_name: [
-                            {
-                                "type": "from_text",
-                                "intent": "some_intent",
-                                "not_intent": slot_not_intent,
-                            }
-                        ],
-                    },
+                    REQUIRED_SLOTS_KEY: [entity_name],
                 }
-            }
+            },
         }
     )
 
@@ -1750,21 +1773,25 @@ def test_ignored_intents_with_other_type_of_slots(
 
     domain = Domain.from_dict(
         {
+            "slots": {
+                entity_name: {
+                    "type": "any",
+                    "mappings": [
+                        {
+                            "type": entity_type,
+                            "value": "affirm",
+                            "intent": "true",
+                            "not_intent": slot_not_intent,
+                        }
+                    ],
+                }
+            },
             "forms": {
                 form_name: {
                     IGNORED_INTENTS: ignored_intents,
-                    REQUIRED_SLOTS_KEY: {
-                        entity_name: [
-                            {
-                                "type": entity_type,
-                                "value": "affirm",
-                                "intent": "true",
-                                "not_intent": slot_not_intent,
-                            }
-                        ],
-                    },
+                    REQUIRED_SLOTS_KEY: [entity_name],
                 }
-            }
+            },
         }
     )
 

--- a/tests/core/featurizers/test_precomputation.py
+++ b/tests/core/featurizers/test_precomputation.py
@@ -351,7 +351,7 @@ def test_container_derive_messages_from_domain_and_add():
         action_texts=action_texts,
         responses=responses,
         entities=["e_a", "e_b", "e_c"],
-        slots=[Slot(name="s")],
+        slots=[Slot(name="s", mappings=[{}])],
         forms=forms,
     )
     lookup_table = MessageContainerForCoreFeaturization()

--- a/tests/core/featurizers/test_single_state_featurizers.py
+++ b/tests/core/featurizers/test_single_state_featurizers.py
@@ -91,7 +91,7 @@ def test_prepare_for_training():
     domain = Domain(
         intents=["greet"],
         entities=["name"],
-        slots=[Slot("name")],
+        slots=[Slot("name", mappings=[{}])],
         responses={},
         forms={},
         action_names=["utter_greet", "action_check_weather"],

--- a/tests/core/nlg/test_response.py
+++ b/tests/core/nlg/test_response.py
@@ -63,9 +63,14 @@ async def test_nlg_when_multiple_conditions_satisfied():
     }
 
     t = TemplatedNaturalLanguageGenerator(responses=responses)
-    slot_a = TextSlot(name="test", initial_value="A", influence_conversation=False)
+    slot_a = TextSlot(
+        name="test", mappings=[{}], initial_value="A", influence_conversation=False
+    )
     slot_b = TextSlot(
-        name="test_another", initial_value="B", influence_conversation=False
+        name="test_another",
+        mappings=[{}],
+        initial_value="B",
+        influence_conversation=False,
     )
     tracker = DialogueStateTracker(sender_id="test_nlg", slots=[slot_a, slot_b])
     resp = await t.generate(
@@ -95,7 +100,10 @@ async def test_nlg_conditional_response_variations_with_interpolated_slots(
     }
     t = TemplatedNaturalLanguageGenerator(responses=responses)
     slot = TextSlot(
-        name=slot_name, initial_value=slot_value, influence_conversation=False
+        name=slot_name,
+        mappings=[{}],
+        initial_value=slot_value,
+        influence_conversation=False,
     )
     tracker = DialogueStateTracker(sender_id="nlg_interpolated", slots=[slot])
 
@@ -129,7 +137,10 @@ async def test_nlg_conditional_response_variations_with_yaml_single_condition(
     t = TemplatedNaturalLanguageGenerator(responses=domain.responses)
 
     slot = AnySlot(
-        name=slot_name, initial_value=slot_value, influence_conversation=False
+        name=slot_name,
+        mappings=[{}],
+        initial_value=slot_value,
+        influence_conversation=False,
     )
     tracker = DialogueStateTracker(sender_id="conversation_id", slots=[slot])
 
@@ -146,10 +157,16 @@ async def test_nlg_conditional_response_variations_with_yaml_multi_constraints()
     t = TemplatedNaturalLanguageGenerator(responses=domain.responses)
 
     first_slot = CategoricalSlot(
-        name="account_type", initial_value="primary", influence_conversation=False
+        name="account_type",
+        mappings=[{}],
+        initial_value="primary",
+        influence_conversation=False,
     )
     second_slot = BooleanSlot(
-        name="can_withdraw", initial_value=True, influence_conversation=False
+        name="can_withdraw",
+        mappings=[{}],
+        initial_value=True,
+        influence_conversation=False,
     )
     tracker = DialogueStateTracker(
         sender_id="conversation_id", slots=[first_slot, second_slot]
@@ -167,7 +184,10 @@ async def test_nlg_conditional_response_variations_with_yaml_and_channel():
     t = TemplatedNaturalLanguageGenerator(responses=domain.responses)
 
     slot = CategoricalSlot(
-        name="account_type", initial_value="primary", influence_conversation=False
+        name="account_type",
+        mappings=[{}],
+        initial_value="primary",
+        influence_conversation=False,
     )
     tracker = DialogueStateTracker(sender_id="conversation_id", slots=[slot])
 
@@ -214,7 +234,10 @@ async def test_nlg_conditional_response_variations_with_diff_slot_types(
     }
     t = TemplatedNaturalLanguageGenerator(responses=responses)
     slot = AnySlot(
-        name=slot_name, initial_value=slot_value, influence_conversation=False
+        name=slot_name,
+        mappings=[{}],
+        initial_value=slot_value,
+        influence_conversation=False,
     )
     tracker = DialogueStateTracker(sender_id="nlg_tracker", slots=[slot])
 
@@ -255,7 +278,9 @@ async def test_nlg_conditional_response_variations_with_none_slot():
         """
     )
     t = TemplatedNaturalLanguageGenerator(domain.responses)
-    slot = AnySlot(name="account", initial_value=None, influence_conversation=False)
+    slot = AnySlot(
+        name="account", mappings=[{}], initial_value=None, influence_conversation=False
+    )
     tracker = DialogueStateTracker(sender_id="test", slots=[slot])
     r = await t.generate("utter_action", tracker, "")
     assert r is None
@@ -275,7 +300,9 @@ async def test_nlg_conditional_response_variations_with_slot_not_a_constraint():
             """
     )
     t = TemplatedNaturalLanguageGenerator(domain.responses)
-    slot = TextSlot(name="account", initial_value="B", influence_conversation=False)
+    slot = TextSlot(
+        name="account", mappings=[{}], initial_value="B", influence_conversation=False
+    )
     tracker = DialogueStateTracker(sender_id="test", slots=[slot])
     r = await t.generate("utter_action", tracker, "")
     assert r is None
@@ -295,7 +322,9 @@ async def test_nlg_conditional_response_variations_with_null_slot():
                 """
     )
     t = TemplatedNaturalLanguageGenerator(domain.responses)
-    slot = AnySlot(name="account", initial_value=None, influence_conversation=False)
+    slot = AnySlot(
+        name="account", mappings=[{}], initial_value=None, influence_conversation=False
+    )
     tracker = DialogueStateTracker(sender_id="test", slots=[slot])
     r = await t.generate("utter_action", tracker, "")
     assert r.get("text") == "text for null"
@@ -343,7 +372,9 @@ async def test_nlg_conditional_response_variation_condition_met_channel_mismatch
         """
     )
     t = TemplatedNaturalLanguageGenerator(domain.responses)
-    slot = TextSlot("test", "A", influence_conversation=False)
+    slot = TextSlot(
+        "test", mappings=[{}], initial_value="A", influence_conversation=False
+    )
     tracker = DialogueStateTracker(sender_id="test", slots=[slot])
     r = await t.generate("utter_action", tracker, "app")
     assert r.get("text") == "app default"
@@ -353,12 +384,41 @@ async def test_nlg_conditional_response_variation_condition_met_channel_mismatch
     "slots,channel,expected_response",
     [
         (
-            [TextSlot("test", "B", influence_conversation=False),],
+            [
+                TextSlot(
+                    "test",
+                    mappings=[{}],
+                    initial_value="B",
+                    influence_conversation=False,
+                ),
+            ],
             "app",
             "condition example B no channel",
         ),
-        ([TextSlot("test", "C", influence_conversation=False),], "", "default"),
-        ([TextSlot("test", "D", influence_conversation=False),], "app", "default"),
+        (
+            [
+                TextSlot(
+                    "test",
+                    mappings=[{}],
+                    initial_value="C",
+                    influence_conversation=False,
+                ),
+            ],
+            "",
+            "default",
+        ),
+        (
+            [
+                TextSlot(
+                    "test",
+                    mappings=[{}],
+                    initial_value="D",
+                    influence_conversation=False,
+                ),
+            ],
+            "app",
+            "default",
+        ),
     ],
 )
 async def test_nlg_conditional_edgecases(slots, channel, expected_response):
@@ -422,8 +482,12 @@ async def test_nlg_conditional_response_variations_condition_logging(
         """
     )
     t = TemplatedNaturalLanguageGenerator(domain.responses)
-    slot_A = TextSlot(name="test_A", initial_value="A", influence_conversation=False)
-    slot_B = TextSlot(name="test_B", initial_value="B", influence_conversation=False)
+    slot_A = TextSlot(
+        name="test_A", mappings=[{}], initial_value="A", influence_conversation=False
+    )
+    slot_B = TextSlot(
+        name="test_B", mappings=[{}], initial_value="B", influence_conversation=False
+    )
     tracker = DialogueStateTracker(sender_id="test", slots=[slot_A, slot_B])
 
     with caplog.at_level(logging.DEBUG):

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -216,6 +216,8 @@ def test_potential_contradiction_resolved_by_conversation_start_when_slot_initia
           {some_slot}:
             type: text
             initial_value: {some_slot_initial_value}
+            mappings:
+            - type: from_text
         """
     )
     greet_rule_at_conversation_start = TrackerWithCachedStates.from_events(
@@ -287,6 +289,8 @@ def test_potential_contradiction_resolved_by_conversation_start_when_slot_initia
           {some_slot}:
             type: text
             initial_value: {some_slot_initial_value}
+            mappings:
+            - type: from_text
         """
     )
 
@@ -380,6 +384,8 @@ def test_incomplete_rules_due_to_slots(policy: RulePolicy):
         slots:
           {some_slot}:
             type: text
+            mappings:
+            - type: from_text
         """
     )
 
@@ -450,6 +456,8 @@ def test_no_incomplete_rules_due_to_slots_after_listen(policy: RulePolicy):
         slots:
           {some_slot}:
             type: text
+            mappings:
+            - type: from_text
         """
     )
 
@@ -508,8 +516,12 @@ def test_no_incomplete_rules_due_to_additional_slots_set(policy: RulePolicy):
         slots:
           {some_slot}:
             type: text
+            mappings:
+            - type: from_text
           {some_other_slot}:
             type: text
+            mappings:
+            - type: from_text
         """
     )
 
@@ -835,6 +847,8 @@ async def test_predict_form_action_if_in_form(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -877,6 +891,8 @@ async def test_predict_loop_action_if_in_loop_but_there_is_e2e_rule(policy: Rule
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {loop_name}: {{}}
         """
@@ -931,6 +947,8 @@ async def test_predict_form_action_if_multiple_turns(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -979,6 +997,8 @@ slots:
       - v1
       - v2
     initial_value: v1
+    mappings:
+    - type: from_text
 """
     )
 
@@ -1027,6 +1047,8 @@ slots:
       - v1
       - v2
     initial_value: v1
+    mappings:
+    - type: from_text
 """
     )
 
@@ -1072,6 +1094,8 @@ async def test_predict_action_listen_after_form(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1116,6 +1140,8 @@ async def test_dont_predict_form_if_already_finished(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1164,6 +1190,8 @@ async def test_form_unhappy_path(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1206,6 +1234,8 @@ async def test_form_unhappy_path_from_general_rule(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1261,6 +1291,8 @@ async def test_form_unhappy_path_from_in_form_rule(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1334,6 +1366,8 @@ async def test_form_unhappy_path_from_story(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1408,6 +1442,8 @@ async def test_form_unhappy_path_no_validation_from_rule(
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1496,6 +1532,8 @@ async def test_form_unhappy_path_no_validation_from_story(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1563,6 +1601,8 @@ async def test_form_unhappy_path_without_rule(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1606,6 +1646,8 @@ async def test_form_activation_rule(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1644,6 +1686,8 @@ async def test_failing_form_activation_due_to_no_rule(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1682,6 +1726,8 @@ def test_form_submit_rule(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -1733,8 +1779,12 @@ def test_immediate_submit(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
           {slot}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         entities:
@@ -2146,8 +2196,12 @@ def test_hide_rule_turn_with_slots(
         slots:
           {slot_which_is_only_in_rule}:
             type: text
+            mappings:
+            - type: from_text
           {slot_which_is_also_in_story}:
             type: text
+            mappings:
+            - type: from_text
         """
     )
 
@@ -2268,6 +2322,8 @@ def test_hide_rule_turn_no_last_action_listen(
         slots:
           {followup_on_chitchat}:
             type: bool
+            mappings:
+            - type: from_text
         """
     )
     simple_rule_no_last_action_listen = TrackerWithCachedStates.from_events(
@@ -2357,6 +2413,8 @@ def test_hide_rule_turn_with_loops(
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
           {another_form_name}: {{}}
@@ -2455,6 +2513,8 @@ def test_do_not_hide_rule_turn_with_loops_in_stories(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -2512,6 +2572,8 @@ def test_hide_rule_turn_with_loops_as_followup_action(policy: RulePolicy):
         slots:
           {REQUESTED_SLOT}:
             type: any
+            mappings:
+            - type: from_text
         forms:
           {form_name}: {{}}
         """
@@ -2900,11 +2962,15 @@ def test_rule_with_multiple_slots(policy: RulePolicy):
                 values:
                  - {value_1}
                  - {value_2}
+                mappings:
+                - type: from_text
               {slot_2}:
                 type: categorical
                 values:
                  - {value_1}
                  - {value_2}
+                mappings:
+                - type: from_text
             """
     )
     rule = TrackerWithCachedStates.from_events(
@@ -2964,11 +3030,15 @@ def test_include_action_unlikely_intent(policy: RulePolicy):
                     values:
                      - {value_1}
                      - {value_2}
+                    mappings:
+                    - type: from_text
                   {slot_2}:
                     type: categorical
                     values:
                      - {value_1}
                      - {value_2}
+                    mappings:
+                    - type: from_text
                 """
     )
     rule_1 = TrackerWithCachedStates.from_events(

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -567,7 +567,8 @@ def test_incomplete_rules_due_to_loops(policy: RulePolicy):
         intents:
         - {GREET_INTENT_NAME}
         forms:
-          {some_form}: {{}}
+          {some_form}:
+            required_slots: []
         """
     )
 
@@ -850,7 +851,8 @@ async def test_predict_form_action_if_in_form(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -894,7 +896,8 @@ async def test_predict_loop_action_if_in_loop_but_there_is_e2e_rule(policy: Rule
             mappings:
             - type: from_text
         forms:
-          {loop_name}: {{}}
+          {loop_name}:
+            required_slots: []
         """
     )
     e2e_rule = TrackerWithCachedStates.from_events(
@@ -950,7 +953,8 @@ async def test_predict_form_action_if_multiple_turns(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1097,7 +1101,8 @@ async def test_predict_action_listen_after_form(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1143,7 +1148,8 @@ async def test_dont_predict_form_if_already_finished(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1193,7 +1199,8 @@ async def test_form_unhappy_path(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1237,7 +1244,8 @@ async def test_form_unhappy_path_from_general_rule(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1294,7 +1302,8 @@ async def test_form_unhappy_path_from_in_form_rule(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1369,7 +1378,8 @@ async def test_form_unhappy_path_from_story(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1445,7 +1455,8 @@ async def test_form_unhappy_path_no_validation_from_rule(
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1535,7 +1546,8 @@ async def test_form_unhappy_path_no_validation_from_story(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1604,7 +1616,8 @@ async def test_form_unhappy_path_without_rule(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1649,7 +1662,8 @@ async def test_form_activation_rule(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1689,7 +1703,8 @@ async def test_failing_form_activation_due_to_no_rule(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1729,7 +1744,8 @@ def test_form_submit_rule(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -1786,7 +1802,8 @@ def test_immediate_submit(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         entities:
         - {entity}
         """
@@ -2416,8 +2433,10 @@ def test_hide_rule_turn_with_loops(
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
-          {another_form_name}: {{}}
+          {form_name}:
+            required_slots: []
+          {another_form_name}:
+            required_slots: []
         """
     )
 
@@ -2516,7 +2535,8 @@ def test_do_not_hide_rule_turn_with_loops_in_stories(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 
@@ -2575,7 +2595,8 @@ def test_hide_rule_turn_with_loops_as_followup_action(policy: RulePolicy):
             mappings:
             - type: from_text
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         """
     )
 

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -993,26 +993,30 @@ async def test_action_default_ask_rephrase(
 
 
 @pytest.mark.parametrize(
-    "slot_mapping",
+    "slot",
     [
-        """my_slot:
-          - type: from_text
+        """- my_slot
         """,
-        "{}",
+        "[]",
     ],
 )
-def test_get_form_action(slot_mapping: Text):
+def test_get_form_action(slot: Text):
     form_action_name = "my_business_logic"
 
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
+    slots:
+      my_slot:
+        type: text
+        mappings:
+        - type: from_text
     actions:
     - my_action
     forms:
       {form_action_name}:
         {REQUIRED_SLOTS_KEY}:
-          {slot_mapping}
+          {slot}
     """
         )
     )
@@ -1030,7 +1034,8 @@ def test_overridden_form_action():
     - my_action
     - {form_action_name}
     forms:
-        {form_action_name}: {{}}
+        {form_action_name}:
+          {REQUIRED_SLOTS_KEY}: []
     """
         )
     )

--- a/tests/core/test_agent.py
+++ b/tests/core/test_agent.py
@@ -233,7 +233,9 @@ async def test_load_agent(trained_rasa_model: Text):
 def test_form_without_form_policy(policy_config: Dict[Text, List[Text]]):
     with pytest.raises(InvalidDomain) as execinfo:
         Agent(
-            domain=Domain.from_dict({"forms": {"restaurant_form": {}}}),
+            domain=Domain.from_dict(
+                {"forms": {"restaurant_form": {"required_slots": []}}}
+            ),
             policies=PolicyEnsemble.from_dict(policy_config),
         )
     assert "have not added the 'RulePolicy'" in str(execinfo.value)
@@ -243,7 +245,7 @@ def test_forms_with_suited_policy():
     policy_config = {"policies": [{"name": RulePolicy.__name__}]}
     # Doesn't raise
     Agent(
-        domain=Domain.from_dict({"forms": {"restaurant_form": {}}}),
+        domain=Domain.from_dict({"forms": {"restaurant_form": {"required_slots": []}}}),
         policies=PolicyEnsemble.from_dict(policy_config),
     )
 

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -604,12 +604,20 @@ class TestMemoizationPolicy(PolicyTestCollection):
             slots:
                 slot_1:
                     type: bool
+                    mappings:
+                    - type: from_text
                 slot_2:
                     type: bool
+                    mappings:
+                    - type: from_text
                 slot_3:
                     type: bool
+                    mappings:
+                    - type: from_text
                 slot_4:
                     type: bool
+                    mappings:
+                    - type: from_text
             """
         )
         events = [
@@ -678,10 +686,16 @@ class TestAugmentedMemoizationPolicy(TestMemoizationPolicy):
                     slot_1:
                         type: bool
                         initial_value: true
+                        mappings:
+                        - type: from_text
                     slot_2:
                         type: bool
+                        mappings:
+                        - type: from_text
                     slot_3:
                         type: bool
+                        mappings:
+                        - type: from_text
                 """
         )
         training_story = TrackerWithCachedStates.from_events(

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -169,7 +169,9 @@ async def mocked_parse(self, text, message_id=None, tracker=None, metadata=None)
 
 
 async def test_parsing_with_tracker():
-    tracker = DialogueStateTracker.from_dict("1", [], [Slot("requested_language")])
+    tracker = DialogueStateTracker.from_dict(
+        "1", [], [Slot("requested_language", mappings=[{}])]
+    )
 
     # we'll expect this value 'en' to be part of the result from the interpreter
     tracker._set_slot("requested_language", "en")
@@ -1218,8 +1220,12 @@ def test_predict_next_action_with_hidden_rules():
         slots:
           {rule_slot}:
             type: text
+            mappings:
+            - type: from_text
           {story_slot}:
             type: text
+            mappings:
+            - type: from_text
         """
     )
 

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -580,7 +580,8 @@ async def test_write_domain_to_file_with_form(tmp_path: Path):
         - utter_greet
         - utter_goodbye
         forms:
-          {form_name}: {{}}
+          {form_name}:
+            required_slots: []
         intents:
         - greet
         """

--- a/tests/examples/test_example_bots_training_data.py
+++ b/tests/examples/test_example_bots_training_data.py
@@ -42,7 +42,7 @@ from rasa.shared.importers.importer import TrainingDataImporter
         ),
     ],
 )
-def test_example_bot_training_data_not_raises(
+def test_example_bot_training_data_raises_only_auto_fill_warning(
     config_file: Text, domain_file: Text, data_folder: Text
 ):
 
@@ -50,11 +50,18 @@ def test_example_bot_training_data_not_raises(
         config_file, domain_file, [data_folder]
     )
 
-    with pytest.warns(None) as record:
+    with pytest.warns(UserWarning) as record:
         importer.get_nlu_data()
         importer.get_stories()
 
-    assert not len(record)
+    # two for slot auto-fill removal
+    assert len(record) == 2
+    assert (
+        "Slot auto-fill has been removed in 3.0 and replaced by "
+        "a new explicit mechanism to set slots. Please refer to "
+        "the docs to learn more." == record[0].message.args[0]
+    )
+    assert record[0].message.args[0] == record[1].message.args[0]
 
 
 def test_example_bot_training_on_initial_project(tmp_path: Path):
@@ -68,8 +75,15 @@ def test_example_bot_training_on_initial_project(tmp_path: Path):
         str(tmp_path / "data"),
     )
 
-    with pytest.warns(None) as record:
+    with pytest.warns(UserWarning) as record:
         importer.get_nlu_data()
         importer.get_stories()
 
-    assert not len(record)
+    # two for slot auto-fill removal
+    assert len(record) == 2
+    assert (
+        "Slot auto-fill has been removed in 3.0 and replaced by "
+        "a new explicit mechanism to set slots. Please refer to "
+        "the docs to learn more." == record[0].message.args[0]
+    )
+    assert record[0].message.args[0] == record[1].message.args[0]

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -40,9 +40,10 @@ from rasa.shared.core.domain import (
     KEY_INTENTS,
     KEY_ENTITIES,
     KEY_SLOTS,
+    SlotMapping,
 )
 from rasa.shared.core.trackers import DialogueStateTracker
-from rasa.shared.core.events import ActionExecuted, SlotSet, UserUttered
+from rasa.shared.core.events import ActionExecuted, SlotSet, UserUttered, ActiveLoop
 
 
 def test_slots_states_before_user_utterance(domain: Domain):
@@ -1651,3 +1652,102 @@ def test_domain_fingerprint_uniqueness():
     )
     f4 = domain_with_extra_responses.fingerprint()
     assert f1 != f4
+
+
+@pytest.mark.parametrize(
+    "slot_name, expected", [("GPE_destination", True), ("GPE_origin", False)]
+)
+def test_slot_mapping_entity_is_desired(slot_name, expected):
+    domain = Domain.from_file("data/test_domains/travel_form.yml")
+    tracker = DialogueStateTracker("test_id", slots=domain.slots)
+    event = UserUttered(
+        text="I'm travelling to Vancouver.",
+        intent={"id": 1, "name": "inform", "confidence": 0.9604260921478271},
+        entities=[{"entity": "GPE", "value": "Vancouver", "role": "destination"}],
+    )
+    tracker.update(event, domain)
+    slot_mappings = domain.as_dict().get("slots").get(slot_name).get("mappings")
+    extracted_entities = tracker.latest_message.entities
+    assert (
+        SlotMapping.entity_is_desired(slot_mappings[0], extracted_entities, tracker)
+        is expected
+    )
+
+
+def test_slot_mapping_intent_is_desired(domain: Domain):
+    domain = Domain.from_file("examples/formbot/domain.yml")
+    tracker = DialogueStateTracker("sender_id_test", slots=domain.slots)
+    event1 = UserUttered(
+        text="I'd like to book a restaurant for 2 people.",
+        intent={
+            "id": 1,
+            "name": "request_restaurant",
+            "confidence": 0.9604260921478271,
+        },
+        entities=[{"entity": "number", "value": 2}],
+    )
+    tracker.update(event1, domain)
+    mappings_for_num_people = (
+        domain.as_dict().get("slots").get("num_people").get("mappings")
+    )
+    assert SlotMapping.intent_is_desired(mappings_for_num_people[0], tracker, domain)
+
+    event2 = UserUttered(
+        text="Yes, 2 please",
+        intent={"id": 2, "name": "affirm", "confidence": 0.9604260921478271},
+        entities=[{"entity": "number", "value": 2}],
+    )
+    tracker.update(event2, domain)
+    assert (
+        SlotMapping.intent_is_desired(mappings_for_num_people[0], tracker, domain)
+        is False
+    )
+
+    event3 = UserUttered(
+        text="Yes, please",
+        intent={"id": 3, "name": "affirm", "confidence": 0.9604260921478271},
+        entities=[],
+    )
+    tracker.update(event3, domain)
+    mappings_for_preferences = (
+        domain.as_dict().get("slots").get("preferences").get("mappings")
+    )
+    assert (
+        SlotMapping.intent_is_desired(mappings_for_preferences[0], tracker, domain)
+        is False
+    )
+
+
+def test_slot_mappings_ignored_intents_during_active_loop():
+    domain = Domain.from_yaml(
+        """
+    intents:
+    - greet
+    - chitchat
+    slots:
+      cuisine:
+        type: text
+        mappings:
+        - type: from_text
+          conditions:
+          - active_loop: restaurant_form
+    forms:
+      restaurant_form:
+        ignored_intents:
+        - chitchat
+        required_slots:
+        - cuisine
+    """
+    )
+    tracker = DialogueStateTracker("sender_id", slots=domain.slots)
+    event1 = ActiveLoop("restaurant_form")
+    event2 = UserUttered(
+        text="The weather is sunny today",
+        intent={"id": 4, "name": "chitchat", "confidence": 0.9604260921478271},
+        entities=[],
+    )
+    tracker.update_with_events([event1, event2], domain)
+    mappings_for_cuisine = domain.as_dict().get("slots").get("cuisine").get("mappings")
+    assert (
+        SlotMapping.intent_is_desired(mappings_for_cuisine[0], tracker, domain) is False
+    )

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -282,7 +282,7 @@ def test_domain_to_dict():
         "slots": {
             "some_slot": {
                 "values": ["high", "low"],
-                "auto_fill": True,
+                "auto_fill": False,
                 "influence_conversation": True,
                 "initial_value": None,
                 "mappings": [{"type": "from_text"}],

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -289,7 +289,6 @@ def test_domain_to_dict():
         "slots": {
             "some_slot": {
                 "values": ["high", "low"],
-                "auto_fill": False,
                 "influence_conversation": True,
                 "initial_value": None,
                 "mappings": [{"type": "from_text"}],
@@ -319,11 +318,15 @@ session_config:
 slots: {{}}
 """
 
-    with pytest.warns(None) as record:
+    with pytest.warns(UserWarning) as record:
         domain = Domain.from_yaml(test_yaml)
         actual_yaml = domain.as_yaml()
 
-    assert not record
+    assert (
+        "Slot auto-fill has been removed in 3.0"
+        " and replaced by a new explicit mechanism to set slots. "
+        "Please refer to the docs to learn more." == record[0].message.args[0]
+    )
 
     expected = rasa.shared.utils.io.read_yaml(test_yaml)
     actual = rasa.shared.utils.io.read_yaml(actual_yaml)

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -1545,7 +1545,7 @@ def test_domain_with_no_form_slots():
           required_slots: []
         """
     )
-    assert domain.slot_mapping_for_form("contract_form") == []
+    assert domain.required_slots_for_form("contract_form") == []
 
 
 def test_domain_with_empty_required_slots():

--- a/tests/shared/core/test_slots.py
+++ b/tests/shared/core/test_slots.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, List, Dict, Text
+from typing import Any, Tuple, List, Dict, Text, Type
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -389,3 +389,14 @@ def test_categorical_slot_ignores_none_value():
 
     message_text = "Rasa will ignore `null` as a possible value for the 'branch' slot."
     assert any(message_text in record.message.args[0] for record in records)
+
+
+@pytest.mark.parametrize(
+    "slot_type", [FloatSlot, BooleanSlot, TextSlot, ListSlot, AnySlot, CategoricalSlot]
+)
+def test_raises_deprecation_warning_auto_fill_true(slot_type: Type[Slot]):
+    with pytest.warns(FutureWarning) as warning:
+        slot = slot_type(name="test", mappings=[{}], auto_fill=True)
+
+    assert slot.auto_fill is False
+    assert "Slot auto-fill has been deactivated in 3.0" in str(warning[0].message)

--- a/tests/shared/core/test_slots.py
+++ b/tests/shared/core/test_slots.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, List, Dict, Text, Type
+from typing import Any, Tuple, List, Dict, Text
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -389,14 +389,3 @@ def test_categorical_slot_ignores_none_value():
 
     message_text = "Rasa will ignore `null` as a possible value for the 'branch' slot."
     assert any(message_text in record.message.args[0] for record in records)
-
-
-@pytest.mark.parametrize(
-    "slot_type", [FloatSlot, BooleanSlot, TextSlot, ListSlot, AnySlot, CategoricalSlot]
-)
-def test_raises_deprecation_warning_auto_fill_true(slot_type: Type[Slot]):
-    with pytest.warns(FutureWarning) as warning:
-        slot = slot_type(name="test", mappings=[{}])
-
-    assert slot.auto_fill is False
-    assert "Slot auto-fill has been deactivated in 3.0" in str(warning[0].message)

--- a/tests/shared/core/test_slots.py
+++ b/tests/shared/core/test_slots.py
@@ -396,7 +396,7 @@ def test_categorical_slot_ignores_none_value():
 )
 def test_raises_deprecation_warning_auto_fill_true(slot_type: Type[Slot]):
     with pytest.warns(FutureWarning) as warning:
-        slot = slot_type(name="test", mappings=[{}], auto_fill=True)
+        slot = slot_type(name="test", mappings=[{}])
 
     assert slot.auto_fill is False
     assert "Slot auto-fill has been deactivated in 3.0" in str(warning[0].message)

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -1373,11 +1373,13 @@ def test_autofill_slots_for_policy_entities():
                 {nlu_entity}:
                     type: text
                     mappings:
-                    - type: from_text
+                    - type: from_entity
+                      entity: {nlu_entity}
                 {policy_entity}:
                     type: text
                     mappings:
-                    - type: from_text
+                    - type: from_entity
+                      entity: {policy_entity}
             """
         )
     )

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -743,7 +743,7 @@ def test_tracker_does_not_modify_slots(
     slot_type: Type[Slot], initial_value: Any, value_to_set: Any
 ):
     slot_name = "some-slot"
-    slot = slot_type(slot_name, initial_value)
+    slot = slot_type(slot_name, mappings=[{}], initial_value=initial_value)
     tracker = DialogueStateTracker("some-conversation-id", [slot])
 
     # change the slot value in the tracker
@@ -1372,8 +1372,12 @@ def test_autofill_slots_for_policy_entities():
             slots:
                 {nlu_entity}:
                     type: text
+                    mappings:
+                    - type: from_text
                 {policy_entity}:
                     type: text
+                    mappings:
+                    - type: from_text
             """
         )
     )
@@ -1435,7 +1439,7 @@ def test_autofill_slots_for_policy_entities():
 
 
 def test_tracker_fingerprinting_consistency():
-    slot = TextSlot(name="name", influence_conversation=True)
+    slot = TextSlot(name="name", mappings=[{}], influence_conversation=True)
     slot.value = "example"
     tr1 = DialogueStateTracker("test_sender_id", slots=[slot])
     tr2 = DialogueStateTracker("test_sender_id", slots=[slot])
@@ -1445,7 +1449,7 @@ def test_tracker_fingerprinting_consistency():
 
 
 def test_tracker_unique_fingerprint(domain: Domain):
-    slot = TextSlot(name="name", influence_conversation=True)
+    slot = TextSlot(name="name", mappings=[{}], influence_conversation=True)
     slot.value = "example"
     tr = DialogueStateTracker("test_sender_id", slots=[slot])
     f1 = tr.fingerprint()
@@ -1497,7 +1501,7 @@ def test_tracker_fingerprint_story_reading(domain: Domain):
             else:
                 events.append(evts)
 
-        slot = TextSlot(name="name", influence_conversation=True)
+        slot = TextSlot(name="name", mappings=[{}], influence_conversation=True)
         slot.value = "example"
 
         tracker = DialogueStateTracker.from_events("sender_id", events, [slot])

--- a/tests/shared/core/training_data/story_reader/test_yaml_story_reader.py
+++ b/tests/shared/core/training_data/story_reader/test_yaml_story_reader.py
@@ -60,8 +60,8 @@ def test_can_read_test_story_with_slots(domain: Domain):
 @pytest.mark.parametrize(
     "domain_dict",
     [
-        {"slots": {"my_slot": {"type": "text"}}},
-        {"slots": {"my_slot": {"type": "list"}}},
+        {"slots": {"my_slot": {"type": "text", "mappings": [{}]}}},
+        {"slots": {"my_slot": {"type": "list", "mappings": [{}]}}},
     ],
 )
 async def test_default_slot_value_if_slots_referenced_by_name_only(domain_dict: Dict):
@@ -84,8 +84,8 @@ async def test_default_slot_value_if_slots_referenced_by_name_only(domain_dict: 
 @pytest.mark.parametrize(
     "domain_dict",
     [
-        {"slots": {"my_slot": {"type": "categorical"}}},
-        {"slots": {"my_slot": {"type": "float"}}},
+        {"slots": {"my_slot": {"type": "categorical", "mappings": [{}]}}},
+        {"slots": {"my_slot": {"type": "float", "mappings": [{}]}}},
     ],
 )
 async def test_default_slot_value_if_incompatible_slots_referenced_by_name_only(
@@ -137,7 +137,7 @@ async def test_default_slot_value_if_unfeaturized_slot():
         - my_slot
     """
     domain = Domain.from_dict(
-        {"intents": ["greet"], "slots": {"my_slot": {"type": "any"}}}
+        {"intents": ["greet"], "slots": {"my_slot": {"type": "any", "mappings": [{}]}}}
     )
     reader = YAMLStoryReader(domain)
     with pytest.warns(None) as warnings:

--- a/tests/shared/core/training_data/story_reader/test_yaml_story_reader.py
+++ b/tests/shared/core/training_data/story_reader/test_yaml_story_reader.py
@@ -60,8 +60,8 @@ def test_can_read_test_story_with_slots(domain: Domain):
 @pytest.mark.parametrize(
     "domain_dict",
     [
-        {"slots": {"my_slot": {"type": "text", "mappings": [{}]}}},
-        {"slots": {"my_slot": {"type": "list", "mappings": [{}]}}},
+        {"slots": {"my_slot": {"type": "text", "mappings": [{"type": "from_text"}]}}},
+        {"slots": {"my_slot": {"type": "list", "mappings": [{"type": "from_text"}]}}},
     ],
 )
 async def test_default_slot_value_if_slots_referenced_by_name_only(domain_dict: Dict):
@@ -84,8 +84,12 @@ async def test_default_slot_value_if_slots_referenced_by_name_only(domain_dict: 
 @pytest.mark.parametrize(
     "domain_dict",
     [
-        {"slots": {"my_slot": {"type": "categorical", "mappings": [{}]}}},
-        {"slots": {"my_slot": {"type": "float", "mappings": [{}]}}},
+        {
+            "slots": {
+                "my_slot": {"type": "categorical", "mappings": [{"type": "from_text"}]}
+            }
+        },
+        {"slots": {"my_slot": {"type": "float", "mappings": [{"type": "from_text"}]}}},
     ],
 )
 async def test_default_slot_value_if_incompatible_slots_referenced_by_name_only(
@@ -137,7 +141,10 @@ async def test_default_slot_value_if_unfeaturized_slot():
         - my_slot
     """
     domain = Domain.from_dict(
-        {"intents": ["greet"], "slots": {"my_slot": {"type": "any", "mappings": [{}]}}}
+        {
+            "intents": ["greet"],
+            "slots": {"my_slot": {"type": "any", "mappings": [{"type": "from_text"}]}},
+        }
     )
     reader = YAMLStoryReader(domain)
     with pytest.warns(None) as warnings:

--- a/tests/shared/importers/test_rasa.py
+++ b/tests/shared/importers/test_rasa.py
@@ -24,7 +24,7 @@ def test_rasa_file_importer(project: Text):
 
     domain = importer.get_domain()
     assert len(domain.intents) == 7 + len(DEFAULT_INTENTS)
-    assert domain.slots == [AnySlot(SESSION_START_METADATA_SLOT)]
+    assert domain.slots == [AnySlot(SESSION_START_METADATA_SLOT, mappings=[{}])]
     assert domain.entities == []
     assert len(domain.action_names_or_texts) == 18
     assert len(domain.responses) == 6

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -353,8 +353,12 @@ def test_verify_form_slots_invalid_domain(tmp_path: Path):
         slots:
              first_name:
                 type: text
+                mappings:
+                - type: from_text
              last_nam:
                 type: text
+                mappings:
+                - type: from_text
         """
     )
     importer = RasaFileImporter(domain_path=domain)
@@ -468,8 +472,12 @@ def test_valid_form_slots_in_domain(tmp_path: Path):
         slots:
              first_name:
                 type: text
+                mappings:
+                - type: from_text
              last_name:
                 type: text
+                mappings:
+                - type: from_text
         """
     )
     importer = RasaFileImporter(domain_path=domain)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -346,31 +346,27 @@ def test_verify_form_slots_invalid_domain(tmp_path: Path):
         forms:
           name_form:
             required_slots:
-              first_name:
-              - type: from_text
-              last_name:
-              - type: from_text
+              - first_name
+              - last_nam
         slots:
              first_name:
                 type: text
                 mappings:
                 - type: from_text
-             last_nam:
+             last_name:
                 type: text
                 mappings:
                 - type: from_text
         """
     )
     importer = RasaFileImporter(domain_path=domain)
-    validator = Validator.from_importer(importer)
     with pytest.warns(UserWarning) as w:
-        validity = validator.verify_form_slots()
-        assert validity is False
+        Validator.from_importer(importer)
 
     assert (
-        w[0].message.args[0] == "The form slot 'last_name' in form 'name_form' "
-        "is not present in the domain slots."
-        "Please add the correct slot or check for typos."
+        f"Loading domain from '{domain}' failed. Using empty domain. "
+        f"Error: 'The slot 'last_nam' in form 'name_form' is "
+        f"not mapped in domain slots.'" == w[0].message.args[0]
     )
 
 
@@ -465,10 +461,8 @@ def test_valid_form_slots_in_domain(tmp_path: Path):
         forms:
           name_form:
             required_slots:
-              first_name:
-              - type: from_text
-              last_name:
-              - type: from_text
+              - first_name
+              - last_name
         slots:
              first_name:
                 type: text


### PR DESCRIPTION
**Proposed changes**:
- Closes #9363 
- Also had to adapt `forms.py` in order to make the unit tests pass, kept the changes to a minimum, so that the next PR will look into considerable more change to this module as planned in issue #9364 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
