### PR TITLE
Limit pytest jobs to 1 on CI for Windows and test-nlu-predictors

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -294,7 +294,12 @@ jobs:
       # (tests will still run in other envs, they will just not create annotations)
       run: pip install pytest-github-actions-annotate-failures
 
-    - name: Test Code 🔍
+    - name: Test Code 🔍 (monothread)
+      # This is a temporary workaround for OOM on Windows caused by increased memory
+      # consumption associated with the upgrade of our tensorflow dependency
+      # see https://github.com/RasaHQ/rasa/issues/9734 for more information.
+      # Once the memory issues have been addressed, all configurations should be run on
+      # multiple threads
       if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest') && (matrix.os == 'windows-latest' && matrix.test == 'test-nlu-predictors')
       env:
         JOBS: 1
@@ -302,7 +307,7 @@ jobs:
       run: |
         make ${{ matrix.test }}
 
-    - name: Test Code 🔍
+    - name: Test Code 🔍 (multithread)
       if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest') && !(matrix.os == 'windows-latest' && matrix.test == 'test-nlu-predictors')
       env:
         JOBS: 2

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -295,9 +295,17 @@ jobs:
       run: pip install pytest-github-actions-annotate-failures
 
     - name: Test Code 🔍
-      if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest')
+      if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest') && (matrix.os == 'windows-latest' && matrix.test == 'test-nlu-predictors')
       env:
         JOBS: 1
+        PYTHONIOENCODING: "utf-8"
+      run: |
+        make ${{ matrix.test }}
+
+    - name: Test Code 🔍
+      if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest') && !(matrix.os == 'windows-latest' && matrix.test == 'test-nlu-predictors')
+      env:
+        JOBS: 2
         PYTHONIOENCODING: "utf-8"
       run: |
         make ${{ matrix.test }}

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -297,7 +297,7 @@ jobs:
     - name: Test Code 🔍
       if: needs.changes.outputs.backend == 'true' && !(matrix.python-version == 3.8 && matrix.os == 'windows-latest') && (matrix.os == 'windows-latest' && matrix.test == 'test-nlu-predictors')
       env:
-        JOBS: 2
+        JOBS: 1
         PYTHONIOENCODING: "utf-8"
       run: |
         make ${{ matrix.test }}

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -1024,6 +1024,7 @@ async def test_sparse_feature_sizes_decreased_incremental_training(
     loaded = Interpreter.load(persisted_path, component_builder, new_config=_config,)
     assert loaded.pipeline
     assert loaded.parse("Rasa is great!") == trained.parse("Rasa is great!")
+    
     if should_raise_exception:
         with pytest.raises(Exception) as exec_info:
             (_, trained, _) = await rasa.nlu.train.train(

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -1024,7 +1024,6 @@ async def test_sparse_feature_sizes_decreased_incremental_training(
     loaded = Interpreter.load(persisted_path, component_builder, new_config=_config,)
     assert loaded.pipeline
     assert loaded.parse("Rasa is great!") == trained.parse("Rasa is great!")
-    
     if should_raise_exception:
         with pytest.raises(Exception) as exec_info:
             (_, trained, _) = await rasa.nlu.train.train(


### PR DESCRIPTION
As per discussion [here](https://rasa-hq.slack.com/archives/C01H2UCNP2T/p1632832706102800), I'm limiting the pytest jobs to 1 on CI for problematic configurations (Windows + `test-nlu-predictors`). 

This is a *temporary* fix in order to get TF 2.6 micro out as quickly as possible. I've created a followup issue to investigate and address the memory issues so that the fix can be reverted.