### PR TITLE
Make action metadata available in tracker in 2.8.x

### DIFF
--- a/changelog/10458.bugfix.md
+++ b/changelog/10458.bugfix.md
@@ -1,0 +1,1 @@
+Make `action_metadata` json serializable and make it available on the tracker. This is a backport of a fix in 3.0.0.

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -655,7 +655,7 @@ class SimplePolicyEnsemble(PolicyEnsemble):
             is_no_user_prediction=best_prediction.is_no_user_prediction,
             diagnostic_data=best_prediction.diagnostic_data,
             hide_rule_turn=best_prediction.hide_rule_turn,
-            action_metadata=best_prediction.action_metadata
+            action_metadata=best_prediction.action_metadata,
         )
 
     def _best_policy_prediction(

--- a/rasa/core/policies/ensemble.py
+++ b/rasa/core/policies/ensemble.py
@@ -655,6 +655,7 @@ class SimplePolicyEnsemble(PolicyEnsemble):
             is_no_user_prediction=best_prediction.is_no_user_prediction,
             diagnostic_data=best_prediction.diagnostic_data,
             hide_rule_turn=best_prediction.hide_rule_turn,
+            action_metadata=best_prediction.action_metadata
         )
 
     def _best_policy_prediction(

--- a/rasa/core/policies/unexpected_intent_policy.py
+++ b/rasa/core/policies/unexpected_intent_policy.py
@@ -488,11 +488,11 @@ class UnexpecTEDIntentPolicy(TEDPolicy):
         def _compile_metadata_for_label(
             label_name: Text, similarity_score: float, threshold: Optional[float],
         ) -> "RankingCandidateMetadata":
-            severity = threshold - similarity_score if threshold else None
+            severity = float(threshold - similarity_score) if threshold else None
             return {
                 NAME: label_name,
-                SCORE_KEY: similarity_score,
-                THRESHOLD_KEY: threshold,
+                SCORE_KEY: float(similarity_score),
+                THRESHOLD_KEY: float(threshold) if threshold else None,
                 SEVERITY_KEY: severity,
             }
 

--- a/tests/core/policies/test_unexpected_intent_policy.py
+++ b/tests/core/policies/test_unexpected_intent_policy.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Optional, List, Dict, Text, Type
 import tensorflow as tf
@@ -489,9 +490,9 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         self,
         trained_policy: UnexpecTEDIntentPolicy,
         default_domain: Domain,
-        predicted_similarity,
-        threshold_value,
-        is_unlikely,
+        predicted_similarity: float,
+        threshold_value: float,
+        is_unlikely: bool,
         monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ):
@@ -538,6 +539,8 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
             # of the metadata is tested separately and
             # not as part of this test.
             assert prediction.action_metadata is not None
+            # Assert metadata is serializable
+            assert json.dumps(prediction.action_metadata)
 
     @pytest.mark.parametrize(
         "tracker_events, should_skip",


### PR DESCRIPTION
**Proposed changes**:
- Port the fix that makes action metadata available in the tracker to 2.8.x

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
