### PR TITLE
Read TF version from poetry.lock

### DIFF
--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -59,10 +59,9 @@ jobs:
 
       - name: Get TensorFlow version
         run: |-
-          # Read TF version, trim special characters ^~><+
-          TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
-          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION is 2.3.4
-          TF_VERSION=${TF_VERSION::3}
+          # Read TF version from poetry.lock file
+          pip install toml
+          TF_VERSION=$(scripts/read_tenforflow_version.sh)
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -158,6 +158,8 @@ jobs:
           # Read TF version from poetry.lock file
           pip install toml
           TF_VERSION=$(scripts/read_tenforflow_version.sh)
+          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION is 2.3.4
+          TF_VERSION=${TF_VERSION::3}
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -155,10 +155,9 @@ jobs:
 
       - name: Get TensorFlow version
         run: |-
-          # Read TF version, trim special characters ^~><+
-          TF_VERSION=$(grep "tensorflow =" pyproject.toml | sed 's/^[^"]*"\([^"]*\),.*/\1/' | sed 's/[\^~><=]//g')
-          # Keep the first 3 characters, e.g. we keep 2.3 if TF_VERSION is 2.3.4
-          TF_VERSION=${TF_VERSION::3}
+          # Read TF version from poetry.lock file
+          pip install toml
+          TF_VERSION=$(scripts/read_tenforflow_version.sh)
           echo "TensorFlow version: $TF_VERSION"
           echo TF_VERSION=$TF_VERSION >> $GITHUB_ENV
 

--- a/scripts/read_tenforflow_version.sh
+++ b/scripts/read_tenforflow_version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+"""Extract the TensorFlow version from poetry.lock. Used in e.g. github workflows."""
+
+import pathlib
+import sys
+import toml
+
+poetry_path = 'poetry.lock'
+
+if __name__ == "__main__":
+    if pathlib.Path(poetry_path).is_file():
+      # Get the list of dict that contains all information about packages
+      package_list = toml.load(poetry_path).get('package')
+      # Extract tensorflow version
+      tf_version = next(filter(lambda x: x.get('name') == 'tensorflow', package_list))['version']
+      print(tf_version)
+      sys.exit(0)
+
+    else:
+      print(f'File {poetry_path} does not exist.')
+      sys.exit(1)

--- a/scripts/read_tenforflow_version.sh
+++ b/scripts/read_tenforflow_version.sh
@@ -13,7 +13,7 @@ if __name__ == "__main__":
       # Get the list of dict that contains all information about packages
       package_list = toml.load(poetry_path).get('package')
       # Extract tensorflow version
-      tf_version = next(filter(lambda x: x.get('name') == 'tensorflow', package_list))['version']
+      tf_version = next(filter(lambda x: x.get('name') == 'tensorflow', package_list)).get('version')
       print(tf_version)
       sys.exit(0)
 


### PR DESCRIPTION
**The problem:**

We were using `sed`-style to read TF version from `pyproject.toml`, which leads us to problems when the version constraints aren't cover in the sed command. We need to find a way to read TensorFlow version from `poetry.lock` directly.

**Proposed changes**:

Use python's toml library to parse and read TensorFlow version from `poetry.lock`. 
It now uses the new `read_tenforflow_version.sh` script to retrieve tf version (e.g. [`2.6`](https://github.com/RasaHQ/rasa/pull/9785/checks?check_run_id=3790279267#step:4:17)) and CUDA/cuDNN libraries [successfully load](https://github.com/RasaHQ/rasa/pull/9785/checks?check_run_id=3790295792). 