### PR TITLE
Validations for unused intents and utterances

### DIFF
--- a/changelog/10079.bugfix.md
+++ b/changelog/10079.bugfix.md
@@ -1,0 +1,1 @@
+Fixed validation behavior and logging output around unused intents and utterances.

--- a/data/test_config/config_defaults.yml
+++ b/data/test_config/config_defaults.yml
@@ -24,3 +24,16 @@ pipeline: []
 #     ambiguity_threshold: 0.1
 
 data:
+policies:
+# # No configuration for policies was provided. The following default policies were used to train your model.
+# # If you'd like to customize them, uncomment and adjust the policies.
+# # See https://rasa.com/docs/rasa/policies for more information.
+#   - name: MemoizationPolicy
+#   - name: RulePolicy
+#   - name: UnexpecTEDIntentPolicy
+#     max_history: 5
+#     epochs: 100
+#   - name: TEDPolicy
+#     max_history: 5
+#     epochs: 100
+#     constrain_similarities: true

--- a/data/test_validation/data/nlu.yml
+++ b/data/test_validation/data/nlu.yml
@@ -1,0 +1,5 @@
+version: "2.0"
+nlu:
+- intent: greet
+  examples: |
+    - hey

--- a/data/test_validation/data/stories.yml
+++ b/data/test_validation/data/stories.yml
@@ -1,0 +1,6 @@
+version: "2.0"
+stories:
+- story: happy path
+  steps:
+  - intent: greet
+  - action: utter_greet

--- a/data/test_validation/domain.yml
+++ b/data/test_validation/domain.yml
@@ -1,0 +1,12 @@
+version: "2.0"
+
+intents:
+  - greet
+  - goodbye
+
+responses:
+  utter_greet:
+    - text: "Hey! How are you?"
+
+  utter_chatter:
+    - text: "Lovely weather today, isn't it?"


### PR DESCRIPTION
Fixes #10079.

The following changes were made:
- we exclude the default / implicit intents from generating warnings if they're unused; otherwise, any empty / newly initialized rasa project would throw warnings for unused intents, which would be confusing to the user
- if an intent is defined, but not used in the NLU data at all, we generate a warning and consequently abort if `--fail-on-warnings`.
- if an intent is defined, but not used either in a story or rule we generate a warning and consequently abort if `--fail-on-warnings`. Note here that the debug message that was printed before was also inexact since it mentioned only stories, this was clarified to also include rules.
- The same as in the bullet point before was also implemented for utterances

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
