### PR TITLE
fix param name in `CountVectorsFeaturizer`

### DIFF
--- a/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
+++ b/rasa/nlu/featurizers/sparse_featurizer/count_vectors_featurizer.py
@@ -605,19 +605,19 @@ class CountVectorsFeaturizer(SparseFeaturizer, GraphComponent):
             return [], []
 
     def train(
-        self, training_data: TrainingData, spacy_nlp: Optional[SpacyModel] = None,
+        self, training_data: TrainingData, model: Optional[SpacyModel] = None,
     ) -> Resource:
         """Trains the featurizer.
 
         Take parameters from config and
         construct a new count vectorizer using the sklearn framework.
         """
-        if spacy_nlp is not None:
+        if model is not None:
             # create spacy lemma_ for OOV_words
             self.OOV_words = [
                 t.lemma_ if self.use_lemma else t.text
                 for w in self.OOV_words
-                for t in spacy_nlp.model(w)
+                for t in model.model(w)
             ]
 
         # process sentences and collect data for all attributes

--- a/tests/nlu/featurizers/test_count_vectors_featurizer.py
+++ b/tests/nlu/featurizers/test_count_vectors_featurizer.py
@@ -585,7 +585,7 @@ def test_count_vector_featurizer_use_lemma(
     spacy_tokenizer.process([train_message])
     spacy_tokenizer.process([test_message])
 
-    ftr.train(TrainingData([train_message]), spacy_nlp=SpacyModel(spacy_nlp, "en"))
+    ftr.train(TrainingData([train_message]), model=SpacyModel(spacy_nlp, "en"))
 
     ftr.process([test_message])
 


### PR DESCRIPTION
**Proposed changes**:
- rename `spacy_nlp` to `model` as the recipe by default tries to fill the `model` param if `model_from` was specified

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
