### PR TITLE
make metadata from UnexpecTED JSON serializable

### DIFF
--- a/rasa/core/policies/unexpected_intent_policy.py
+++ b/rasa/core/policies/unexpected_intent_policy.py
@@ -521,11 +521,11 @@ class UnexpecTEDIntentPolicyGraphComponent(TEDPolicy):
         def _compile_metadata_for_label(
             label_name: Text, similarity_score: float, threshold: Optional[float],
         ) -> "RankingCandidateMetadata":
-            severity = threshold - similarity_score if threshold else None
+            severity = float(threshold - similarity_score) if threshold else None
             return {
                 NAME: label_name,
-                SCORE_KEY: similarity_score,
-                THRESHOLD_KEY: threshold,
+                SCORE_KEY: float(similarity_score),
+                THRESHOLD_KEY: float(threshold) if threshold else None,
                 SEVERITY_KEY: severity,
             }
 

--- a/tests/core/policies/test_unexpected_intent_policy.py
+++ b/tests/core/policies/test_unexpected_intent_policy.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Optional, List, Dict, Text, Type
 import tensorflow as tf
@@ -518,9 +519,9 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         resource: Resource,
         execution_context: ExecutionContext,
         default_domain: Domain,
-        predicted_similarity,
-        threshold_value,
-        is_unlikely,
+        predicted_similarity: float,
+        threshold_value: float,
+        is_unlikely: bool,
         monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ):
@@ -569,6 +570,8 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
             # of the metadata is tested separately and
             # not as part of this test.
             assert prediction.action_metadata is not None
+            # Assert metadata is serializable
+            assert json.dumps(prediction.action_metadata)
 
     @pytest.mark.parametrize(
         "tracker_events, should_skip",


### PR DESCRIPTION
**Proposed changes**:
- cast `numpy.float32` to `float` to make things JSON serializable. This bug didn't appear early as we didn't add the `action_metadata` to the winning prediction and hence not to the tracker store

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
