### PR TITLE
Make `RASA_ENVIRONMENT` available in events logged by Kafka producer

### DIFF
--- a/changelog/10413.improvement.md
+++ b/changelog/10413.improvement.md
@@ -1,0 +1,2 @@
+The value of the `RASA_ENVIRONMENT` environmental variable is sent as a header in messages logged by `KafkaEventBroker`.
+This value was previously only made available by `PikaEventConsumer`.

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -1,3 +1,4 @@
+import os
 import json
 import logging
 from asyncio import AbstractEventLoop
@@ -8,6 +9,7 @@ from rasa.core.brokers.broker import EventBroker
 from rasa.shared.utils.io import DEFAULT_ENCODING
 from rasa.utils.endpoints import EndpointConfig
 from rasa.shared.exceptions import RasaException
+import rasa.shared.utils.common
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +200,16 @@ class KafkaEventBroker(EventBroker):
         logger.debug(
             f"Calling kafka send({self.topic}, value={event}, key={partition_key!s})"
         )
-        self.producer.send(self.topic, value=event, key=partition_key)
+
+        headers = [("RASA_ENVIRONMENT", bytes(self.rasa_environment, encoding=DEFAULT_ENCODING))]
+
+        self.producer.send(self.topic, value=event, key=partition_key, headers=headers)
 
     def _close(self) -> None:
         self.producer.close()
+
+
+    @rasa.shared.utils.common.lazy_property
+    def rasa_environment(self) -> Optional[Text]:
+        """Get value of the `RASA_ENVIRONMENT` environment variable."""
+        return os.environ.get("RASA_ENVIRONMENT")

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -197,11 +197,11 @@ class KafkaEventBroker(EventBroker):
         else:
             partition_key = None
 
-        logger.debug(
-            f"Calling kafka send({self.topic}, value={event}, key={partition_key!s})"
-        )
-
         headers = [("RASA_ENVIRONMENT", bytes(self.rasa_environment, encoding=DEFAULT_ENCODING))]
+
+        logger.debug(
+            f"Calling kafka send({self.topic}, value={event}, key={partition_key!s}, headers={headers})"
+        )
 
         self.producer.send(self.topic, value=event, key=partition_key, headers=headers)
 

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -197,17 +197,22 @@ class KafkaEventBroker(EventBroker):
         else:
             partition_key = None
 
-        headers = [("RASA_ENVIRONMENT", bytes(self.rasa_environment, encoding=DEFAULT_ENCODING))]
+        headers = [
+            (
+                "RASA_ENVIRONMENT",
+                bytes(self.rasa_environment, encoding=DEFAULT_ENCODING),
+            )
+        ]
 
         logger.debug(
-            f"Calling kafka send({self.topic}, value={event}, key={partition_key!s}, headers={headers})"
+            f"Calling kafka send({self.topic}, value={event},"
+            f" key={partition_key!s}, headers={headers})"
         )
 
         self.producer.send(self.topic, value=event, key=partition_key, headers=headers)
 
     def _close(self) -> None:
         self.producer.close()
-
 
     @rasa.shared.utils.common.lazy_property
     def rasa_environment(self) -> Optional[Text]:


### PR DESCRIPTION
**Proposed changes**:
- Add a `RASA_ENVIRONMENT` header to the Kafka event producer to make it available to consumers [as is done in the `app_id` for Pika](https://github.com/RasaHQ/rasa/blob/4fd90e7b55a6e354a7dfd16286e5fe7f11b53f52/rasa/core/brokers/pika.py#L297)
- Closes https://github.com/RasaHQ/rasa-x/issues/7010 in conjunction with https://github.com/RasaHQ/rasa-x/pull/7013

**Status (please check what you already did)**:
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
