### PR TITLE
fix origin check in Features.combine; add tests

### DIFF
--- a/rasa/shared/nlu/training_data/features.py
+++ b/rasa/shared/nlu/training_data/features.py
@@ -280,22 +280,12 @@ class Features:
                 ):
                     if expected != actual:
                         raise ValueError(
-                            f"Expected {expected} to be the origin of the {idx}-th "
+                            f"Expected '{expected}' to be the origin of the {idx}-th "
                             f"feature (because of `origin_of_combination`) but found a "
-                            f"feature from {actual}."
+                            f"feature from '{actual}'."
                         )
-        else:
-            origins: Set[Tuple[Text]] = set(
-                tuple(f.origin) if not isinstance(f.origin, Text) else (f.origin,)
-                for f in features_list
-            )
-            if len(origins) > 1:
-                raise ValueError(
-                    f"Expected all Features to have the same origin "
-                    f"found the following origins: {origins}."
-                )
         # (2) attributes (is_sparse, type, attribute) must coincide
-        # Note: we could also use `filter` for this check, but then the erorr msgs
+        # Note: we could also use `filter` for this check, but then the error msgs
         # aren't as nice.
         sparseness: Set[bool] = set(f.is_sparse() for f in features_list)
         if len(sparseness) > 1:
@@ -366,10 +356,10 @@ class Features:
             )
         output = []
         for is_sparse in [True, False]:
-            # all sparse featues before all dense features
+            # all sparse features before all dense features
             for type in [FEATURE_TYPE_SEQUENCE, FEATURE_TYPE_SENTENCE]:
                 # sequence feature that is (not) sparse before sentence feature that is
-                #  (not) sparse
+                # (not) sparse
                 sublist = Features.filter(
                     features_list=features_list, type=type, is_sparse=is_sparse,
                 )

--- a/tests/shared/nlu/training_data/test_features.py
+++ b/tests/shared/nlu/training_data/test_features.py
@@ -457,7 +457,7 @@ def test_reduce_raises_if_combining_different_origins_or_attributes(differ: Text
         message = "Expected all Features to describe the same attribute"
         expected_origin = ["origin"]
     else:
-        message = f"Expected 'origin-1' to be the origin of the 0-th"
+        message = "Expected 'origin-1' to be the origin of the 0-th"
         expected_origin = ["origin-1"]
     with pytest.raises(ValueError, match=message):
         Features.reduce(features_list, expected_origins=expected_origin)


### PR DESCRIPTION
**Proposed changes**:
- remove origin check in `Features.combine` if `expected_features` is `None` because there is nothing we can check - the origins must differ as it is should be the only thing that differs (attribute, type, sparseness are identical)
- added a unit test case 
- adapted tests for `Features.reduce` which was misusing that "feature"

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
