### PR TITLE
Swap spacy model used by dockerfile

### DIFF
--- a/docker/configs/config_pretrained_embeddings_spacy_de.yml
+++ b/docker/configs/config_pretrained_embeddings_spacy_de.yml
@@ -2,7 +2,7 @@ language: "de"
 
 pipeline:
   - name: SpacyNLP
-    model: "de_core_news_md"
+    model: "de_core_news_sm"
   - name: SpacyTokenizer
   - name: SpacyFeaturizer
   - name: RegexFeaturizer


### PR DESCRIPTION
**Proposed changes**:
- `Dockerfile.pretrained_embeddings_spacy_de` installs `de_core_news_sm` instead of `de_core_news_md`, so change config YAML to match this (closes #10139 )

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
