### PR TITLE
3.0 mitie nlp error message

### DIFF
--- a/rasa/nlu/utils/mitie_utils.py
+++ b/rasa/nlu/utils/mitie_utils.py
@@ -99,7 +99,7 @@ class MitieNLP(GraphComponent):
             raise InvalidConfigException(
                 "The model file configured in the MITIE"
                 "component cannot be found. "
-                "Please ensure the directory path and "
+                "Please ensure the directory path and/or "
                 "filename, '{}', are correct.".format(Path(model_file))
             )
         extractor = mitie.total_word_feature_extractor(str(model_file))

--- a/rasa/nlu/utils/mitie_utils.py
+++ b/rasa/nlu/utils/mitie_utils.py
@@ -86,7 +86,7 @@ class MitieNLP(GraphComponent):
         import mitie
 
         model_file = config.get("model")
-        if not model_file or not Path(model_file).is_file():
+        if not model_file:
             raise InvalidConfigException(
                 "The MITIE component 'MitieNLP' needs "
                 "the configuration value for 'model'."
@@ -94,6 +94,13 @@ class MitieNLP(GraphComponent):
                 "documentation in the pipeline section "
                 "to get more info about this "
                 "parameter."
+            )
+        if not Path(model_file).is_file():
+            raise InvalidConfigException(
+                "The model file configured in the MITIE"
+                "component cannot be found. "
+                "Please ensure the directory path and "
+                "filename, '{}', are correct.".format(Path(model_file))
             )
         extractor = mitie.total_word_feature_extractor(str(model_file))
 

--- a/rasa/nlu/utils/mitie_utils.py
+++ b/rasa/nlu/utils/mitie_utils.py
@@ -97,7 +97,7 @@ class MitieNLP(GraphComponent):
             )
         if not Path(model_file).is_file():
             raise InvalidConfigException(
-                "The model file configured in the MITIE"
+                "The model file configured in the MITIE "
                 "component cannot be found. "
                 "Please ensure the directory path and/or "
                 "filename, '{}', are correct.".format(Path(model_file))

--- a/rasa/nlu/utils/mitie_utils.py
+++ b/rasa/nlu/utils/mitie_utils.py
@@ -100,7 +100,7 @@ class MitieNLP(GraphComponent):
                 "The model file configured in the MITIE "
                 "component cannot be found. "
                 "Please ensure the directory path and/or "
-                "filename, '{}', are correct.".format(Path(model_file))
+                "filename, '{}', are correct.".format(model_file)
             )
         extractor = mitie.total_word_feature_extractor(str(model_file))
 


### PR DESCRIPTION
closes #10140

Adds a separate error message to clarify when configuration for MITIE NLU component is incorrect due to a missing file.

