### PR TITLE
Port docs changes from the "documentation" to the "2.8.x" branch

### DIFF
--- a/docs/docs/business-logic.mdx
+++ b/docs/docs/business-logic.mdx
@@ -76,6 +76,18 @@ forms:
             value: false
 ```
 
+:::caution Deprecated in 2.6
+The `required_slots` keyword was introduced. The following syntax is deprecated and will be removed in 3.0.0:
+```yaml-rasa title="domain.yml"
+forms:
+  restaurant_form:
+    # this format is deprecated
+    cuisine:
+      - type: from_entity
+        entity: cuisine
+```
+:::
+
 For any slot filled `from_entity`, the entity needs to be added
 to the domain.
 

--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -87,7 +87,7 @@ The following arguments can be used to configure the training process:
 
 ### Incremental training
 
-:::caution
+:::caution New in 2.2
 This feature is experimental.
 We introduce experimental features to get feedback from our community, so we encourage you to try it out!
 However, the functionality might be changed or removed in the future.
@@ -152,10 +152,14 @@ can be triggered at any conversation turn. Subsequently, the following message w
  at this point in the conversation. Check out UnexpecTEDIntentPolicy docs to learn more.
 ```
 
- As the message states, this is an indication that you have explored a conversation path
- which is unexpected according to the current set of training stories and hence adding this
- path to training stories is recommended. Like other bot actions, you can choose to confirm
- or deny running this action.
+As the message states, this is an indication that you have explored a conversation path
+which is unexpected according to the current set of training stories and hence adding this
+path to training stories is recommended. Like other bot actions, you can choose to confirm
+or deny running this action.
+
+:::info New in 2.8
+`UnexpecTEDIntentPolicy` was added.
+:::
 
 
 If you provide a trained model using the `--model` argument, training is skipped
@@ -413,6 +417,10 @@ domain files:
 
 ```text [rasa data validate --help]
 ```
+
+:::info New in 2.8
+Story validation is no longer an experimental feature as of 2.8. The feature behaviour remains unchanged.
+:::
 
 ## rasa export
 

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -129,11 +129,15 @@ word vectors in your pipeline.
   In addition to SpaCy's pretrained language models, you can also use this component to
   attach spaCy models that you've trained yourself.
 
+:::caution Changed in 2.5
+Rasa Open Source will try to fallback to a common model on your behalf if you don't pass a `model` setting. This is a
+temporary feature we've introduced as part of the spaCy 3.0 migration but the fallback will be removed in Rasa Open Source 3.0.0.
+:::
 
 ### HFTransformersNLP
 
-:::caution Deprecated
-The `HFTransformersNLP` is deprecated and will be removed in a future release. The [LanguageModelFeaturizer](./components.mdx#languagemodelfeaturizer)
+:::caution Deprecated in 2.1
+The `HFTransformersNLP` is deprecated and will be removed in 3.0. The [LanguageModelFeaturizer](./components.mdx#languagemodelfeaturizer)
 now implements its behavior.
 :::
 
@@ -212,6 +216,10 @@ now implements its behavior.
       # The `default` cache_dir is the same as https://huggingface.co/transformers/serialization.html#cache-directory .
       cache_dir: null
   ```
+
+  :::caution Changed in 2.1
+  The default pre-trained weights for BERT have been renamed from `bert-base-uncased` to `rasa/LaBSE`.
+  :::
 
 
   ## Tokenizers
@@ -423,8 +431,8 @@ now implements its behavior.
 
   ### ConveRTTokenizer
 
-:::caution Deprecated
-The `ConveRTTokenizer` is deprecated and will be removed in a future release. The [ConveRTFeaturizer](./components.mdx#convertfeaturizer)
+:::caution Deprecated in 2.1
+The `ConveRTTokenizer` is deprecated and will be removed in 3.0. The [ConveRTFeaturizer](./components.mdx#convertfeaturizer)
 now implements its behavior. Any [tokenizer](./components.mdx#tokenizers) can be used in its place.
 :::
 
@@ -482,7 +490,7 @@ now implements its behavior. Any [tokenizer](./components.mdx#tokenizers) can be
 
   ### LanguageModelTokenizer
 
-:::caution Deprecated
+:::caution Deprecated in 2.1
 The `LanguageModelTokenizer` is deprecated and will be removed in a future release. The [LanguageModelFeaturizer](./components.mdx#languagemodelfeaturizer)
 now implements its behavior. Any [tokenizer](./components.mdx#tokenizers) can be used in its place.
 :::
@@ -666,6 +674,10 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
 
   `tokens`
 
+  :::caution Changed in 2.1
+  `ConveRTFeaturizer` no longer requires `ConveRTTokenizer`.
+  :::
+
 
 
 * **Type**
@@ -727,6 +739,10 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
 
   `tokens`.
 
+  :::caution Changed in 2.1
+  `LanguageModelFeaturizer` no longer requires `ConveRTTokenizer`.
+  :::
+
 
 
 * **Type**
@@ -749,6 +765,10 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
 
 
 * **Configuration**
+
+  :::caution Changed in 2.1
+  The `model_name`, `model_weights` and `cache_dir` parameters were added to the pipeline configuration file.
+  :::
 
   Include a [Tokenizer](./components.mdx#tokenizers) component before this component.
 
@@ -850,6 +870,33 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
     # use match word boundaries for lookup table
     "use_word_boundaries": True
   ```
+
+  :::info New in 2.2
+  `use_word_boundaries` was added.
+  :::
+
+  **Configuring for incremental training**
+
+  To ensure that `sparse_features` are of fixed size during
+  [incremental training](./command-line-interface.mdx#incremental-training), the
+  component should be configured to account for additional patterns that may be
+  added to the training data in future. To do so, configure the `number_additional_patterns`
+  parameter while training the base model from scratch:
+
+  ```yaml-rasa {3}
+  pipeline:
+  - name: RegexFeaturizer
+    number_additional_patterns: 10
+  ```
+
+  If not configured by the user, the component will use twice the number of
+  patterns currently present in the training data (including lookup tables and regex patterns)
+  as the default value for `number_additional_patterns`.
+  This number is kept at a minimum of 10 in order to avoid running out of additional
+  slots for new patterns too frequently during incremental training.
+  Once the component runs out of additional pattern slots, the new patterns are dropped
+  and not considered during featurization. At this point, it is advisable
+  to retrain a new model from scratch.
 
 
 ### CountVectorsFeaturizer
@@ -975,6 +1022,39 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
     "use_shared_vocab": False
   ```
 
+  **Configuring for incremental training**
+
+  :::info New in 2.2
+  Incremental training was added as an experimental feature.
+  :::
+
+  To ensure that `sparse_features` are of fixed size during
+  [incremental training](./command-line-interface.mdx#incremental-training), the
+  component should be configured to account for additional vocabulary tokens
+  that may be added as part of new training examples in the future.
+  To do so, configure the `additional_vocabulary_size` parameter while training the base model from scratch:
+
+  ```yaml-rasa {3-6}
+  pipeline:
+  - name: CountVectorsFeaturizer
+    additional_vocabulary_size:
+      text: 1000
+      response: 1000
+      action_text: 1000
+  ```
+
+  As in the above example, you can define additional vocabulary size for each of
+  `text` (user messages), `response` (bot responses used by `ResponseSelector`) and
+  `action_text` (bot responses not used by `ResponseSelector`). If you are building a shared
+  vocabulary (`use_shared_vocab=True`), you only need to define a value for the `text` attribute.
+  If any of the attribute is not configured by the user, the component takes half of the current
+  vocabulary size as the default value for the attribute's `additional_vocabulary_size`.
+  This number is kept at a minimum of 1000 in order to avoid running out of additional vocabulary
+  slots too frequently during incremental training. Once the component runs out of additional vocabulary slots,
+  the new vocabulary tokens are dropped and not considered during featurization. At this point,
+  it is advisable to retrain a new model from scratch.
+
+
 The above configuration parameters are the ones you should configure to fit your model to your data.
 However, additional parameters exist that can be adapted.
 
@@ -1026,6 +1106,10 @@ However, additional parameters exist that can be adapted.
 | alias                     | CountVectorFeaturizer   | Alias name of featurizer.                                    |
 +---------------------------+-------------------------+--------------------------------------------------------------+
 | use_lemma                 | True                    | Use the lemma of words for featurization.                    |
++---------------------------+-------------------------+--------------------------------------------------------------+
+| additional_vocabulary_size| text: 1000              | Size of additional vocabulary to account for incremental     |
+|                           | response: 1000          | training while training a model from scratch                 |
+|                           | action_text: 1000       |                                                              |
 +---------------------------+-------------------------+--------------------------------------------------------------+
 ```
 
@@ -1438,6 +1522,17 @@ Intent classifiers assign one of the intents defined in the domain file to incom
     This helps in keeping similarities between input and negative labels to smaller values.
     This should help in better generalization of the model to real world test sets.
 
+  * `model_confidence`:
+    This parameter allows the user to configure how confidences are computed during inference. It can take two values:
+    * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
+    * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
+
+    Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to tune fallback thresholds for the [FallbackClassifier](./components.mdx#fallbackclassifier).
+
+  :::info New in 2.3
+  `constrain_similarities` and `model_confidence` were added.
+  :::
+
 
 The above configuration parameters are the ones you should configure to fit your model to your data.
 However, additional parameters exist that can be adapted.
@@ -1692,6 +1787,10 @@ See [starspace paper](https://arxiv.org/abs/1709.03856) for details.
       the difference of the confidence scores for the two highest ranked intents is
       smaller than the `ambiguity_threshold`.
 
+
+:::caution Changed in 2.8
+`FallbackClassifier` used to set the confidence to 1.0 but now follows the fallback `threshold` config value.
+:::
 
 ## Entity Extractors
 
@@ -1978,6 +2077,10 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
         email: True
   ```
 
+  :::info New in 2.1
+  `split_entities_by_comma` was added.
+  :::
+
   :::note
   If POS features are used (`pos` or `pos2`), you need to have `SpacyTokenizer` in your pipeline.
 
@@ -2162,6 +2265,10 @@ The `SpacyEntityExtractor` extractor does not provide a `confidence` level and w
         # use match word boundaries for lookup table
         "use_word_boundaries": True
   ```
+
+  :::info New in 2.2
+  `use_word_boundaries` was added.
+  :::
 
 
 ### EntitySynonymMapper
@@ -2628,6 +2735,10 @@ Selectors predict a bot response from a set of candidate responses.
     }
     ```
 
+    :::caution Deprecated in 2.4
+    `template_name` and `response_templates` keys under `response` have been deprecated in favor of
+    `utter_action` and `responses` respectively and will be removed in Rasa Open Source 3.0.0.
+    :::
 
 
 * **Description**
@@ -2702,6 +2813,18 @@ Selectors predict a bot response from a set of candidate responses.
     This parameter when set to `True` applies a sigmoid cross entropy loss over all similarity terms.
     This helps in keeping similarities between input and negative labels to smaller values.
     This should help in better generalization of the model to real world test sets.
+
+  * `model_confidence`:
+    This parameter allows the user to configure how confidences are computed during inference. It can take two values:
+    * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
+    * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
+
+    Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to tune fallback thresholds for the [FallbackClassifier](./components.mdx#fallbackclassifier).
+
+  
+  :::info New in 2.3
+  `constrain_similarities` and `model_confidence` were added.
+  :::
 
   The component can also be configured to train a response selector for a particular retrieval intent.
   The parameter `retrieval_intent` sets the name of the retrieval intent for which this response selector model is trained.

--- a/docs/docs/connectors/telegram.mdx
+++ b/docs/docs/connectors/telegram.mdx
@@ -45,6 +45,10 @@ to make the new channel endpoint available for Telegram to send messages to.
 
 ## Supported Response Attachments
 
+:::caution Changed in 1.10
+Support for additional responses was added.
+:::
+
 In addition to standard `text:` responses, this channel also supports the following components from the [Telegram API](https://core.telegram.org/bots/api/#message):
 
 - `button` arguments:

--- a/docs/docs/connectors/twilio-voice.mdx
+++ b/docs/docs/connectors/twilio-voice.mdx
@@ -9,6 +9,10 @@ import twilioSipWebhook from './img/twilio-set-sip-webhook.png';
 
 You can use the Twilio Voice connector to answer phone calls made to your Twilio phone number or Twilio SIP domain.
 
+:::info New in 2.6
+The Twilio Voice connector was added.
+:::
+
 ## Running on Twilio
 
 ### Connect to a Twilio Phone Number

--- a/docs/docs/connectors/your-own-website.mdx
+++ b/docs/docs/connectors/your-own-website.mdx
@@ -134,6 +134,10 @@ implements this session creation mechanism (version >= 0.5.0).
 
 ### JWT Authentication
 
+:::info New in 2.6
+The JWT authentication option has been added.
+:::
+
 The SocketIO channel can be optionally configured to perform JWT authentication on connect
 by defining the `jwt_key` and optional `jwt_method` in the `credentials.yml` file. 
 

--- a/docs/docs/default-actions.mdx
+++ b/docs/docs/default-actions.mdx
@@ -133,6 +133,10 @@ class ActionSessionStart(Action):
         return [SessionStarted(), ActionExecuted("action_listen")]
 ```
 
+:::info New in 2.3
+The slot `session_started_metadata` was added.
+:::
+
 ## action_default_fallback
 
 This action undoes the last user-bot interaction and sends the `utter_default` response if it is defined.
@@ -189,6 +193,10 @@ action to instruct Rasa Open Source to use the deprecated `FormAction` which is 
 the Rasa SDK.
 
 ## action_unlikely_intent
+
+:::info New in 2.8
+`action_unlikely_intent` was added together with `UnexpecTEDIntentPolicy`.
+:::
 
 Rasa Open Source triggers `action_unlikely_intent` via [`UnexpecTEDIntentPolicy`](./policies.mdx#unexpected-intent-policy).
 You can control how often this action is predicted by tuning the [`tolerance`](./policies.mdx#unexpected-intent-policy)

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -73,8 +73,6 @@ parameter for slots with the same name.
 The `entities` section lists all entities that can be
 extracted by any [entity extractor](./components.mdx) in your
 NLU pipeline.
-If you are using the feature [Entity Roles and Groups](./nlu-training-data.mdx#entities-roles-and-groups) you also
-need to list the roles and groups of an entity in this section.
 
 For example:
 
@@ -84,6 +82,15 @@ entities:
    - time             # entity extracted by DucklingEntityExtractor
    - membership_type  # custom entity extracted by DIETClassifier
    - priority         # custom entity extracted by DIETClassifier
+```
+
+If you are using the feature [Entity Roles and Groups](./nlu-training-data.mdx#entities-roles-and-groups) you also
+need to list the roles and groups of an entity in this section.
+
+For example:
+
+```yaml-rasa
+entities:
    - city:            # custom entity extracted by DIETClassifier
        roles:
        - from
@@ -97,6 +104,10 @@ entities:
        - 1
        - 2
 ```
+
+:::caution Changed in 2.1
+Entity Roles and Groups now need to be specified in the domain.
+:::
 
 ## Slots
 

--- a/docs/docs/event-brokers.mdx
+++ b/docs/docs/event-brokers.mdx
@@ -115,6 +115,10 @@ You will need a running Kafka server.
 
 ### Partition Key
 
+:::info New in 2.5
+The `partition_by_sender` parameter was added.
+:::
+
 Rasa Open Source's Kafka producer can optionally be configured to partition messages by conversation ID.
 This can be configured by setting `partition_by_sender` in the `endpoints.yml` file to True.
 By default, this parameter is set to `False` and the producer will randomly assign a partition to each message.  

--- a/docs/docs/forms.mdx
+++ b/docs/docs/forms.mdx
@@ -63,6 +63,18 @@ forms:
             entity: number
 ```
 
+:::caution Deprecated in 2.6
+The `required_slots` keyword was introduced. The following syntax is deprecated and will be removed in 3.0.0:
+```yaml-rasa title="domain.yml"
+forms:
+  restaurant_form:
+    # this format is deprecated
+    cuisine:
+      - type: from_entity
+        entity: cuisine
+```
+:::
+
 Once the form action gets called for the first time, the form gets activated and will
 prompt the user for the next required slot value. It does this by
 looking for a [response](./responses.mdx) called
@@ -326,6 +338,11 @@ Forms are fully customizable using [Custom Actions](./actions.mdx#custom-actions
 After extracting a slot value from user input, you can validate the extracted slots.
 By default Rasa Open Source only validates if any slot was filled after requesting
 a slot.
+
+:::caution Changed in 2.1
+Forms no longer raise `ActionExecutionRejection` if nothing is extracted from the user’s
+utterance for any of the required slots.
+:::
 
 You can implement a [Custom Action](./actions.mdx#custom-actions) `validate_<form_name>`
 to validate any extracted slots. Make sure to add this action to the `actions`

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -286,6 +286,12 @@ We recommend using at least the "medium" sized models (`_md`) instead of the spa
 default small `en_core_web_sm` model. Small models require less
 memory to run, but will likely reduce intent classification performance.
 
+:::caution Changed in 2.5
+Support for Spacy 3 was added. In prior versions of Rasa Open Source, to install spaCy with
+its language model for the English language, you need to additionally run
+`python3 -m spacy link en_core_web_md en`.
+:::
+
 ### Dependencies for MITIE
 
 First, run

--- a/docs/docs/lock-stores.mdx
+++ b/docs/docs/lock-stores.mdx
@@ -87,3 +87,7 @@ address the same node when sending messages for a given conversation ID.
 
   * `socket_timeout` (default: `10`): Time in seconds after which an
      error is raised if Redis doesn't answer
+
+:::info New in 2.1
+The `key_prefix` parameter was added.
+:::

--- a/docs/docs/nlg.mdx
+++ b/docs/docs/nlg.mdx
@@ -178,6 +178,11 @@ Key | Description
 You can use any or all of this information to decide
 how to generate your response.
 
+:::caution Deprecated in 2.4
+The `template` key has been deprecated in favor of `response` and will be removed in Rasa Open Source 3.0.0.
+:::
+
+
 ### Response Format
 
 The endpoint needs to respond with the generated response. 

--- a/docs/docs/nlu-only-server.mdx
+++ b/docs/docs/nlu-only-server.mdx
@@ -19,7 +19,7 @@ nlu:
     token_name: <name of the token> # [optional] (default: token)
 ```
 
-The `token` and `token_name` refer to optional [authentication paramenters](./http-api.mdx#token-based-auth).
+The `token` and `token_name` refer to optional [authentication parameters](./http-api.mdx#token-based-auth).
 
 The dialogue management server should serve a model that does not include an NLU model.
 To obtain a dialogue management only model, train a model with `rasa train core` or use 

--- a/docs/docs/nlu-training-data.mdx
+++ b/docs/docs/nlu-training-data.mdx
@@ -168,6 +168,10 @@ When using lookup tables with `RegexFeaturizer`, provide enough examples for the
 
 ## Entities Roles and Groups
 
+:::info New in 2.8
+Entities Roles and Groups is no longer an experimental feature as of 2.8. The feature behaviour remains unchanged.
+:::
+
 Annotating words as custom entities allows you to define certain concepts in your training data.
 For example, you can identify cities by annotating them:
 
@@ -240,9 +244,11 @@ To fill slots from entities with a specific role/group, you need to either defin
 
 ### Entity Roles and Groups influencing dialogue predictions
 
+:::caution Changed in 2.1
 If you want to influence the dialogue predictions by roles or groups, you need to modify your stories to contain
 the desired role or group label. You also need to list the corresponding roles and groups of an entity in your
 [domain file](./domain.mdx#entities).
+:::
 
 Let's assume you want to output a different sentence depending on what the user's location is. E.g.
 if the user just arrived from London, you might want to ask how the trip to London was. But if the user is on the way

--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -204,6 +204,12 @@ If you want to fine-tune your model, start by modifying the following parameters
   This helps in keeping similarities between input and negative labels to smaller values.
   This should help in better generalization of the model to real world test sets.
 
+* `model_confidence`:
+  This parameter allows the user to configure how confidences are computed during inference. It can take two values:
+  * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
+  * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
+
+  Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to [handle actions predicted with low confidence](./fallback-handoff.mdx#handling-low-action-confidence).
 
 The above configuration parameters are the ones you should configure to fit your model to your data.
 However, additional parameters exist that can be adapted.
@@ -396,7 +402,7 @@ for details.
 
 ### UnexpecTED Intent Policy
 
-:::caution
+:::caution New in 2.8
 This feature is experimental.
 We introduce experimental features to get feedback from our community, so we encourage you to try it out!
 However, the functionality might be changed or removed in the future.

--- a/docs/docs/rules.mdx
+++ b/docs/docs/rules.mdx
@@ -69,6 +69,10 @@ For example if you define the greeting rule as above and don't add it to any of 
 after `RulePolicy` predicts `utter_greet`, `TEDPolicy` will
 make predictions as if the `greet, utter_greet` turn did not occur.
 
+:::caution Changed in 2.5
+The ML-only policies behavior of ignoring rule-only dialogue turns at prediction time was added.
+:::
+
 
 ### Rules for the Conversation Start
 

--- a/docs/docs/stories.mdx
+++ b/docs/docs/stories.mdx
@@ -191,7 +191,7 @@ This format is only used for testing and cannot be used for training.
 
 ## End-to-end Training
 
-:::caution experimental feature
+:::caution New in 2.2
 End-to-end training is an experimental feature.
 We introduce experimental features to get feedback from our community, so we encourage you to try it out!
 However, the functionality might be changed or removed in the future.

--- a/docs/docs/testing-your-assistant.mdx
+++ b/docs/docs/testing-your-assistant.mdx
@@ -379,6 +379,10 @@ incorrect action was predicted instead.
 
 ### Interpreting the generated warnings
 
+:::info New in 2.8
+Warnings for stories were added.
+:::
+
 The test script will also generate a warnings file called `results/stories_with_warnings.yml`.
 This file contains all test stories for which [`action_unlikely_intent`](./default-actions.mdx#action_unlikely_intent)
 was predicted at any conversation turn but all actions from the original story were predicted correctly.

--- a/docs/docs/tracker-stores.mdx
+++ b/docs/docs/tracker-stores.mdx
@@ -227,6 +227,11 @@ To set up Rasa Open Source with Redis the following steps are required:
 * `use_ssl` (default: `False`): whether or not to use SSL for transit encryption
 
 
+:::info New in 2.1
+The `key_prefix` parameter was added.
+:::
+
+
 ## MongoTrackerStore
 
 

--- a/docs/docs/tuning-your-model.mdx
+++ b/docs/docs/tuning-your-model.mdx
@@ -384,6 +384,10 @@ pipeline:
 
 ### Accessing Diagnostic Data
 
+:::info New in 2.3
+Diagnostic data was made available.
+:::
+
 To gain a better understanding of what your models do, you can access intermediate results of the prediction process.
 To do this, you need to access the `diagnostic_data` field of the [Message](./reference/rasa/shared/nlu/training_data/message.md#message-objects)
 and [Prediction](./reference/rasa/core/policies/policy.md#policyprediction-objects) objects, which contain


### PR DESCRIPTION
**Proposed changes**:
Copy changes that are already on the `documentation` branch (and live on the docs site) in the [`version-2.x` folder](https://github.com/RasaHQ/rasa/tree/documentation/docs/versioned_docs/version-2.x) onto the `2.8.x` branch, in the `docs/` folder. This is going to be needed if we want to cut a new micro (e.g. 2.8.9) or new minor (e.g. 2.9) from this release branch.

(💡 yesterday we released 2.8.8 and it did override the changes on the `documentation` branch, and I had to manually revert the changes. Merging this pull request will prevent this from happening in the future)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
