### PR TITLE
remove double links from changelog

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -18,13 +18,12 @@ https://github.com/RasaHQ/rasa/tree/main/changelog/ . -->
 
 ## [2.8.15] - 2021-11-25
 ### Bugfixes
-- [#10381](https://github.com/rasahq/rasa/issues/10381): [#10381](https://github.com/RasaHQ/rasa/issues/10381): Validate regular
-  expressions in nlu training data configuration.
+- [#10381](https://github.com/rasahq/rasa/issues/10381): Validate regular expressions in nlu training data configuration.
 
 ## [2.8.14] - 2021-11-18
 ### Bugfixes
-- [#10241](https://github.com/rasahq/rasa/issues/10241): [#10241](https://github.com/RasaHQ/rasa/issues/10241): Bump TensorFlow version to 2.6.2.
-- [#10257](https://github.com/rasahq/rasa/issues/10257): [#10257](https://github.com/RasaHQ/rasa/issues/10257): Downgrade google-auth to <2.
+- [#10241](https://github.com/rasahq/rasa/issues/10241): Bump TensorFlow version to 2.6.2.
+- [#10257](https://github.com/rasahq/rasa/issues/10257): Downgrade google-auth to <2.
 
 
 ## [2.8.13] - 2021-11-11


### PR DESCRIPTION
Some recent changelog entries were added incorrectly. This change removes the link duplication.