### PR TITLE
Utilizing retrieval intents in test stories

### DIFF
--- a/changelog/8459.improvement.md
+++ b/changelog/8459.improvement.md
@@ -1,0 +1,37 @@
+1) Failed test stories will display full retrieval intents. 
+
+2) Retrieval intents will be extracted during action prediction in test stories so that we won't have unnecessary mismatches anymore.
+
+Let's take this example story:
+```yaml
+- story: test story
+  steps:
+  - user: |
+      what is your name?
+    intent: chitchat/ask_name
+  - action: utter_chitchat/ask_name
+  - intent: bye
+  - action: utter_bye
+```
+
+Before:
+```yaml
+  steps:
+  - intent: chitchat   # 1) intent is not displayed in it's original form
+  - action: utter_chitchat/ask_name  # predicted: utter_chitchat  
+                  # 2) retrieval intent is not extracted during action prediction and we have a mismatch
+  
+  - intent: bye  # some other fail
+  - action: utter_bye # some other fail
+```
+
+Both 1) and 2) problems are solved.
+
+Now:
+```yaml
+  steps:
+  - intent: chitchat/ask_name
+  - action: utter_chitchat/ask_name
+  - intent: bye  # some other fail
+  - action: utter_bye # some other fail
+```

--- a/data/test_retrieval_intents_in_test_stories/config.yml
+++ b/data/test_retrieval_intents_in_test_stories/config.yml
@@ -1,0 +1,14 @@
+language: en
+pipeline:
+- name: WhitespaceTokenizer
+- name: CountVectorsFeaturizer
+- name: DIETClassifier
+  epochs: 5
+- name: ResponseSelector
+  epochs: 5
+policies:
+- name: TEDPolicy
+  random_seed: 42
+  epochs: 5
+- name: MemoizationPolicy
+  max_history: 5

--- a/data/test_retrieval_intents_in_test_stories/data/nlu.yml
+++ b/data/test_retrieval_intents_in_test_stories/data/nlu.yml
@@ -1,0 +1,23 @@
+version: "2.0"
+
+nlu:
+- intent: greet
+  examples: |
+    - hey
+    - hello
+    - hi
+    - hello there
+    - good morning
+
+- intent: faq/is-this-legit
+  examples: |
+    - is that really legit ?
+    - is this real?
+    - can I trust these projects?
+
+- intent: faq/inquire-cost
+  examples: |
+    - Ok.  How much would that cost?
+    - How much are offsets
+    - How much do they cost
+    - how much will it cost me

--- a/data/test_retrieval_intents_in_test_stories/data/stories.yml
+++ b/data/test_retrieval_intents_in_test_stories/data/stories.yml
@@ -1,0 +1,12 @@
+version: "2.0"
+
+stories:
+- story: greet
+  steps:
+  - intent: greet
+  - action: utter_greet
+
+- story: faq
+  steps:
+  - intent: faq
+  - action: utter_faq

--- a/data/test_retrieval_intents_in_test_stories/domain.yml
+++ b/data/test_retrieval_intents_in_test_stories/domain.yml
@@ -1,0 +1,14 @@
+version: "2.0"
+
+intents:
+- greet
+- faq:
+    is_retrieval_intent: true
+
+responses:
+  utter_greet:
+  - text: hi!
+  utter_faq/is-this-legit:
+  - text: yes, it is
+  utter_faq/inquire-cost:
+  - text: idk

--- a/data/test_retrieval_intents_in_test_stories/tests/test_stories.yml
+++ b/data/test_retrieval_intents_in_test_stories/tests/test_stories.yml
@@ -1,0 +1,32 @@
+version: "2.0"
+
+stories:
+- story: test full intent name
+  steps:
+  - user: |
+      is that really legit ?
+    intent: faq/is-this-legit
+  - action: utter_faq/is-this-legit
+
+- story: test retrieving full utter action when predicted wrongly
+  steps:
+  - user: |
+      is that really legit ?
+    intent: faq/is-this-legit
+  - action: utter_faq/inquire-cost
+
+- story: test that works well without retrieval intents
+  steps:
+  - user: |
+      is that really legit ?
+    intent: faq
+  - action: utter_greet
+
+- story: test that works well without retrieval intents
+  steps:
+  - user: |
+      is that really legit ?
+    intent: faq
+  - action: utter_faq
+
+

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -4,25 +4,21 @@ import logging
 from typing import List, Text, Optional, Dict, Any, TYPE_CHECKING
 
 import aiohttp
-
 import rasa.core
-from rasa.core.policies.policy import PolicyPrediction
-
-from rasa.shared.core import events
 from rasa.core.constants import DEFAULT_REQUEST_TIMEOUT
-
+from rasa.core.policies.policy import PolicyPrediction
 from rasa.nlu.constants import (
     RESPONSE_SELECTOR_DEFAULT_INTENT,
     RESPONSE_SELECTOR_PROPERTY_NAME,
     RESPONSE_SELECTOR_PREDICTION_KEY,
     RESPONSE_SELECTOR_UTTER_ACTION_KEY,
 )
-
 from rasa.shared.constants import (
     DOCS_BASE_URL,
     DEFAULT_NLU_FALLBACK_INTENT_NAME,
     UTTER_PREFIX,
 )
+from rasa.shared.core import events
 from rasa.shared.core.constants import (
     USER_INTENT_OUT_OF_SCOPE,
     ACTION_LISTEN_NAME,
@@ -37,8 +33,7 @@ from rasa.shared.core.constants import (
     ACTION_BACK_NAME,
     REQUESTED_SLOT,
 )
-from rasa.shared.exceptions import RasaException
-from rasa.shared.nlu.constants import INTENT_NAME_KEY, INTENT_RANKING_KEY
+from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
     UserUtteranceReverted,
     UserUttered,
@@ -50,10 +45,10 @@ from rasa.shared.core.events import (
     Restarted,
     SessionStarted,
 )
+from rasa.shared.exceptions import RasaException
+from rasa.shared.nlu.constants import INTENT_NAME_KEY, INTENT_RANKING_KEY
 from rasa.shared.utils.schemas.events import EVENTS_SCHEMA
 from rasa.utils.endpoints import EndpointConfig, ClientResponseError
-from rasa.shared.core.domain import Domain
-
 
 if TYPE_CHECKING:
     from rasa.shared.core.trackers import DialogueStateTracker
@@ -359,6 +354,34 @@ class ActionRetrieveResponse(ActionBotResponse):
         """Resolve the name of the intent from the action name."""
         return action_name.split(UTTER_PREFIX)[1]
 
+    def get_full_retrieval_name(
+        self, tracker: "DialogueStateTracker"
+    ) -> Optional[Text]:
+        """Extracts retrieval intent from response selector and
+        returns complete action utterance name."""
+        if RESPONSE_SELECTOR_PROPERTY_NAME not in tracker.latest_message.parse_data:
+            return None
+
+        response_selector_properties = tracker.latest_message.parse_data[
+            RESPONSE_SELECTOR_PROPERTY_NAME
+        ]
+
+        if (
+            self.intent_name_from_action(self.action_name)
+            in response_selector_properties
+        ):
+            query_key = self.intent_name_from_action(self.action_name)
+        elif RESPONSE_SELECTOR_DEFAULT_INTENT in response_selector_properties:
+            query_key = RESPONSE_SELECTOR_DEFAULT_INTENT
+        else:
+            return None
+
+        selected = response_selector_properties[query_key]
+        full_retrieval_utter_action = selected[RESPONSE_SELECTOR_PREDICTION_KEY][
+            RESPONSE_SELECTOR_UTTER_ACTION_KEY
+        ]
+        return full_retrieval_utter_action
+
     async def run(
         self,
         output_channel: "OutputChannel",
@@ -367,7 +390,6 @@ class ActionRetrieveResponse(ActionBotResponse):
         domain: "Domain",
     ) -> List[Event]:
         """Query the appropriate response and create a bot utterance with that."""
-
         response_selector_properties = tracker.latest_message.parse_data[
             RESPONSE_SELECTOR_PROPERTY_NAME
         ]

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -32,6 +32,7 @@ from rasa.nlu.constants import (
     RESPONSE_SELECTOR_DEFAULT_INTENT,
     RESPONSE_SELECTOR_RETRIEVAL_INTENTS,
     TOKENS_NAMES,
+    RESPONSE_SELECTOR_PROPERTY_NAME,
 )
 from rasa.shared.nlu.constants import (
     INTENT,
@@ -57,6 +58,8 @@ from rasa.shared.importers.importer import TrainingDataImporter
 from rasa.shared.utils.io import DEFAULT_ENCODING
 from rasa.utils.tensorflow.constants import QUERY_INTENT_KEY, SEVERITY_KEY
 from rasa.exceptions import ActionLimitReached
+
+from rasa.core.actions.action import ActionRetrieveResponse
 
 if typing.TYPE_CHECKING:
     from rasa.core.agent import Agent
@@ -519,7 +522,6 @@ def _collect_user_uttered_predictions(
 
     # predicted intent: note that this is only the base intent at this point
     predicted_base_intent = predicted.get(INTENT, {}).get(INTENT_NAME_KEY)
-
     # if the test story only provides the base intent AND the prediction was correct,
     # we are not interested in full retrieval intents and skip this section.
     # In any other case we are interested in the full retrieval intent (e.g. for report)
@@ -550,8 +552,20 @@ def _collect_user_uttered_predictions(
                 f" \n\n{story_dump}"
             )
     else:
+        response_selector_info = (
+            {
+                RESPONSE_SELECTOR_PROPERTY_NAME: predicted[
+                    RESPONSE_SELECTOR_PROPERTY_NAME
+                ]
+            }
+            if RESPONSE_SELECTOR_PROPERTY_NAME in predicted
+            else None
+        )
         end_to_end_user_utterance = EndToEndUserUtterance(
-            event.text, event.intent, event.entities
+            text=event.text,
+            intent=event.intent,
+            entities=event.entities,
+            parse_data=response_selector_info,
         )
         partial_tracker.update(end_to_end_user_utterance)
 
@@ -600,18 +614,48 @@ def _get_e2e_entity_evaluation_result(
     return None
 
 
+def _get_predicted_action_name(
+    predicted_action: rasa.core.actions.action.Action,
+    partial_tracker: DialogueStateTracker,
+    expected_action_name: Text,
+) -> Optional[Text]:
+    """Get the name of predicted action.
+
+    If the action is instance of `ActionRetrieveResponse`, we need to return full
+    action name with its retrieval intent (e.g. utter_faq/is-this-legit).
+    The only case when we should not do it is when an expected action given in
+    a test story is a retrieval action but it's not specified in the test story.
+    To illustrate this, we're basically avoiding this unnecessary mismatch:
+    utter_faq (expected) != utter_faq/is-this-legit (predicted).
+    In this case or if the action isn't instance of `ActionRetrieveResponse`,
+    the function returns only the action name (e.g. utter_faq).
+    """
+    if (
+        isinstance(predicted_action, ActionRetrieveResponse)
+        and expected_action_name != predicted_action.name()
+    ):
+        full_retrieval_name = predicted_action.get_full_retrieval_name(partial_tracker)
+        predicted_action_name = (
+            full_retrieval_name if full_retrieval_name else predicted_action.name()
+        )
+    else:
+        predicted_action_name = predicted_action.name()
+    return predicted_action_name
+
+
 def _run_action_prediction(
     processor: "MessageProcessor",
     partial_tracker: DialogueStateTracker,
     expected_action: Text,
 ) -> Tuple[Text, PolicyPrediction, Optional[EntityEvaluationResult]]:
     action, prediction = processor.predict_next_action(partial_tracker)
-    predicted_action = action.name()
+    predicted_action = _get_predicted_action_name(
+        action, partial_tracker, expected_action
+    )
 
     policy_entity_result = _get_e2e_entity_evaluation_result(
         processor, partial_tracker, prediction
     )
-
     if (
         prediction.policy_name
         and predicted_action != expected_action
@@ -624,11 +668,12 @@ def _run_action_prediction(
         emulate_loop_rejection(partial_tracker)
         # try again
         action, prediction = processor.predict_next_action(partial_tracker)
-
         # Even if the prediction is also wrong, we don't have to undo the emulation
         # of the action rejection as we know that the user explicitly specified
         # that something else than the form was supposed to run.
-        predicted_action = action.name()
+        predicted_action = _get_predicted_action_name(
+            action, partial_tracker, expected_action
+        )
 
     return predicted_action, prediction, policy_entity_result
 
@@ -764,7 +809,6 @@ async def _predict_tracker_actions(
         agent.domain.slots,
         sender_source=tracker.sender_source,
     )
-
     tracker_actions = []
     policy_entity_results = []
 
@@ -777,7 +821,6 @@ async def _predict_tracker_actions(
             ) = _collect_action_executed_predictions(
                 processor, partial_tracker, event, fail_on_prediction_errors,
             )
-
             if entity_result:
                 policy_entity_results.append(entity_result)
 
@@ -802,14 +845,13 @@ async def _predict_tracker_actions(
             # Leaving that as it is because Markdown is in legacy mode.
             else:
                 predicted = await processor.parse_message(UserMessage(event.text))
+
             user_uttered_result = _collect_user_uttered_predictions(
                 event, predicted, partial_tracker, fail_on_prediction_errors
             )
-
             tracker_eval_store.merge_store(user_uttered_result)
         else:
             partial_tracker.update(event)
-
     return tracker_eval_store, partial_tracker, tracker_actions, policy_entity_results
 
 

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -56,7 +56,9 @@ from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_START,
     ENTITY_ATTRIBUTE_CONFIDENCE,
     ENTITY_ATTRIBUTE_END,
+    FULL_RETRIEVAL_INTENT_NAME_KEY,
 )
+
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -456,7 +458,6 @@ class UserUttered(Event):
             "message_id": self.message_id,
             "metadata": self.metadata,
         }
-
         if parse_data:
             self.parse_data.update(**parse_data)
 
@@ -488,6 +489,11 @@ class UserUttered(Event):
     def intent_name(self) -> Optional[Text]:
         """Returns intent name or `None` if no intent."""
         return self.intent.get(INTENT_NAME_KEY)
+
+    @property
+    def full_retrieval_intent_name(self) -> Optional[Text]:
+        """Returns full retrieval intent name or `None` if no retrieval intent."""
+        return self.intent.get(FULL_RETRIEVAL_INTENT_NAME_KEY)
 
     def __eq__(self, other: Any) -> bool:
         """Compares object with other object."""

--- a/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
+++ b/rasa/shared/core/training_data/story_writer/yaml_story_writer.py
@@ -101,7 +101,6 @@ class YAMLStoryWriter(StoryWriter):
         result = self.stories_to_yaml(story_steps, is_test_story)
         if is_appendable and KEY_STORIES in result:
             result = result[KEY_STORIES]
-
         rasa.shared.utils.io.write_yaml(result, target, True)
 
     def stories_to_yaml(
@@ -149,7 +148,6 @@ class YAMLStoryWriter(StoryWriter):
         result = OrderedDict()
         result[KEY_STORY_NAME] = story_step.block_name
         steps = self.process_checkpoints(story_step.start_checkpoints)
-
         for event in story_step.events:
             if not self._filter_event(event):
                 continue
@@ -210,7 +208,11 @@ class YAMLStoryWriter(StoryWriter):
         """
         result = CommentedMap()
         if user_utterance.intent_name and not user_utterance.use_text_for_featurization:
-            result[KEY_USER_INTENT] = user_utterance.intent_name
+            result[KEY_USER_INTENT] = (
+                user_utterance.full_retrieval_intent_name
+                if user_utterance.full_retrieval_intent_name
+                else user_utterance.intent_name
+            )
 
         if hasattr(user_utterance, "inline_comment"):
             comment = user_utterance.inline_comment()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -553,6 +553,60 @@ async def e2e_bot(
     return Path(zipped_model)
 
 
+@pytest.fixture(scope="session")
+async def intent_retrieval_bot_domain_file() -> Path:
+    return Path("data/test_retrieval_intents_in_test_stories/domain.yml")
+
+
+@pytest.fixture(scope="session")
+async def intent_retrieval_bot_config_file() -> Path:
+    return Path("data/test_retrieval_intents_in_test_stories/config.yml")
+
+
+@pytest.fixture(scope="session")
+async def intent_retrieval_bot_training_files() -> List[Path]:
+    return [
+        Path("data/test_retrieval_intents_in_test_stories/data/stories.yml"),
+        Path("data/test_retrieval_intents_in_test_stories/data/nlu.yml"),
+    ]
+
+
+@pytest.fixture(scope="session")
+async def intent_retrieval_bot_test_stories() -> Path:
+    return Path("data/test_retrieval_intents_in_test_stories/tests/test_stories.yml")
+
+
+@pytest.fixture(scope="session")
+async def intent_retrieval_bot_test_results() -> Path:
+    return Path("data/test_retrieval_intents_in_test_stories/results/")
+
+
+@pytest.fixture(scope="session")
+async def trained_intent_retrieval_bot(
+    trained_async: Callable,
+    intent_retrieval_bot_domain_file: Path,
+    intent_retrieval_bot_config_file: Path,
+    intent_retrieval_bot_training_files: List[Path],
+) -> Path:
+    zipped_model = await trained_async(
+        domain=intent_retrieval_bot_domain_file,
+        config=intent_retrieval_bot_config_file,
+        training_files=intent_retrieval_bot_training_files,
+    )
+
+    if not zipped_model:
+        raise RasaException("Model training for intent retrieval bot failed.")
+
+    return Path(zipped_model)
+
+
+@pytest.fixture(scope="module")
+async def intent_retrieval_agent(
+    trained_intent_retrieval_bot: Optional[Path],
+) -> Agent:
+    return Agent.load_local_model(trained_intent_retrieval_bot)
+
+
 @pytest.fixture(scope="module")
 async def response_selector_agent(
     trained_response_selector_bot: Optional[Path],


### PR DESCRIPTION
PR for issue #8459 
**Proposed changes**:
- Failed test stories will display full retrieval intents.
- Retrieval intents will be extracted during action prediction in test stories so that we won't have unnecessary mismatches anymore.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
