### PR TITLE
Use a unique fingerprint for a resource that is consistent after caching.

### DIFF
--- a/rasa/engine/caching.py
+++ b/rasa/engine/caching.py
@@ -124,7 +124,11 @@ class Cacheable(Protocol):
 
     @classmethod
     def from_cache(
-        cls, node_name: Text, directory: Path, model_storage: ModelStorage
+        cls,
+        node_name: Text,
+        directory: Path,
+        model_storage: ModelStorage,
+        output_fingerprint: Text,
     ) -> Cacheable:
         """Loads `Cacheable` from cache.
 
@@ -133,6 +137,9 @@ class Cacheable(Protocol):
             directory: Directory containing the persisted `Cacheable`.
             model_storage: The current model storage (e.g. used when restoring
                 `Resource` objects so that they can fill the model storage with data).
+            output_fingerprint: The fingerprint of the cached result (e.g. used when
+                restoring `Resource` objects as the fingerprint can not be easily
+                calculated from the object itself).
 
         Returns:
             Instantiated `Cacheable`.
@@ -407,7 +414,11 @@ class LocalTrainingCache(TrainingCache):
             return None
 
         return self._load_from_cache(
-            result_location, result_type, node_name, model_storage
+            result_location,
+            result_type,
+            node_name,
+            model_storage,
+            output_fingerprint_key,
         )
 
     def _get_cached_result(
@@ -434,6 +445,7 @@ class LocalTrainingCache(TrainingCache):
         result_type: Text,
         node_name: Text,
         model_storage: ModelStorage,
+        output_fingerprint_key,
     ) -> Optional[Cacheable]:
         try:
             module = rasa.shared.utils.common.class_from_module_path(result_type)
@@ -446,7 +458,9 @@ class LocalTrainingCache(TrainingCache):
                 )
                 return None
 
-            return module.from_cache(node_name, path_to_cached, model_storage)
+            return module.from_cache(
+                node_name, path_to_cached, model_storage, output_fingerprint_key
+            )
         except Exception as e:
             logger.warning(
                 f"Failed to restore cached output of type '{result_type}' from "

--- a/rasa/engine/caching.py
+++ b/rasa/engine/caching.py
@@ -445,7 +445,7 @@ class LocalTrainingCache(TrainingCache):
         result_type: Text,
         node_name: Text,
         model_storage: ModelStorage,
-        output_fingerprint_key,
+        output_fingerprint_key: Text,
     ) -> Optional[Cacheable]:
         try:
             module = rasa.shared.utils.common.class_from_module_path(result_type)

--- a/rasa/engine/storage/resource.py
+++ b/rasa/engine/storage/resource.py
@@ -30,7 +30,7 @@ class Resource:
     """
 
     name: Text
-    output_fingerprint: Optional[Text] = field(
+    output_fingerprint: Text = field(
         default_factory=lambda: uuid.uuid4().hex,
         # We do not use this for comparison as it is not consistent after serialization.
         compare=False,

--- a/rasa/engine/storage/resource.py
+++ b/rasa/engine/storage/resource.py
@@ -3,7 +3,7 @@ import logging
 import typing
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Text, Optional
+from typing import Text
 import uuid
 
 import rasa.utils.common

--- a/rasa/engine/training/hooks.py
+++ b/rasa/engine/training/hooks.py
@@ -42,6 +42,7 @@ class TrainingHook(GraphNodeHook):
         graph_component_class = self._get_graph_component_class(
             execution_context, node_name
         )
+
         fingerprint_key = fingerprinting.calculate_fingerprint_key(
             graph_component_class=graph_component_class,
             config=config,

--- a/tests/engine/graph_components_test_classes.py
+++ b/tests/engine/graph_components_test_classes.py
@@ -226,7 +226,11 @@ class CacheableText:
 
     @classmethod
     def from_cache(
-        cls, node_name: Text, directory: Path, model_storage: ModelStorage
+        cls,
+        node_name: Text,
+        directory: Path,
+        model_storage: ModelStorage,
+        output_fingerprint: Text,
     ) -> CacheableText:
         text = rasa.shared.utils.io.read_file(directory / "my_file.txt")
         return cls(text=text)

--- a/tests/engine/test_caching.py
+++ b/tests/engine/test_caching.py
@@ -45,7 +45,11 @@ class TestCacheableOutput:
 
     @classmethod
     def from_cache(
-        cls, node_name: Text, directory: Path, model_storage: ModelStorage
+        cls,
+        node_name: Text,
+        directory: Path,
+        model_storage: ModelStorage,
+        output_fingerprint: Text,
     ) -> "TestCacheableOutput":
 
         value = rasa.shared.utils.io.read_json_file(directory / "cached.json")

--- a/tests/engine/training/test_graph_trainer.py
+++ b/tests/engine/training/test_graph_trainer.py
@@ -532,6 +532,8 @@ def test_resources_fingerprints_are_unique_when_cached(
     train_schema.nodes["assert_node"].config["value_to_assert"] = "5"
     train_with_schema(train_schema, temp_cache)
 
+    # Add something to the config so only "assert_node" re-runs.
+    train_schema.nodes["assert_node"].config["something"] = "something"
     # This breaks when `Resource`s use the node name as a fingerprint.
     # This is because the `Resource` for the first run is retrieved from the cache which
     # returns 4 whereas it should be the second resource which returns 5, and the schema

--- a/tests/engine/training/test_graph_trainer.py
+++ b/tests/engine/training/test_graph_trainer.py
@@ -8,7 +8,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from _pytest.tmpdir import TempPathFactory
 import pytest
 
-from rasa.engine.caching import TrainingCache
+from rasa.engine.caching import LocalTrainingCache, TrainingCache
 from rasa.engine.exceptions import GraphComponentException
 from rasa.engine.graph import (
     GraphComponent,
@@ -492,6 +492,118 @@ def test_graph_trainer_train_logging_with_cached_components(
             "Finished training component 'SubtractByX'.",
             "Restored component 'CacheableComponent' from cache.",
         }
+
+
+def test_resources_fingerprints_are_unique_when_cached(
+    tmp_path: Path,
+    temp_cache: LocalTrainingCache,
+    train_with_schema: Callable,
+    caplog: LogCaptureFixture,
+):
+    train_schema = GraphSchema(
+        {
+            "train": SchemaNode(
+                needs={},
+                uses=PersistableTestComponent,
+                fn="train",
+                constructor_name="create",
+                config={"test_value": "4"},
+                is_target=True,
+            ),
+            "process": SchemaNode(
+                needs={"resource": "train"},
+                uses=PersistableTestComponent,
+                fn="run_inference",
+                constructor_name="load",
+                config={},
+            ),
+            "assert_node": SchemaNode(
+                needs={"i": "process"},
+                uses=AssertComponent,
+                fn="run_assert",
+                constructor_name="create",
+                config={"value_to_assert": "4"},
+                is_target=True,
+            ),
+        }
+    )
+
+    # Train to cache
+    train_with_schema(train_schema, temp_cache)
+
+    train_schema.nodes["train"].config["test_value"] = "5"
+    train_schema.nodes["assert_node"].config["value_to_assert"] = "5"
+    train_with_schema(train_schema, temp_cache)
+
+    # This breaks when `Resource`s use the node name as a fingerprint.
+    # This is because the `Resource` for the first run is retrieved from the cache which
+    # returns 4 whereas it should be the second resource which returns 5, and the schema
+    # assert_node expects 5 now.
+    train_with_schema(train_schema, temp_cache)
+
+
+def test_resources_fingerprints_remain_after_being_cached(
+    tmp_path: Path,
+    temp_cache: LocalTrainingCache,
+    train_with_schema: Callable,
+    caplog: LogCaptureFixture,
+):
+    train_schema = GraphSchema(
+        {
+            "train": SchemaNode(
+                needs={},
+                uses=PersistableTestComponent,
+                fn="train",
+                constructor_name="create",
+                config={"test_value": "4"},
+                is_target=True,
+            ),
+            "process": SchemaNode(
+                needs={"resource": "train"},
+                uses=PersistableTestComponent,
+                fn="run_inference",
+                constructor_name="load",
+                config={},
+                is_target=True,
+            ),
+        }
+    )
+
+    # Train and cache.
+    train_with_schema(train_schema, temp_cache)
+
+    # We can determine if a cached `Resource` has a static fingerprint by comparing two
+    # subsequent cache entries of a child node.
+    import sqlalchemy as sa
+
+    with temp_cache._sessionmaker.begin() as session:
+        # This will get the cache entry for the "process" node.
+        query_for_most_recently_used_entry = sa.select(temp_cache.CacheEntry).order_by(
+            temp_cache.CacheEntry.last_used.desc()
+        )
+        entry = session.execute(query_for_most_recently_used_entry).scalars().first()
+        # The fingerprint key will incorporate the fingerprint of the `Resource`
+        # provided by the "train" node. We save this key to compare after the next run.
+        fingerprint_key = entry.fingerprint_key
+        # Deleting the entry will force it to be recreated next train.
+        delete_query = sa.delete(temp_cache.CacheEntry).where(
+            temp_cache.CacheEntry.fingerprint_key == fingerprint_key
+        )
+        session.execute(delete_query)
+
+    # In this second train, the Resource output of "train" will be retrieved from the
+    # cache.
+    train_with_schema(train_schema, temp_cache)
+
+    with temp_cache._sessionmaker.begin() as session:
+        # This will get the new cache entry for the "process" node.
+        query_for_most_recently_used_entry = sa.select(temp_cache.CacheEntry).order_by(
+            temp_cache.CacheEntry.last_used.desc()
+        )
+        entry = session.execute(query_for_most_recently_used_entry).scalars().first()
+        # Assert the fingerptint key of the new entry is the same. This confirms that
+        # the Resource from the cache has the same fingerprint.
+        assert entry.fingerprint_key == fingerprint_key
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/training/test_graph_trainer.py
+++ b/tests/engine/training/test_graph_trainer.py
@@ -495,10 +495,7 @@ def test_graph_trainer_train_logging_with_cached_components(
 
 
 def test_resources_fingerprints_are_unique_when_cached(
-    tmp_path: Path,
-    temp_cache: LocalTrainingCache,
-    train_with_schema: Callable,
-    caplog: LogCaptureFixture,
+    temp_cache: LocalTrainingCache, train_with_schema: Callable,
 ):
     train_schema = GraphSchema(
         {
@@ -543,10 +540,7 @@ def test_resources_fingerprints_are_unique_when_cached(
 
 
 def test_resources_fingerprints_remain_after_being_cached(
-    tmp_path: Path,
-    temp_cache: LocalTrainingCache,
-    train_with_schema: Callable,
-    caplog: LogCaptureFixture,
+    temp_cache: LocalTrainingCache, train_with_schema: Callable,
 ):
     train_schema = GraphSchema(
         {
@@ -601,7 +595,7 @@ def test_resources_fingerprints_remain_after_being_cached(
             temp_cache.CacheEntry.last_used.desc()
         )
         entry = session.execute(query_for_most_recently_used_entry).scalars().first()
-        # Assert the fingerptint key of the new entry is the same. This confirms that
+        # Assert the fingerprint key of the new entry is the same. This confirms that
         # the Resource from the cache has the same fingerprint.
         assert entry.fingerprint_key == fingerprint_key
 


### PR DESCRIPTION
Use a unique fingerprint for a resource that is consistent after caching. This ensures we always retrieve the correct resource for a node from the cache.

Fixes #10147

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
