### PR TITLE
slots extracted `from_intent` or `from_entity` for an un-specified intent/entity raises no error/warning

### DIFF
--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1154,7 +1154,7 @@ class ActionExtractSlots(Action):
 
         for slot in user_slots:
             for mapping in slot.mappings:
-                if not _check_mapping_validity(mapping, domain):
+                if not SlotMapping.check_mapping_validity(mapping, domain):
                     continue
 
                 intent_is_desired = SlotMapping.intent_is_desired(
@@ -1207,29 +1207,6 @@ class ActionExtractSlots(Action):
         )
 
         return validated_events
-
-
-def _check_mapping_validity(mapping: Dict[Text, Any], domain: "Domain") -> bool:
-    """Checks if intent and entity specified in a mapping exist in domain."""
-    if (
-        mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY)
-        and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities
-    ):
-        rasa.shared.utils.io.raise_warning(
-            f"Slot uses a 'from_entity' mapping for a non-existent entity '{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'"
-        )
-        return False
-
-    if (
-        mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_INTENT)
-        and mapping.get("intent") not in domain.intents
-    ):
-        rasa.shared.utils.io.raise_warning(
-            f"Slot uses a 'from_intent' mapping for a non-existent intent '{mapping.get('intent')}'"
-        )
-        return False
-
-    return True
 
 
 def extract_slot_value_from_predefined_mapping(

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1211,9 +1211,15 @@ class ActionExtractSlots(Action):
 
 def _check_if_specified_in_domain(mapping: Dict[Text, Any], domain: "Domain"):
     if mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY) and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities:
+        rasa.shared.utils.io.raise_warning(
+            f"Slot uses a 'from_entity' mapping for a non-existent entity '{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'"
+        )
         return False
 
     if mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_INTENT) and mapping.get("intent") not in domain.intents:
+        rasa.shared.utils.io.raise_warning(
+            f"Slot uses a 'from_intent' mapping for a non-existent intent '{mapping.get('intent')}'"
+        )
         return False
 
     return True

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1154,6 +1154,9 @@ class ActionExtractSlots(Action):
 
         for slot in user_slots:
             for mapping in slot.mappings:
+                if not _check_if_specified_in_domain(mapping, domain):
+                    continue
+
                 intent_is_desired = SlotMapping.intent_is_desired(
                     mapping, tracker, domain
                 )
@@ -1204,6 +1207,16 @@ class ActionExtractSlots(Action):
         )
 
         return validated_events
+
+
+def _check_if_specified_in_domain(mapping: Dict[Text, Any], domain: "Domain"):
+    if mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY) and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities:
+        return False
+
+    if mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_INTENT) and mapping.get("intent") not in domain.intents:
+        return False
+
+    return True
 
 
 def extract_slot_value_from_predefined_mapping(

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1154,7 +1154,7 @@ class ActionExtractSlots(Action):
 
         for slot in user_slots:
             for mapping in slot.mappings:
-                if not _check_if_specified_in_domain(mapping, domain):
+                if not _check_mapping_validity(mapping, domain):
                     continue
 
                 intent_is_desired = SlotMapping.intent_is_desired(
@@ -1209,14 +1209,20 @@ class ActionExtractSlots(Action):
         return validated_events
 
 
-def _check_if_specified_in_domain(mapping: Dict[Text, Any], domain: "Domain"):
-    if mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY) and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities:
+def _check_mapping_validity(mapping: Dict[Text, Any], domain: "Domain"):
+    if (
+        mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY)
+        and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities
+    ):
         rasa.shared.utils.io.raise_warning(
             f"Slot uses a 'from_entity' mapping for a non-existent entity '{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'"
         )
         return False
 
-    if mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_INTENT) and mapping.get("intent") not in domain.intents:
+    if (
+        mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_INTENT)
+        and mapping.get("intent") not in domain.intents
+    ):
         rasa.shared.utils.io.raise_warning(
             f"Slot uses a 'from_intent' mapping for a non-existent intent '{mapping.get('intent')}'"
         )

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1208,7 +1208,8 @@ class ActionExtractSlots(Action):
         return validated_events
 
 
-def _check_mapping_validity(mapping: Dict[Text, Any], domain: "Domain"):
+def _check_mapping_validity(mapping: Dict[Text, Any], domain: "Domain") -> bool:
+    """Checks if intent and entity specified in a mapping exist in domain."""
     if (
         mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY)
         and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1154,7 +1154,8 @@ class ActionExtractSlots(Action):
 
         for slot in user_slots:
             for mapping in slot.mappings:
-                _check_mapping_validity(mapping, domain)
+                if not _check_mapping_validity(mapping, domain):
+                    continue
 
                 intent_is_desired = SlotMapping.intent_is_desired(
                     mapping, tracker, domain

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1154,7 +1154,7 @@ class ActionExtractSlots(Action):
 
         for slot in user_slots:
             for mapping in slot.mappings:
-                if not SlotMapping.check_mapping_validity(mapping, domain):
+                if not SlotMapping.check_mapping_validity(slot.name, mapping, domain):
                     continue
 
                 intent_is_desired = SlotMapping.intent_is_desired(

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1154,8 +1154,7 @@ class ActionExtractSlots(Action):
 
         for slot in user_slots:
             for mapping in slot.mappings:
-                if not _check_mapping_validity(mapping, domain):
-                    continue
+                _check_mapping_validity(mapping, domain)
 
                 intent_is_desired = SlotMapping.intent_is_desired(
                     mapping, tracker, domain

--- a/rasa/shared/core/slot_mappings.py
+++ b/rasa/shared/core/slot_mappings.py
@@ -168,7 +168,7 @@ class SlotMapping(Enum):
         return slot_fulfils_entity_mapping
 
     @staticmethod
-    def check_mapping_validity(mapping: Dict[Text, Any], domain: "Domain") -> bool:
+    def check_mapping_validity(slot_name: Text, mapping: Dict[Text, Any], domain: "Domain") -> bool:
         """Checks the mapping for validity.
 
         Args:
@@ -185,7 +185,7 @@ class SlotMapping(Enum):
             and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities
         ):
             rasa.shared.utils.io.raise_warning(
-                f"Slot uses a 'from_entity' mapping for a non-existent entity "
+                f"Slot '{slot_name}' uses a 'from_entity' mapping for a non-existent entity "
                 f"'{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'. Skipping slot extraction because of invalid mapping."
             )
             return False
@@ -195,7 +195,7 @@ class SlotMapping(Enum):
             and mapping.get("intent") not in domain.intents
         ):
             rasa.shared.utils.io.raise_warning(
-                f"Slot uses a 'from_intent' mapping for a non-existent intent "
+                f"Slot '{slot_name}' uses a 'from_intent' mapping for a non-existent intent "
                 f"'{mapping.get('intent')}'. Skipping slot extraction because of invalid mapping."
             )
             return False

--- a/rasa/shared/core/slot_mappings.py
+++ b/rasa/shared/core/slot_mappings.py
@@ -185,7 +185,8 @@ class SlotMapping(Enum):
             and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities
         ):
             rasa.shared.utils.io.raise_warning(
-                f"Slot uses a 'from_entity' mapping for a non-existent entity '{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'"
+                f"Slot uses a 'from_entity' mapping for a non-existent entity "
+                f"'{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'. Skipping slot extraction because of invalid mapping."
             )
             return False
 
@@ -194,7 +195,8 @@ class SlotMapping(Enum):
             and mapping.get("intent") not in domain.intents
         ):
             rasa.shared.utils.io.raise_warning(
-                f"Slot uses a 'from_intent' mapping for a non-existent intent '{mapping.get('intent')}'"
+                f"Slot uses a 'from_intent' mapping for a non-existent intent "
+                f"'{mapping.get('intent')}'. Skipping slot extraction because of invalid mapping."
             )
             return False
 

--- a/rasa/shared/core/slot_mappings.py
+++ b/rasa/shared/core/slot_mappings.py
@@ -168,7 +168,9 @@ class SlotMapping(Enum):
         return slot_fulfils_entity_mapping
 
     @staticmethod
-    def check_mapping_validity(slot_name: Text, mapping: Dict[Text, Any], domain: "Domain") -> bool:
+    def check_mapping_validity(
+        slot_name: Text, mapping: Dict[Text, Any], domain: "Domain"
+    ) -> bool:
         """Checks the mapping for validity.
 
         Args:
@@ -185,8 +187,9 @@ class SlotMapping(Enum):
             and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities
         ):
             rasa.shared.utils.io.raise_warning(
-                f"Slot '{slot_name}' uses a 'from_entity' mapping for a non-existent entity "
-                f"'{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'. Skipping slot extraction because of invalid mapping."
+                f"Slot '{slot_name}' uses a 'from_entity' mapping "
+                f"for a non-existent entity '{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'. "
+                f"Skipping slot extraction because of invalid mapping."
             )
             return False
 
@@ -195,8 +198,9 @@ class SlotMapping(Enum):
             and mapping.get("intent") not in domain.intents
         ):
             rasa.shared.utils.io.raise_warning(
-                f"Slot '{slot_name}' uses a 'from_intent' mapping for a non-existent intent "
-                f"'{mapping.get('intent')}'. Skipping slot extraction because of invalid mapping."
+                f"Slot '{slot_name}' uses a 'from_intent' mapping for "
+                f"a non-existent intent '{mapping.get('intent')}'. "
+                f"Skipping slot extraction because of invalid mapping."
             )
             return False
 

--- a/rasa/shared/core/slot_mappings.py
+++ b/rasa/shared/core/slot_mappings.py
@@ -167,6 +167,39 @@ class SlotMapping(Enum):
 
         return slot_fulfils_entity_mapping
 
+    @staticmethod
+    def check_mapping_validity(mapping: Dict[Text, Any], domain: "Domain") -> bool:
+        """Checks the mapping for validity.
+
+        Args:
+            mapping: Slot mapping.
+            domain: The domain to check against.
+
+        Returns:
+            True, if intent and entity specified in a mapping exist in domain.
+        """
+        from rasa.shared.core.constants import MAPPING_TYPE
+
+        if (
+            mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_ENTITY)
+            and mapping.get(ENTITY_ATTRIBUTE_TYPE) not in domain.entities
+        ):
+            rasa.shared.utils.io.raise_warning(
+                f"Slot uses a 'from_entity' mapping for a non-existent entity '{mapping.get(ENTITY_ATTRIBUTE_TYPE)}'"
+            )
+            return False
+
+        if (
+            mapping.get(MAPPING_TYPE) == str(SlotMapping.FROM_INTENT)
+            and mapping.get("intent") not in domain.intents
+        ):
+            rasa.shared.utils.io.raise_warning(
+                f"Slot uses a 'from_intent' mapping for a non-existent intent '{mapping.get('intent')}'"
+            )
+            return False
+
+        return True
+
 
 def validate_slot_mappings(domain_slots: Dict[Text, Any]) -> None:
     """Raises InvalidDomain exception if slot mappings are invalid."""

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -472,6 +472,14 @@ async def test_validate_slots(
     tracker = DialogueStateTracker.from_events(sender_id="bla", evts=events)
 
     domain = f"""
+    version: "3.0"
+    
+    entities:
+    - num_tables
+    - some_entity
+    - some_other_entity
+    - some_slot
+    
     slots:
       {slot_name}:
         type: any
@@ -482,15 +490,17 @@ async def test_validate_slots(
         mappings:
         - type: from_entity
           entity: num_tables
+          
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
             - {slot_name}
             - num_tables
+            
     actions:
     - validate_{form_name}
     """
-    domain = Domain.from_yaml(domain)
+    domain = Domain.from_yaml(textwrap.dedent(domain))
     action_extract_slots = ActionExtractSlots(action_endpoint=None)
 
     slot_events = await action_extract_slots.run(

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -473,13 +473,13 @@ async def test_validate_slots(
 
     domain = f"""
     version: "3.0"
-    
+
     entities:
     - num_tables
     - some_entity
     - some_other_entity
     - some_slot
-    
+
     slots:
       {slot_name}:
         type: any
@@ -490,13 +490,13 @@ async def test_validate_slots(
         mappings:
         - type: from_entity
           entity: num_tables
-          
+
     forms:
       {form_name}:
         {REQUIRED_SLOTS_KEY}:
             - {slot_name}
             - num_tables
-            
+
     actions:
     - validate_{form_name}
     """

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -2322,13 +2322,17 @@ async def test_action_extract_slots_with_not_existing_entity():
 
     action_extract_slots = ActionExtractSlots(None)
 
-    events = await action_extract_slots.run(
-        CollectingOutputChannel(),
-        TemplatedNaturalLanguageGenerator(domain.responses),
-        tracker,
-        domain,
-    )
-    assert events == [1]
+    with pytest.warns(
+        None,
+        match="Slot uses a `from_entity` mapping for a non-existent entity 'city2'",
+    ):
+        events = await action_extract_slots.run(
+            CollectingOutputChannel(),
+            TemplatedNaturalLanguageGenerator(domain.responses),
+            tracker,
+            domain,
+        )
+    assert events == []
 
 
 async def test_action_extract_slots_with_not_existing_intent():
@@ -2355,13 +2359,17 @@ async def test_action_extract_slots_with_not_existing_intent():
 
     action_extract_slots = ActionExtractSlots(None)
 
-    events = await action_extract_slots.run(
-        CollectingOutputChannel(),
-        TemplatedNaturalLanguageGenerator(domain.responses),
-        tracker,
-        domain,
-    )
-    assert events == [1]
+    with pytest.warns(
+        UserWarning,
+        match=r"Slot uses a 'from_intent' mapping for a non-existent intent 'affirm'",
+    ):
+        events = await action_extract_slots.run(
+            CollectingOutputChannel(),
+            TemplatedNaturalLanguageGenerator(domain.responses),
+            tracker,
+            domain,
+        )
+    assert events == []
 
 
 async def test_action_extract_slots_with_none_value_predefined_mapping():

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -1355,7 +1355,7 @@ async def test_action_extract_slots_with_list_slot(
         textwrap.dedent(
             f"""
     version: "3.0"
-    
+
     entities:
     - topping
 
@@ -1751,15 +1751,15 @@ async def test_extract_other_list_slot_from_entity(
         textwrap.dedent(
             f"""
     version: "3.0"
-    
+
     entities:
     - topping
     - some_slot
-    
+
     intents:
     - some_intent
     - greeted
-    
+
     slots:
       {slot_name}:
         type: list
@@ -2341,8 +2341,9 @@ async def test_action_extract_slots_with_not_existing_entity():
 
     with pytest.warns(
         None,
-        match="Slot 'location' uses a `from_entity` mapping for a non-existent entity 'city2'. "
-              "Skipping slot extraction because of invalid mapping.",
+        match="Slot 'location' uses a `from_entity` mapping for "
+        "a non-existent entity 'city2'. "
+        "Skipping slot extraction because of invalid mapping.",
     ):
         events = await action_extract_slots.run(
             CollectingOutputChannel(),
@@ -2379,8 +2380,9 @@ async def test_action_extract_slots_with_not_existing_intent():
 
     with pytest.warns(
         UserWarning,
-        match=r"Slot 'location' uses a 'from_intent' mapping for a non-existent intent 'affirm'. "
-              r"Skipping slot extraction because of invalid mapping.",
+        match=r"Slot 'location' uses a 'from_intent' mapping for "
+        r"a non-existent intent 'affirm'. "
+        r"Skipping slot extraction because of invalid mapping.",
     ):
         events = await action_extract_slots.run(
             CollectingOutputChannel(),

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -1159,6 +1159,7 @@ async def test_action_extract_slots_predefined_mappings(
             - deny
             entities:
             - city
+            - name
             slots:
               location:
                 type: text
@@ -1298,6 +1299,8 @@ async def test_action_extract_slots_when_mapping_applies(
 
     domain = Domain.from_dict(
         {
+            "intents": ["greet"],
+            "entities": ["some_slot"],
             "slots": {entity_name: {"type": "text", "mappings": [slot_mapping]}},
             "forms": {form_name: {REQUIRED_SLOTS_KEY: [entity_name]}},
         }
@@ -1352,6 +1355,9 @@ async def test_action_extract_slots_with_list_slot(
         textwrap.dedent(
             f"""
     version: "3.0"
+    
+    entities:
+    - topping
 
     slots:
       {slot_name}:
@@ -1692,6 +1698,7 @@ async def test_action_extract_slots_from_entity(
     )
     domain = Domain.from_dict(
         {
+            "entities": ["some_entity"],
             "slots": {"some_slot": {"type": "any", "mappings": [mapping],}},
             "forms": {form_name: {REQUIRED_SLOTS_KEY: ["some_slot"]}},
         }
@@ -1744,7 +1751,15 @@ async def test_extract_other_list_slot_from_entity(
         textwrap.dedent(
             f"""
     version: "3.0"
-
+    
+    entities:
+    - topping
+    - some_slot
+    
+    intents:
+    - some_intent
+    - greeted
+    
     slots:
       {slot_name}:
         type: list
@@ -2316,7 +2331,6 @@ async def test_action_extract_slots_with_not_existing_entity():
             mappings:
             - type: from_entity
               entity: city2
-              conditions: []
         """
     )
     domain = Domain.from_yaml(domain_yaml)

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -2298,6 +2298,72 @@ async def test_action_extract_slots_with_empty_conditions():
     assert events == [SlotSet("location", "Berlin")]
 
 
+async def test_action_extract_slots_with_not_existing_entity():
+    domain_yaml = textwrap.dedent(
+        """
+        version: "3.0"
+
+        entities:
+        - city
+
+        slots:
+          location:
+            type: float
+            influence_conversation: false
+            mappings:
+            - type: from_entity
+              entity: city2
+              conditions: []
+        """
+    )
+    domain = Domain.from_yaml(domain_yaml)
+    event = UserUttered("Hi", entities=[{"entity": "city", "value": "Berlin"}])
+    tracker = DialogueStateTracker.from_events(sender_id="test_id", evts=[event])
+
+    action_extract_slots = ActionExtractSlots(None)
+
+    events = await action_extract_slots.run(
+        CollectingOutputChannel(),
+        TemplatedNaturalLanguageGenerator(domain.responses),
+        tracker,
+        domain,
+    )
+    assert events == [1]
+
+
+async def test_action_extract_slots_with_not_existing_intent():
+    domain_yaml = textwrap.dedent(
+        """
+        version: "3.0"
+
+        intents:
+        - greet
+
+        slots:
+          location:
+            type: text
+            influence_conversation: false
+            mappings:
+            - type: from_intent
+              intent: affirm
+              value: some_value
+        """
+    )
+    domain = Domain.from_yaml(domain_yaml)
+    event = UserUttered("Hi", entities=[{"entity": "city", "value": "Berlin"}])
+    tracker = DialogueStateTracker.from_events(sender_id="test_id", evts=[event])
+
+    action_extract_slots = ActionExtractSlots(None)
+
+    events = await action_extract_slots.run(
+        CollectingOutputChannel(),
+        TemplatedNaturalLanguageGenerator(domain.responses),
+        tracker,
+        domain,
+    )
+    assert events == [1]
+
+
 async def test_action_extract_slots_with_none_value_predefined_mapping():
     domain_yaml = textwrap.dedent(
         """

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -1194,12 +1194,14 @@ async def test_action_extract_slots_predefined_mappings(
 
     action_extract_slots = ActionExtractSlots(action_endpoint=None)
     tracker = DialogueStateTracker.from_events("sender", evts=[user])
-    events = await action_extract_slots.run(
-        CollectingOutputChannel(),
-        TemplatedNaturalLanguageGenerator(domain.responses),
-        tracker,
-        domain,
-    )
+
+    with pytest.warns(None):
+        events = await action_extract_slots.run(
+            CollectingOutputChannel(),
+            TemplatedNaturalLanguageGenerator(domain.responses),
+            tracker,
+            domain,
+        )
 
     assert events == [SlotSet(slot_name, slot_value)]
 
@@ -2289,12 +2291,13 @@ async def test_action_extract_slots_with_empty_conditions():
 
     action_extract_slots = ActionExtractSlots(None)
 
-    events = await action_extract_slots.run(
-        CollectingOutputChannel(),
-        TemplatedNaturalLanguageGenerator(domain.responses),
-        tracker,
-        domain,
-    )
+    with pytest.warns(None):
+        events = await action_extract_slots.run(
+            CollectingOutputChannel(),
+            TemplatedNaturalLanguageGenerator(domain.responses),
+            tracker,
+            domain,
+        )
     assert events == [SlotSet("location", "Berlin")]
 
 

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -2341,7 +2341,8 @@ async def test_action_extract_slots_with_not_existing_entity():
 
     with pytest.warns(
         None,
-        match="Slot uses a `from_entity` mapping for a non-existent entity 'city2'",
+        match="Slot 'location' uses a `from_entity` mapping for a non-existent entity 'city2'. "
+              "Skipping slot extraction because of invalid mapping.",
     ):
         events = await action_extract_slots.run(
             CollectingOutputChannel(),
@@ -2378,7 +2379,8 @@ async def test_action_extract_slots_with_not_existing_intent():
 
     with pytest.warns(
         UserWarning,
-        match=r"Slot uses a 'from_intent' mapping for a non-existent intent 'affirm'",
+        match=r"Slot 'location' uses a 'from_intent' mapping for a non-existent intent 'affirm'. "
+              r"Skipping slot extraction because of invalid mapping.",
     ):
         events = await action_extract_slots.run(
             CollectingOutputChannel(),


### PR DESCRIPTION
**Proposed changes**:
- fix #10122 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
