### PR TITLE
WIP: Fix override of nested dictionary configs

### DIFF
--- a/rasa/core/policies/unexpected_intent_policy.py
+++ b/rasa/core/policies/unexpected_intent_policy.py
@@ -112,6 +112,7 @@ from rasa.utils.tensorflow.model_data import (
 )
 
 import rasa.utils.io as io_utils
+import rasa.utils.common
 from rasa.core.exceptions import RasaCoreException
 from rasa.shared.utils import common
 
@@ -889,7 +890,7 @@ class UnexpecTEDIntentPolicy(TEDPolicy):
 
     @classmethod
     def _update_loaded_params(cls, meta: Dict[Text, Any]) -> Dict[Text, Any]:
-        meta = train_utils.override_defaults(cls.get_default_config(), meta)
+        meta = rasa.utils.common.override_defaults(cls.get_default_config(), meta)
         return meta
 
     @classmethod

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -11,6 +11,8 @@ from rasa.engine.exceptions import (
     GraphSchemaException,
 )
 import rasa.shared.utils.common
+import rasa.utils.train_utils
+
 from rasa.engine.storage.resource import Resource
 
 from rasa.engine.storage.storage import ModelStorage
@@ -359,10 +361,11 @@ class GraphNode:
         self._constructor_fn: Callable = getattr(
             self._component_class, self._constructor_name
         )
-        self._component_config: Dict[Text, Any] = {
-            **self._component_class.get_default_config(),
-            **component_config,
-        }
+        self._component_config: Dict[
+            Text, Any
+        ] = rasa.utils.train_utils.override_defaults(
+            self._component_class.get_default_config(), component_config,
+        )
         self._fn_name: Text = fn_name
         self._fn: Callable = getattr(self._component_class, self._fn_name)
         self._inputs: Dict[Text, Text] = inputs

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -11,7 +11,7 @@ from rasa.engine.exceptions import (
     GraphSchemaException,
 )
 import rasa.shared.utils.common
-import rasa.utils.train_utils
+import rasa.utils.common
 
 from rasa.engine.storage.resource import Resource
 
@@ -361,9 +361,7 @@ class GraphNode:
         self._constructor_fn: Callable = getattr(
             self._component_class, self._constructor_name
         )
-        self._component_config: Dict[
-            Text, Any
-        ] = rasa.utils.train_utils.override_defaults(
+        self._component_config: Dict[Text, Any] = rasa.utils.common.override_defaults(
             self._component_class.get_default_config(), component_config,
         )
         self._fn_name: Text = fn_name

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import logging
 import os
 import shutil
@@ -308,6 +309,35 @@ def update_existing_keys(
         if k in updated:
             updated[k] = v
     return updated
+
+
+def override_defaults(
+    defaults: Optional[Dict[Text, Any]], custom: Optional[Dict[Text, Any]]
+) -> Dict[Text, Any]:
+    """Override default config with the given config.
+
+    We cannot use `dict.update` method because configs contain nested dicts.
+
+    Args:
+        defaults: default config
+        custom: user config containing new parameters
+
+    Returns:
+        updated config
+    """
+    if defaults:
+        config = copy.deepcopy(defaults)
+    else:
+        config = {}
+
+    if custom:
+        for key in custom.keys():
+            if isinstance(config.get(key), dict):
+                config[key].update(custom[key])
+            else:
+                config[key] = custom[key]
+
+    return config
 
 
 class RepeatedLogFilter(logging.Filter):

--- a/tests/engine/test_graph_node.py
+++ b/tests/engine/test_graph_node.py
@@ -332,7 +332,6 @@ def test_loading_from_resource_eager(default_model_storage: ModelStorage):
 
 
 def test_config_with_nested_dict_override(default_model_storage: ModelStorage):
-
     class ComponentWithNestedDictConfig(GraphComponent):
         @staticmethod
         def get_default_config() -> Dict[Text, Any]:
@@ -340,12 +339,12 @@ def test_config_with_nested_dict_override(default_model_storage: ModelStorage):
 
         @classmethod
         def create(
-                cls,
-                config: Dict,
-                model_storage: ModelStorage,
-                resource: Resource,
-                execution_context: ExecutionContext,
-                **kwargs: Any,
+            cls,
+            config: Dict,
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+            **kwargs: Any,
         ) -> ComponentWithNestedDictConfig:
             return cls()
 

--- a/tests/engine/test_graph_node.py
+++ b/tests/engine/test_graph_node.py
@@ -329,3 +329,47 @@ def test_loading_from_resource_eager(default_model_storage: ModelStorage):
 
     assert actual_node_name == node_name
     assert value == test_value
+
+
+def test_config_with_nested_dict_override(default_model_storage: ModelStorage):
+
+    class ComponentWithNestedDictConfig(GraphComponent):
+        @staticmethod
+        def get_default_config() -> Dict[Text, Any]:
+            return {"nested-dict": {"key1": "value1", "key2": "value2"}}
+
+        @classmethod
+        def create(
+                cls,
+                config: Dict,
+                model_storage: ModelStorage,
+                resource: Resource,
+                execution_context: ExecutionContext,
+                **kwargs: Any,
+        ) -> ComponentWithNestedDictConfig:
+            return cls()
+
+        def run(self) -> None:
+            return None
+
+    node = GraphNode(
+        node_name="nested_dict_config",
+        component_class=ComponentWithNestedDictConfig,
+        constructor_name="create",
+        component_config={"nested-dict": {"key2": "override-value2"}},
+        fn_name="run",
+        inputs={},
+        eager=True,
+        model_storage=default_model_storage,
+        resource=None,
+        execution_context=ExecutionContext(GraphSchema({}), "123"),
+    )
+
+    expected_config = {"nested-dict": {"key1": "value1", "key2": "override-value2"}}
+
+    for key, value in expected_config.items():
+        assert key in node._component_config
+        if isinstance(value, dict):
+            for nested_key, nested_value in expected_config[key].items():
+                assert nested_key in node._component_config[key]
+                assert node._component_config[key][nested_key] == nested_value

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from typing import Callable, List, Optional, Text, Dict, Any, Tuple
 
+import rasa.utils.train_utils
 from rasa.engine.graph import ExecutionContext, GraphComponent
 from rasa.engine.storage.resource import Resource
 from rasa.engine.storage.storage import ModelStorage
@@ -74,7 +75,9 @@ def create_diet(
 
         default_execution_context.is_finetuning = finetune
         return constructor(
-            config={**DIETClassifier.get_default_config(), **config},
+            config=rasa.utils.train_utils.override_defaults(
+                DIETClassifier.get_default_config(), config
+            ),
             model_storage=default_model_storage,
             execution_context=default_execution_context,
             resource=default_diet_resource,
@@ -311,6 +314,7 @@ async def test_train_persist_load_with_different_settings(
 @pytest.mark.timeout(240, func_only=True)
 async def test_train_persist_load_with_nested_dict_config(
     create_train_load_and_process_diet: Callable[..., Message],
+    create_diet: Callable[..., DIETClassifier],
 ):
     config = {HIDDEN_LAYERS_SIZES: {"text": [256, 512]}}
     create_train_load_and_process_diet(config)

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -35,6 +35,7 @@ from rasa.utils.tensorflow.constants import (
     ENTITY_RECOGNITION,
     INTENT_CLASSIFICATION,
     MODEL_CONFIDENCE,
+    HIDDEN_LAYERS_SIZES,
 )
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier
@@ -303,6 +304,15 @@ async def test_train_persist_load_with_different_settings(
     create_diet: Callable[..., DIETClassifier],
 ):
     config = {LOSS_TYPE: "margin", EPOCHS: 1}
+    create_train_load_and_process_diet(config)
+    create_diet(config, load=True, finetune=True)
+
+
+@pytest.mark.timeout(240, func_only=True)
+async def test_train_persist_load_with_nested_dict_config(
+    create_train_load_and_process_diet: Callable[..., Message],
+):
+    config = {HIDDEN_LAYERS_SIZES: {"text": [256, 512]}}
     create_train_load_and_process_diet(config)
     create_diet(config, load=True, finetune=True)
 

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from typing import Callable, List, Optional, Text, Dict, Any, Tuple
 
-import rasa.utils.train_utils
+import rasa.utils.common
 from rasa.engine.graph import ExecutionContext, GraphComponent
 from rasa.engine.storage.resource import Resource
 from rasa.engine.storage.storage import ModelStorage
@@ -75,7 +75,7 @@ def create_diet(
 
         default_execution_context.is_finetuning = finetune
         return constructor(
-            config=rasa.utils.train_utils.override_defaults(
+            config=rasa.utils.common.override_defaults(
                 DIETClassifier.get_default_config(), config
             ),
             model_storage=default_model_storage,

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -136,3 +136,13 @@ def test_find_unavailable_packages():
 )
 def test_module_path_from_class(clazz: Type, module_path: Text):
     assert rasa.utils.common.module_path_from_class(clazz) == module_path
+
+
+def test_override_defaults():
+    defaults = {"nested-dict": {"key1": "value1", "key2": "value2"}}
+    custom = {"nested-dict": {"key2": "override-value2"}}
+
+    updated_config = rasa.utils.common.override_defaults(defaults, custom)
+
+    expected_config = {"nested-dict": {"key1": "value1", "key2": "override-value2"}}
+    assert updated_config == expected_config


### PR DESCRIPTION
Closes #10391 

When the config of a component contains a nested dictionary, and users specify only certain keys, the whole dictionary in the default config gets overwritten, so that the keys that are not specified by the user are missing, leading to errors when components try to access them.

**Proposed changes**:
- Update the default config by checking for nested dictionaries.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
