### PR TITLE
add warning log asking user to update training data version

### DIFF
--- a/rasa/shared/utils/validation.py
+++ b/rasa/shared/utils/validation.py
@@ -247,6 +247,17 @@ def validate_training_data_format_version(
             raise TypeError
 
         if version.parse(LATEST_TRAINING_DATA_FORMAT_VERSION) >= parsed_version:
+            if version_value < LATEST_TRAINING_DATA_FORMAT_VERSION:
+                # not raising here since it's not critical
+                logger.warning(
+                    f"Training data file {filename} has a lower "
+                    f"format version than your Rasa Open Source installation: "
+                    f"{version_value} < {LATEST_TRAINING_DATA_FORMAT_VERSION}. "
+                    f"Rasa Open Source will read the file as a version "
+                    f"{LATEST_TRAINING_DATA_FORMAT_VERSION} file but "
+                    f"please update your version key to 3.0. "
+                    f"See {DOCS_URL_TRAINING_DATA}."
+                )
             return True
 
     except TypeError:

--- a/rasa/shared/utils/validation.py
+++ b/rasa/shared/utils/validation.py
@@ -255,8 +255,8 @@ def validate_training_data_format_version(
                     f"{version_value} < {LATEST_TRAINING_DATA_FORMAT_VERSION}. "
                     f"Rasa Open Source will read the file as a version "
                     f"{LATEST_TRAINING_DATA_FORMAT_VERSION} file but "
-                    f"please update your version key to 3.0. "
-                    f"See {DOCS_URL_TRAINING_DATA}."
+                    f"please update your version key to "
+                    f"{LATEST_TRAINING_DATA_FORMAT_VERSION}. See {DOCS_URL_TRAINING_DATA}."
                 )
             return True
 

--- a/rasa/shared/utils/validation.py
+++ b/rasa/shared/utils/validation.py
@@ -256,7 +256,8 @@ def validate_training_data_format_version(
                     f"Rasa Open Source will read the file as a version "
                     f"{LATEST_TRAINING_DATA_FORMAT_VERSION} file but "
                     f"please update your version key to "
-                    f"{LATEST_TRAINING_DATA_FORMAT_VERSION}. See {DOCS_URL_TRAINING_DATA}."
+                    f"{LATEST_TRAINING_DATA_FORMAT_VERSION}. "
+                    f"See {DOCS_URL_TRAINING_DATA}."
                 )
             return True
 


### PR DESCRIPTION
**Proposed changes**:
Closes #10288
- This adds a log warning in the case where a user has manually migrated their domain and data files to the latest Rasa Open Source version format, but is still specifying a lower version in these files. eg: using a rasa 3.0 format, but still specifying `version: "2.0"`. 
- This warning will be logged during the validation step, asking the user to update the version in their domain or data files to the LATEST_TRAINING_DATA_FORMAT_VERSION.

<img width="1249" alt="Screenshot 2021-11-22 at 12 55 36" src="https://user-images.githubusercontent.com/1754975/142858351-118bbfaf-0a82-456b-8c9e-b63d4cca7188.png">
