### PR TITLE
Don't merge 2.8.x into main

### DIFF
--- a/.github/workflows/automatic-release-to-main-merger.yml
+++ b/.github/workflows/automatic-release-to-main-merger.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
     - '[0-9]+.[0-9]+.x'
+    # Don't merge 2.8.x into main
+    - '!2.8.x'
 
     types:
     # means that the PR is closed, we still have to check if it was merged


### PR DESCRIPTION
**Proposed changes**:
- Disable the `release-to-main-merger` workflow on `2.8.x` branch

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
