### PR TITLE
model regression test: support various GPU runners

### DIFF
--- a/.github/configs/tf-cuda.json
+++ b/.github/configs/tf-cuda.json
@@ -1,0 +1,16 @@
+{
+  "config": [
+    {
+      "TF": "2.3",
+      "IMAGE_TAG": "cuda-10.1-cudnn7"
+    },
+    {
+      "TF": "2.5",
+      "IMAGE_TAG": "test-yiyao"
+    },
+    {
+      "TF": "2.6",
+      "IMAGE_TAG": "test-yiyao"
+    }
+  ]
+}

--- a/.github/configs/tf-cuda.json
+++ b/.github/configs/tf-cuda.json
@@ -1,4 +1,5 @@
 {
+  "default_image_tag": "latest",
   "config": [
     {
       "TF": "2.3",
@@ -6,11 +7,11 @@
     },
     {
       "TF": "2.5",
-      "IMAGE_TAG": "test-yiyao"
+      "IMAGE_TAG": "cuda-11.2.0-cudnn8"
     },
     {
       "TF": "2.6",
-      "IMAGE_TAG": "test-yiyao"
+      "IMAGE_TAG": "cuda-11.2.0-cudnn8"
     }
   ]
 }

--- a/.github/runner/github-runner-deployment.yaml.tmpl
+++ b/.github/runner/github-runner-deployment.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 720
       containers:
       - name: github-runner
-        image: {{getenv "GH_RUNNER_IMAGE"}}:latest
+        image: {{getenv "GH_RUNNER_IMAGE"}}:test-yiyao
         imagePullPolicy: Always
         livenessProbe:
           initialDelaySeconds: 30

--- a/.github/runner/github-runner-deployment.yaml.tmpl
+++ b/.github/runner/github-runner-deployment.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 720
       containers:
       - name: github-runner
-        image: {{getenv "GH_RUNNER_IMAGE"}}:{{getenv "GH_RUNNER_IMAGE_TAG"}}
+        image: {{getenv "GH_RUNNER_IMAGE"}}:{{getenv "GH_RUNNER_IMAGE_TAG" "latest"}}
         imagePullPolicy: Always
         livenessProbe:
           initialDelaySeconds: 30

--- a/.github/runner/github-runner-deployment.yaml.tmpl
+++ b/.github/runner/github-runner-deployment.yaml.tmpl
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 720
       containers:
       - name: github-runner
-        image: {{getenv "GH_RUNNER_IMAGE"}}:test-yiyao
+        image: {{getenv "GH_RUNNER_IMAGE"}}:{{getenv "GH_RUNNER_IMAGE_TAG"}}
         imagePullPolicy: Always
         livenessProbe:
           initialDelaySeconds: 30

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -59,9 +59,9 @@ jobs:
 
       - name: Get TensorFlow version
         run: |-
-          # Read TF version
+          # Read TF version, trim special characters ^~><+
           TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
-          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION if 2.3.4
+          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION is 2.3.4
           TF_VERSION=${TF_VERSION::3}
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -57,8 +57,25 @@ jobs:
           curl -o gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64
           chmod 755 gomplate
 
+      - name: Get TensorFlow version
+        run: |-
+          # Read TF version
+          TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
+          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION if 2.3.4
+          TF_VERSION=${TF_VERSION::3}
+          echo "TensorFlow version: $TF_VERSION"
+          echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
+
+       # Use compatible CUDA/cuDNN with the given TF version
+      - name: Prepare GitHub runner image tag
+        run: |-
+          GH_RUNNER_IMAGE_TAG=$(jq -r 'if (.config | any(.TF == "${{ env.TF_VERSION }}" )) then (.config[] | select(.TF == "${{ env.TF_VERSION }}") | .IMAGE_TAG) else .default_image_tag end' .github/configs/tf-cuda.json)
+          echo "GitHub runner image tag for TensorFlow ${{ env.TF_VERSION }} is ${GH_RUNNER_IMAGE_TAG}"
+          echo GH_RUNNER_IMAGE_TAG=$GH_RUNNER_IMAGE_TAG >> $GITHUB_ENV
+
       - name: Render deployment template
         run: |-
+          export GH_RUNNER_IMAGE_TAG=${{ env.GH_RUNNER_IMAGE_TAG }}
           export GH_RUNNER_IMAGE=${{ secrets.GH_RUNNER_IMAGE }}
           ./gomplate -f .github/runner/github-runner-deployment.yaml.tmpl -o runner_deployment.yaml
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -163,7 +163,7 @@ jobs:
       # Use compatible CUDA/cuDNN with the given TF version
       - name: Prepare GitHub runner image tag
         run: |-
-          GH_RUNNER_IMAGE_TAG=$(jq -r '.config[] | select(.TF  == "${{ env.TF_VERSION }}") | .IMAGE_TAG' .github/configs/tf-cuda.json)
+          GH_RUNNER_IMAGE_TAG=$(jq -r 'if (.config | any(.TF == "${{ env.TF_VERSION }}" )) then (.config[] | select(.TF == "${{ env.TF_VERSION }}") | .IMAGE_TAG) else .default_image_tag end' .github/configs/tf-cuda.json)
           echo "GitHub runner image tag for TensorFlow ${{ env.TF_VERSION }} is ${GH_RUNNER_IMAGE_TAG}"
           echo GH_RUNNER_IMAGE_TAG=$GH_RUNNER_IMAGE_TAG >> $GITHUB_ENV
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -163,7 +163,7 @@ jobs:
       # Use compatible CUDA/cuDNN with the given TF version
       - name: Prepare GitHub runner image tag
         run: |-
-          GH_RUNNER_IMAGE_TAG=$(jq -r '.config[] | select(.TF  == "${{ env.TF_VERSION }}") | .IMAGE_TAG' .github/config/tf-cuda.json)
+          GH_RUNNER_IMAGE_TAG=$(jq -r '.config[] | select(.TF  == "${{ env.TF_VERSION }}") | .IMAGE_TAG' .github/configs/tf-cuda.json)
           echo "GitHub runner image tag for TensorFlow ${{ env.TF_VERSION }} is ${GH_RUNNER_IMAGE_TAG}"
           echo GH_RUNNER_IMAGE_TAG=$GH_RUNNER_IMAGE_TAG >> $GITHUB_ENV
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -153,10 +153,12 @@ jobs:
           sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64
           sudo chmod +x /usr/local/bin/gomplate
 
-      # Read TF version
       - name: Get TensorFlow version
         run: |-
-          TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\)".*/\1/' | sed 's/[\^\~]//g')
+          # Read TF version
+          TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
+          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION if 2.3.4
+          TF_VERSION=$(TF_VERSION::3)
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -155,9 +155,9 @@ jobs:
 
       - name: Get TensorFlow version
         run: |-
-          # Read TF version
+          # Read TF version, trim special characters ^~><+
           TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
-          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION if 2.3.4
+          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION is 2.3.4
           TF_VERSION=${TF_VERSION::3}
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -153,8 +153,23 @@ jobs:
           sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64
           sudo chmod +x /usr/local/bin/gomplate
 
+      # Read TF version
+      - name: Get TensorFlow version
+        run: |-
+          TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\)".*/\1/' | sed 's/[\^\~]//g')
+          echo "TensorFlow version: $TF_VERSION"
+          echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
+
+      # Use compatible CUDA/cuDNN with the given TF version
+      - name: Prepare GitHub runner image tag
+        run: |-
+          GH_RUNNER_IMAGE_TAG=$(jq -r '.config[] | select(.TF  == \"${{ env.TF_VERSION }}\") | .IMAGE_TAG' .github/config/tf-cuda.json)
+          echo "GitHub runner image tag for TensorFlow ${{ env.TF_VERSION }} is ${GH_RUNNER_IMAGE_TAG}"
+          echo GH_RUNNER_IMAGE_TAG=$GH_RUNNER_IMAGE_TAG >> $GITHUB_ENV
+
       - name: Render deployment template
         run: |-
+          export GH_RUNNER_IMAGE_TAG=${{ env.GH_RUNNER_IMAGE_TAG }}
           export GH_RUNNER_IMAGE=${{ secrets.GH_RUNNER_IMAGE }}
           gomplate -f .github/runner/github-runner-deployment.yaml.tmpl -o runner_deployment.yaml
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -158,7 +158,7 @@ jobs:
           # Read TF version
           TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
           # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION if 2.3.4
-          TF_VERSION=$(TF_VERSION::3)
+          TF_VERSION=${TF_VERSION::3}
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -163,7 +163,7 @@ jobs:
       # Use compatible CUDA/cuDNN with the given TF version
       - name: Prepare GitHub runner image tag
         run: |-
-          GH_RUNNER_IMAGE_TAG=$(jq -r '.config[] | select(.TF  == \"${{ env.TF_VERSION }}\") | .IMAGE_TAG' .github/config/tf-cuda.json)
+          GH_RUNNER_IMAGE_TAG=$(jq -r '.config[] | select(.TF  == "${{ env.TF_VERSION }}") | .IMAGE_TAG' .github/config/tf-cuda.json)
           echo "GitHub runner image tag for TensorFlow ${{ env.TF_VERSION }} is ${GH_RUNNER_IMAGE_TAG}"
           echo GH_RUNNER_IMAGE_TAG=$GH_RUNNER_IMAGE_TAG >> $GITHUB_ENV
 


### PR DESCRIPTION
**Proposed changes**:

Add a TensorFlow-CUDA mapping to select GitHub GPU runner according to the TensorFlow version defined in `pyproject.toml`. 


The mapping is defined in `tf-cuda.json` file. If there is any updates on the [compatibility matrix](https://www.tensorflow.org/install/source#gpu), this file should be updated accordingly.

For example,
- If the `tf` version is not set in `tf-cuda.json` file, we use the default image tag  `latest`, which refers to the latest gpu runner. 
- If `tf` version is `>=2.3.4, 2.4`, the GitHub runner will use `cuda-10.1` and `cudnn7`. See the test run [here](https://github.com/RasaHQ/rasa/pull/9686/checks?check_run_id=3664735921#step:4:12) and [here](https://github.com/RasaHQ/rasa/pull/9686/checks?check_run_id=3664735921#step:5:10).
- When `tf` version is `~2.6`, use `cuda-11.2.0` and `cudnn8`. See the test run [here](https://github.com/RasaHQ/rasa/runs/3663447697?check_suite_focus=true#step:4:9) and [here](https://github.com/RasaHQ/rasa/runs/3663447697?check_suite_focus=true#step:5:10).

