### PR TITLE
add deprecation warning to `/execute` endpoint

### DIFF
--- a/changelog/10507.misc.md
+++ b/changelog/10507.misc.md
@@ -1,0 +1,1 @@
+Add deprecation warning for the cli to the POST `/conversations/<conversation_id:path>/execute` endpoint.

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -840,8 +840,8 @@ def create_app(
     async def execute_action(request: Request, conversation_id: Text) -> HTTPResponse:
         rasa.shared.utils.io.raise_warning(
             'The "POST /conversations/<conversation_id>/execute"'
-            ' endpoint is deprecated. Inserting actions to the tracker externally'
-            ' should be avoided. Actions should be predicted by the policies only.',
+            " endpoint is deprecated. Inserting actions to the tracker externally"
+            " should be avoided. Actions should be predicted by the policies only.",
             category=FutureWarning,
         )
         request_params = request.json

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -838,6 +838,12 @@ def create_app(
     @ensure_loaded_agent(app)
     @ensure_conversation_exists()
     async def execute_action(request: Request, conversation_id: Text) -> HTTPResponse:
+        rasa.shared.utils.io.raise_warning(
+            'The "POST /conversations/<conversation_id>/execute"'
+            ' endpoint is deprecated. Inserting actions to the tracker externally'
+            ' should be avoided. Actions should be predicted by the policies only.',
+            category=FutureWarning,
+        )
         request_params = request.json
 
         action_to_execute = request_params.get("name", None)


### PR DESCRIPTION
closes #10507

**Proposed changes**:
Add deprecation warning to POST `/conversations/<conversation_id:path>/execute` endpoint

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
