### PR TITLE
Tidy output when raising InvalidModelError

### DIFF
--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -402,7 +402,15 @@ class GraphNode:
             # handling of exceptions.
             raise
         except Exception as e:
-            raise e
+            if not isinstance(e, RasaException):
+                raise GraphComponentException(
+                    f"Error initializing graph component for node {self._node_name}."
+                ) from e
+            else:
+                logger.error(
+                    f"Error initializing graph component for node {self._node_name}."
+                )
+                raise
 
     def _get_resource(self, kwargs: Dict[Text, Any]) -> Resource:
         if "resource" in kwargs:

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -402,9 +402,7 @@ class GraphNode:
             # handling of exceptions.
             raise
         except Exception as e:
-            raise GraphComponentException(
-                f"Error initializing graph component for node '{self._node_name}'."
-            ) from e
+            raise e
 
     def _get_resource(self, kwargs: Dict[Text, Any]) -> Resource:
         if "resource" in kwargs:

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import typing
 import logging
-import sys
 from typing import Any, Dict, List, Optional, Text, Tuple
 
 from rasa.engine.graph import ExecutionContext, GraphComponent

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import dataclasses
 import typing
 import logging
+import sys
 from typing import Any, Dict, List, Optional, Text, Tuple
-
 
 from rasa.engine.graph import ExecutionContext, GraphComponent
 from rasa.engine.recipes.default_recipe import DefaultV1Recipe
@@ -78,6 +78,8 @@ class SpacyNLP(GraphComponent):
     def load_model(spacy_model_name: Text) -> SpacyModel:
         """Try loading the model, catching the OSError if missing."""
         import spacy
+
+        sys.tracebacklimit = 0
 
         if not spacy_model_name:
             raise InvalidModelError(

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -88,7 +88,7 @@ class SpacyNLP(GraphComponent):
                 f"For example:\n"
                 f"- name: SpacyNLP\n"
                 f"  model: en_core_web_md\n"
-                f"More informaton can be found on {DOCS_URL_COMPONENTS}#spacynlp"
+                f"More information can be found on {DOCS_URL_COMPONENTS}#spacynlp"
             )
 
         try:
@@ -99,7 +99,7 @@ class SpacyNLP(GraphComponent):
                 f"Please confirm that {spacy_model_name} is an available spaCy model. "
                 f"You need to download one upfront. For example:\n"
                 f"python -m spacy download en_core_web_md\n"
-                f"More informaton can be found on {DOCS_URL_COMPONENTS}#spacynlp"
+                f"More information can be found on {DOCS_URL_COMPONENTS}#spacynlp"
             )
 
     @classmethod

--- a/rasa/nlu/utils/spacy_utils.py
+++ b/rasa/nlu/utils/spacy_utils.py
@@ -79,8 +79,6 @@ class SpacyNLP(GraphComponent):
         """Try loading the model, catching the OSError if missing."""
         import spacy
 
-        sys.tracebacklimit = 0
-
         if not spacy_model_name:
             raise InvalidModelError(
                 f"Missing model configuration for `SpacyNLP` in `config.yml`.\n"


### PR DESCRIPTION
**Proposed changes**:
Closes #10232 
This uses the originating error info in `graph.py` when a rasa exception is raised. 
These errors now appear as:

```
❯ rasa train
2021-11-26 16:24:14 INFO     rasa.nlu.utils.spacy_utils  - Trying to load SpaCy model with name 'None'.
2021-11-26 16:24:14 ERROR    rasa.engine.graph  - Error initializing graph component for node provide_SpacyNLP0.
InvalidModelError: Missing model configuration for `SpacyNLP` in `config.yml`.
You must pass a model to the `SpacyNLP` component explicitly.
For example:
- name: SpacyNLP
  model: en_core_web_md
More information can be found on https://rasa.com/docs/rasa/components#spacynlp

❯ rasa train
2021-11-26 16:25:40 INFO     rasa.nlu.utils.spacy_utils  - Trying to load SpaCy model with name 'IUYIUYI'.
2021-11-26 16:25:40 ERROR    rasa.engine.graph  - Error initializing graph component for node provide_SpacyNLP0.
InvalidModelError: Please confirm that IUYIUYI is an available spaCy model. You need to download one upfront. For example:
python -m spacy download en_core_web_md
More information can be found on https://rasa.com/docs/rasa/components#spacynlp
```