### PR TITLE
add regex validation to pattern utils

### DIFF
--- a/docs/docs/nlu-training-data.mdx
+++ b/docs/docs/nlu-training-data.mdx
@@ -104,7 +104,7 @@ If your entity has a deterministic structure, you can use regular expressions in
 
 #### Regular Expressions as Features
 
-You can use regular expressions to create features for the [`RegexFeaturizer`](components.mdx#regexfeaturizer) component in you NLU pipeline.
+You can use regular expressions to create features for the [`RegexFeaturizer`](components.mdx#regexfeaturizer) component in your NLU pipeline.
 
 When using a regular expression with the  `RegexFeaturizer`, the
 name of the regular expression does not matter.

--- a/rasa/nlu/utils/pattern_utils.py
+++ b/rasa/nlu/utils/pattern_utils.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Text, Union
 
 import rasa.shared.utils.io
 from rasa.shared.nlu.training_data.training_data import TrainingData
+from rasa.shared.exceptions import InvalidConfigException
 
 
 def _convert_lookup_tables_to_regex(
@@ -152,5 +153,16 @@ def extract_patterns(
                 training_data, use_only_entities, use_word_boundaries
             )
         )
+
+    # validate regexes, raise Error when invalid
+    for pattern in patterns:
+        try:
+            re.compile(pattern["pattern"])
+        except re.error:
+            raise InvalidConfigException(
+                f"Model training failed. '{pattern['pattern']}' "
+                "is not a valid regex. Please update your nlu "
+                f"training data configuration at {pattern}."
+            )
 
     return patterns

--- a/tests/nlu/utils/test_pattern_utils.py
+++ b/tests/nlu/utils/test_pattern_utils.py
@@ -181,3 +181,40 @@ def test_extract_patterns_use_only_lookup_tables_or_regex_features(
     )
 
     assert actual_patterns == expected_patterns
+
+
+@pytest.mark.parametrize(
+    "lookup_tables, regex_features, use_lookup_tables, use_regex_features",
+    [
+        (
+            {"name": "person", "elements": ["Max", "John"]},
+            {"name": "zipcode", "pattern": "*[0-9]{5}"},
+            True,
+            True,
+        ),
+    ],
+)
+def test_regex_validation(
+    lookup_tables: Dict[Text, List[Text]],
+    regex_features: Dict[Text, Text],
+    use_lookup_tables: bool,
+    use_regex_features: bool,
+):
+    """Tests if exception is raised when regex patterns are invalid."""
+
+    training_data = TrainingData()
+    if lookup_tables:
+        training_data.lookup_tables = [lookup_tables]
+    if regex_features:
+        training_data.regex_features = [regex_features]
+
+    with pytest.raises(Exception) as e:
+        pattern_utils.extract_patterns(
+            training_data,
+            use_lookup_tables=use_lookup_tables,
+            use_regexes=use_regex_features,
+        )
+
+    assert "Model training failed." in str(e.value)
+    assert "not a valid regex." in str(e.value)
+    assert "Please update your nlu training data configuration" in str(e.value)


### PR DESCRIPTION
**Proposed changes**:
addresses the OSS side of #6960

This adds regex validation to the `extract_pattern` method of `rasa/nlu/utils/pattern_utils.py` and a corresponding test.
I'm not totally sure about the error message, eg:
```
 "Model training failed. '*[0-9]{5}' is not a valid regex. Please update your nlu training data configuration at {'name': 'zipcode', 'pattern': '*[0-9]{5}'}."
```

Discussion concluded that training should fail and a readable error message displayed, however I'm not sure if this message gives the user enough info about where this config is.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
