### PR TITLE
add tmate session to debug runner

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -302,6 +302,10 @@ jobs:
       run: |
         make ${{ matrix.test }}
 
+    - name: Setup tmate session
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+
     - name: Send Coverage Report 📊
       if: needs.changes.outputs.backend == 'true' && matrix.python-version == 3.6 && matrix.os != 'windows-latest'
       continue-on-error: true

--- a/rasa/api.py
+++ b/rasa/api.py
@@ -153,4 +153,3 @@ def test(
     rasa.utils.common.run_in_loop(
         test_nlu(model, nlu_data, output, additional_arguments)
     )
-

--- a/rasa/api.py
+++ b/rasa/api.py
@@ -153,3 +153,4 @@ def test(
     rasa.utils.common.run_in_loop(
         test_nlu(model, nlu_data, output, additional_arguments)
     )
+


### PR DESCRIPTION
**Proposed changes**:
Add a step right after backend's test. If the test fails, setup a tmate session, which allows us ssh into it and debug directly from there.