### PR TITLE
Fix warning to display actual configuration values

### DIFF
--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -441,7 +441,8 @@ def _check_evaluation_setting(component_config: Dict[Text, Any]) -> None:
         and component_config[EVAL_NUM_EPOCHS] > component_config[EPOCHS]
     ):
         warning = (
-            f"the value of '{EVAL_NUM_EPOCHS}' is greater than the value of '{EPOCHS}'."
+            f"'{EVAL_NUM_EPOCHS}={component_config[EVAL_NUM_EPOCHS]}' is "
+            f"greater than '{EPOCHS}={component_config[EPOCHS]}'."
             f" No evaluation will occur."
         )
         if component_config[CHECKPOINT_MODEL]:

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -293,8 +293,9 @@ def test_warning_eval_num_epochs_greater_than_epochs(
     component_config: Dict[Text, Text]
 ):
     warning = (
-        f"the value of '{EVAL_NUM_EPOCHS}' is greater than the value of "
-        f"'{EPOCHS}'. No evaluation will occur."
+        f"'{EVAL_NUM_EPOCHS}={component_config[EVAL_NUM_EPOCHS]}' is "
+        f"greater than '{EPOCHS}={component_config[EPOCHS]}'."
+        f" No evaluation will occur."
     )
     with pytest.warns(UserWarning) as record:
         train_utils._check_evaluation_setting(component_config)


### PR DESCRIPTION
**Proposed changes**:
- Duplicate of https://github.com/RasaHQ/rasa/pull/8944
- Adds the actual values of the configuration to the warning message to make the warning more helpful.

(The community member didn't respond for a long time, so this PR just completes their work, sadly I can't do it in their PR itself.)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
