### PR TITLE
Overriding default config in case of nested dictionaries

### DIFF
--- a/changelog/10391.bugfix.md
+++ b/changelog/10391.bugfix.md
@@ -1,0 +1,3 @@
+Fix overriding of default config with custom config containing nested dictionaries. Before,
+ the keys of a nested dictionary in the default config that were not specified in the 
+custom config got lost.

--- a/rasa/core/policies/unexpected_intent_policy.py
+++ b/rasa/core/policies/unexpected_intent_policy.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from pathlib import Path
 from typing import Any, List, Optional, Text, Dict, Type, TYPE_CHECKING
 
+import rasa.utils.common
 from rasa.engine.graph import ExecutionContext
 from rasa.engine.recipes.default_recipe import DefaultV1Recipe
 from rasa.engine.storage.resource import Resource
@@ -889,7 +890,7 @@ class UnexpecTEDIntentPolicy(TEDPolicy):
 
     @classmethod
     def _update_loaded_params(cls, meta: Dict[Text, Any]) -> Dict[Text, Any]:
-        meta = train_utils.override_defaults(cls.get_default_config(), meta)
+        meta = rasa.utils.common.override_defaults(cls.get_default_config(), meta)
         return meta
 
     @classmethod

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -11,6 +11,7 @@ from rasa.engine.exceptions import (
     GraphSchemaException,
 )
 import rasa.shared.utils.common
+import rasa.utils.common
 from rasa.engine.storage.resource import Resource
 
 from rasa.engine.storage.storage import ModelStorage
@@ -359,10 +360,9 @@ class GraphNode:
         self._constructor_fn: Callable = getattr(
             self._component_class, self._constructor_name
         )
-        self._component_config: Dict[Text, Any] = {
-            **self._component_class.get_default_config(),
-            **component_config,
-        }
+        self._component_config: Dict[Text, Any] = rasa.utils.common.override_defaults(
+            self._component_class.get_default_config(), component_config,
+        )
         self._fn_name: Text = fn_name
         self._fn: Callable = getattr(self._component_class, self._fn_name)
         self._inputs: Dict[Text, Text] = inputs

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -325,17 +325,16 @@ def override_defaults(
     Returns:
         updated config
     """
-    if defaults:
-        config = copy.deepcopy(defaults)
-    else:
-        config = {}
+    config = copy.deepcopy(defaults) if defaults else {}
 
-    if custom:
-        for key in custom.keys():
-            if isinstance(config.get(key), dict):
-                config[key].update(custom[key])
-            else:
-                config[key] = custom[key]
+    if not custom:
+        return config
+
+    for key in custom.keys():
+        if isinstance(config.get(key), dict):
+            config[key].update(custom[key])
+            continue
+        config[key] = custom[key]
 
     return config
 

--- a/rasa/utils/common.py
+++ b/rasa/utils/common.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import logging
 import os
 import shutil
@@ -308,6 +309,35 @@ def update_existing_keys(
         if k in updated:
             updated[k] = v
     return updated
+
+
+def override_defaults(
+    defaults: Optional[Dict[Text, Any]], custom: Optional[Dict[Text, Any]]
+) -> Dict[Text, Any]:
+    """Override default config with the given config.
+
+    We cannot use `dict.update` method because configs contain nested dicts.
+
+    Args:
+        defaults: default config
+        custom: user config containing new parameters
+
+    Returns:
+        updated config
+    """
+    if defaults:
+        config = copy.deepcopy(defaults)
+    else:
+        config = {}
+
+    if custom:
+        for key in custom.keys():
+            if isinstance(config.get(key), dict):
+                config[key].update(custom[key])
+            else:
+                config[key] = custom[key]
+
+    return config
 
 
 class RepeatedLogFilter(logging.Filter):

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import copy
 import numpy as np
 from typing import Optional, Text, Dict, Any, Union, List, Tuple, TYPE_CHECKING
 
@@ -296,35 +295,6 @@ def entity_label_to_tags(
         confidence_values[tag_spec.tag_name] = confidences
 
     return predicted_tags, confidence_values
-
-
-def override_defaults(
-    defaults: Optional[Dict[Text, Any]], custom: Optional[Dict[Text, Any]]
-) -> Dict[Text, Any]:
-    """Override default config with the given config.
-
-    We cannot use `dict.update` method because configs contain nested dicts.
-
-    Args:
-        defaults: default config
-        custom: user config containing new parameters
-
-    Returns:
-        updated config
-    """
-    if defaults:
-        config = copy.deepcopy(defaults)
-    else:
-        config = {}
-
-    if custom:
-        for key in custom.keys():
-            if isinstance(config.get(key), dict):
-                config[key].update(custom[key])
-            else:
-                config[key] = custom[key]
-
-    return config
 
 
 def create_data_generators(

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -316,7 +316,7 @@ async def test_train_persist_load_with_nested_dict_config(
     create_train_load_and_process_diet: Callable[..., Message],
     create_diet: Callable[..., DIETClassifier],
 ):
-    config = {HIDDEN_LAYERS_SIZES: {"text": [256, 512]}}
+    config = {HIDDEN_LAYERS_SIZES: {"text": [256, 512]}, ENTITY_RECOGNITION: False}
     create_train_load_and_process_diet(config)
     create_diet(config, load=True, finetune=True)
 

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -136,3 +136,13 @@ def test_find_unavailable_packages():
 )
 def test_module_path_from_class(clazz: Type, module_path: Text):
     assert rasa.utils.common.module_path_from_class(clazz) == module_path
+
+
+def test_override_defaults():
+    defaults = {"nested-dict": {"key1": "value1", "key2": "value2"}}
+    custom = {"nested-dict": {"key2": "override-value2"}}
+
+    updated_config = rasa.utils.common.override_defaults(defaults, custom)
+
+    expected_config = {"nested-dict": {"key1": "value1", "key2": "override-value2"}}
+    assert updated_config == expected_config


### PR DESCRIPTION
Fixes #10391 

The error reported in the above ticket seemingly comes from the default configuration being overridden without taking care of nested dictionaries. This as far as I can tell happens in the `GraphNode` implementation in `rasa/engine/graph.py`, where the default and custom configs of a component get merged via [dictionary unpacking](https://github.com/RasaHQ/rasa/blob/3.0.x/rasa/engine/graph.py#L362). Since by definition of the dictionary creation via unpacking, the [last value for a given key wins](https://stackoverflow.com/a/39678945/17496163), this will not keep the unspecified keys of the nested dict in the default config.

**Proposed changes**:
- In Rasa 2.x, default and custom config parameters were combined using the function [override_defaults](https://github.com/RasaHQ/rasa/blob/2.8.x/rasa/utils/train_utils.py#L379) that keeps the entries in the default config nested dictionary if their keys are not specified in the custom config. A possible solution would therefore be to use a similar function in the initialization of `GraphNode` to merge default and custom configs.
- However, a potential issue w.r.t. to testing the solution is that components are initialized as a `GraphNode` via [from_schema_node](https://github.com/RasaHQ/rasa/blob/3.0.x/rasa/engine/graph.py#L522) when they are run in the engine, but unit tested by calling the component's `create` function directly, e.g. [here](https://github.com/RasaHQ/rasa/blob/3.0.x/tests/nlu/classifiers/test_diet_classifier.py#L75). The unit tests use the same dictionary unpacking as the graph node initialization and therefore this currently leads to the same error. However, a fix in `graph.py` does not have any effect on the unit tests of the individual components.
- The current state of the code is such that a fix is implemented for `GraphNode` and tested generically in `/tests/engine/test_graph_node.py`, as well as a unit test for `DIETClassifier` with the observed setting that failed from the bug report, which needs the same fix in the unit tests fixture.
- The output of the unit tests before the fix got added can be seen [here](https://github.com/RasaHQ/rasa/runs/4366488870?check_suite_focus=true#step:16:109) for `GraphNode` and [here](https://github.com/RasaHQ/rasa/runs/4366489403?check_suite_focus=true#step:16:131) for `DIETClassifier`. NOTE: They are from the previous PR that has been closed since it branched off from `main` rather than `3.0.x`, but the changes were taken over into this PR.

**Open questions**
- Due to the second bullet point described above, it seems that the components unit tests do not fully reproduce how the components are run in the graph engine, at least w.r.t. initializing the components and consuming the custom config. Is this a general issue that needs to be looked at further?

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
