### PR TITLE
unhandle echo messages from messenger

### DIFF
--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -45,6 +45,7 @@ class Messenger:
             "message" in message
             and "attachments" in message["message"]
             and message["message"]["attachments"][0]["type"] == "audio"
+            and not message["message"].get("is_echo")
         )
 
     @staticmethod
@@ -54,6 +55,7 @@ class Messenger:
             "message" in message
             and "attachments" in message["message"]
             and message["message"]["attachments"][0]["type"] == "image"
+            and not message["message"].get("is_echo")
         )
 
     @staticmethod
@@ -63,6 +65,7 @@ class Messenger:
             "message" in message
             and "attachments" in message["message"]
             and message["message"]["attachments"][0]["type"] == "video"
+            and not message["message"].get("is_echo")
         )
 
     @staticmethod
@@ -72,6 +75,7 @@ class Messenger:
             "message" in message
             and "attachments" in message["message"]
             and message["message"]["attachments"][0]["type"] == "file"
+            and not message["message"].get("is_echo")
         )
 
     @staticmethod


### PR DESCRIPTION
According to Facebook Messenger API documentation https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/message-echoes/?locale=en_En, an echo message is also triggered for image, video, file, and audio attachments. 
These changes ignore those echo messages.

**Proposed changes**:
- Ignore echo messages related to file, audio, video, and image attachments from Facebook

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
