### PR TITLE
Use correct env var for home dir on Windows in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ prepare-transformers:
 	CACHE_DIR=$$HOME_DIR/.cache/torch/transformers;\
 	mkdir -p "$$CACHE_DIR";\
 	i=0;\
-	while read -r URL; do read -r CACHE_FILE; if { [ $(CI) ]  &&  [ $$i -gt 4 ]; } || ! [ $(CI) ]; then wget $$URL -O $$CACHE_DIR/$$CACHE_FILE; echo $$CACHE_DIR/$$CACHE_FILE; fi; i=$$((i + 1)); done < "data/test/hf_transformers_models.txt"
+	while read -r URL; do read -r CACHE_FILE; if { [ $(CI) ]  &&  [ $$i -gt 4 ]; } || ! [ $(CI) ]; then wget $$URL -O $$CACHE_DIR/$$CACHE_FILE; fi; i=$$((i + 1)); done < "data/test/hf_transformers_models.txt"
 
 prepare-tests-files: prepare-spacy prepare-mitie install-mitie prepare-transformers
 

--- a/Makefile
+++ b/Makefile
@@ -125,15 +125,11 @@ endif
 	rm data/MITIE*.bz2
 
 prepare-transformers:
-ifeq ($(OS),Windows_NT)
-    HOME_DIR=%HOMEDRIVE%%HOMEPATH%
-else
-    HOME_DIR=$(HOME)
-endif
-	CACHE_DIR=$HOME_DIR/.cache/torch/transformers;\
+	if [ $(OS) = "Windows_NT" ]; then HOME_DIR=%HOMEDRIVE%%HOMEPATH%; else HOME_DIR=$(HOME); fi;\
+	CACHE_DIR=$$HOME_DIR/.cache/torch/transformers;\
 	mkdir -p "$$CACHE_DIR";\
-    i=0;\
-	while read -r URL; do read -r CACHE_FILE; if { [ $(CI) ]  &&  [ $$i -gt 4 ]; } || ! [ $(CI) ]; then wget $$URL -O $$CACHE_DIR/$$CACHE_FILE; fi; i=$$((i + 1)); done < "data/test/hf_transformers_models.txt"
+	i=0;\
+	while read -r URL; do read -r CACHE_FILE; if { [ $(CI) ]  &&  [ $$i -gt 4 ]; } || ! [ $(CI) ]; then wget $$URL -O $$CACHE_DIR/$$CACHE_FILE; echo $$CACHE_DIR/$$CACHE_FILE; fi; i=$$((i + 1)); done < "data/test/hf_transformers_models.txt"
 
 prepare-tests-files: prepare-spacy prepare-mitie install-mitie prepare-transformers
 

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,12 @@ endif
 	rm data/MITIE*.bz2
 
 prepare-transformers:
-	CACHE_DIR=$(HOME)/.cache/torch/transformers;\
+ifeq ($(OS),Windows_NT)
+    HOME_DIR=%HOMEDRIVE%%HOMEPATH%
+else
+    HOME_DIR=$(HOME)
+endif
+	CACHE_DIR=$HOME_DIR/.cache/torch/transformers;\
 	mkdir -p "$$CACHE_DIR";\
     i=0;\
 	while read -r URL; do read -r CACHE_FILE; if { [ $(CI) ]  &&  [ $$i -gt 4 ]; } || ! [ $(CI) ]; then wget $$URL -O $$CACHE_DIR/$$CACHE_FILE; fi; i=$$((i + 1)); done < "data/test/hf_transformers_models.txt"

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ endif
 	rm data/MITIE*.bz2
 
 prepare-transformers:
-	if [ $(OS) = "Windows_NT" ]; then HOME_DIR=%HOMEDRIVE%%HOMEPATH%; else HOME_DIR=$(HOME); fi;\
+	if [ $(OS) = "Windows_NT" ]; then HOME_DIR=$(HOMEDRIVE)/$(HOMEPATH); else HOME_DIR=$(HOME); fi;\
 	CACHE_DIR=$$HOME_DIR/.cache/torch/transformers;\
 	mkdir -p "$$CACHE_DIR";\
 	i=0;\

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ endif
 	rm data/MITIE*.bz2
 
 prepare-transformers:
-	if [ $(OS) = "Windows_NT" ]; then HOME_DIR=$(HOMEDRIVE)/$(HOMEPATH); else HOME_DIR=$(HOME); fi;\
+	if [ $(OS) = "Windows_NT" ]; then HOME_DIR=$(HOMEDRIVE)$(HOMEPATH); else HOME_DIR=$(HOME); fi;\
 	CACHE_DIR=$$HOME_DIR/.cache/torch/transformers;\
 	mkdir -p "$$CACHE_DIR";\
 	i=0;\

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ endif
 	rm data/MITIE*.bz2
 
 prepare-transformers:
-	if [ $(OS) = "Windows_NT" ]; then HOME_DIR=$(HOMEDRIVE)$(HOMEPATH); else HOME_DIR=$(HOME); fi;\
+	if [ $(OS) = "Windows_NT" ]; then HOME_DIR="$(HOMEDRIVE)$(HOMEPATH)"; else HOME_DIR=$(HOME); fi;\
 	CACHE_DIR=$$HOME_DIR/.cache/torch/transformers;\
 	mkdir -p "$$CACHE_DIR";\
 	i=0;\


### PR DESCRIPTION
Fixes bug where transformers models for CI tests were being cached to incorrect location on Windows

Since the $HOME env isn’t set in Windows we were downloading the `lm_featurizer` models to a different place from where it looks when you run the `lm_featurizer` tests, so if it has to download them within the test then it can crash or timeout.