### PR TITLE
Bugfix 10448 cross validation lookup tables

### DIFF
--- a/changelog/10448.bugfix.md
+++ b/changelog/10448.bugfix.md
@@ -1,0 +1,3 @@
+Copy lookup tables to train and test folds in cross validation. Before, the generated folds did not have a copy of
+the lookup tables from the original NLU data, so that `RegexEntityExtractor` could not recognize any entities during 
+the evaluation.

--- a/data/test/demo-rasa-lookup-ents.yml
+++ b/data/test/demo-rasa-lookup-ents.yml
@@ -1,0 +1,27 @@
+version: "3.0"
+nlu:
+- intent: affirm
+  examples: |
+    - yes
+    - yep
+    - yeah
+    - indeed
+    - that's right
+    - ok
+    - great
+    - right, thank you
+    - correct
+    - great choice
+    - sounds really good
+- intent: buy_groceries
+  examples: |
+    - I'd like to buy some [milk](product)
+    - One pack of [butter](product) please
+    - A loaf of [bread](product)
+    - I want to make some [pasta](product) tonight
+- lookup: product
+  examples: |
+    - milk
+    - bread
+    - butter
+    - pasta

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -1461,12 +1461,14 @@ def generate_folds(
                 training_examples=train,
                 entity_synonyms=training_data.entity_synonyms,
                 regex_features=training_data.regex_features,
+                lookup_tables=training_data.lookup_tables,
                 responses=training_data.responses,
             ),
             TrainingData(
                 training_examples=test,
                 entity_synonyms=training_data.entity_synonyms,
                 regex_features=training_data.regex_features,
+                lookup_tables=training_data.lookup_tables,
                 responses=training_data.responses,
             ),
         )

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -594,7 +594,7 @@ async def test_run_cv_evaluation_with_response_selector():
 )  # these can take a longer time than the default timeout
 async def test_run_cv_evaluation_lookup_tables():
     td = rasa.shared.nlu.training_data.loading.load_data(
-        "../../data/test/demo-rasa-lookup-ents.yml"
+        "data/test/demo-rasa-lookup-ents.yml"
     )
 
     nlu_config = {

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -72,7 +72,7 @@ from rasa.shared.nlu.constants import (
 from rasa.shared.nlu.training_data.message import Message
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.model_testing import compare_nlu_models
-from rasa.utils.tensorflow.constants import EPOCHS
+from rasa.utils.tensorflow.constants import EPOCHS, ENTITY_RECOGNITION
 
 # https://github.com/pytest-dev/pytest-asyncio/issues/68
 # this event_loop is used by pytest-asyncio, and redefining it
@@ -587,6 +587,49 @@ async def test_run_cv_evaluation_with_response_selector():
     assert len(entity_results.test[diet_name]["F1-score"]) == n_folds
     for extractor_evaluation in entity_results.evaluation.values():
         assert all(key in extractor_evaluation for key in ["errors", "report"])
+
+
+@pytest.mark.timeout(
+    280, func_only=True
+)  # these can take a longer time than the default timeout
+async def test_run_cv_evaluation_lookup_tables():
+    td = rasa.shared.nlu.training_data.loading.load_data(
+        "../../data/test/demo-rasa-lookup-ents.yml"
+    )
+
+    nlu_config = {
+        "language": "en",
+        "pipeline": [
+            {"name": "WhitespaceTokenizer"},
+            {"name": "CountVectorsFeaturizer"},
+            {"name": "DIETClassifier", EPOCHS: 1, ENTITY_RECOGNITION: False},
+            {"name": "RegexEntityExtractor", "use_lookup_tables": True},
+        ],
+    }
+
+    n_folds = 2
+    intent_results, entity_results, response_selection_results = await cross_validate(
+        td,
+        n_folds,
+        nlu_config,
+        successes=False,
+        errors=False,
+        disable_plotting=True,
+        report_as_dict=True,
+    )
+
+    regex_extractor_name = "RegexEntityExtractor"
+    assert regex_extractor_name in entity_results.test
+
+    assert len(entity_results.test[regex_extractor_name]["Accuracy"]) == n_folds
+    assert len(entity_results.test[regex_extractor_name]["Precision"]) == n_folds
+    assert len(entity_results.test[regex_extractor_name]["F1-score"]) == n_folds
+
+    # All entities in the test set appear in the lookup table, so should get perfect scores
+    for fold in range(n_folds):
+        assert entity_results.test[regex_extractor_name]["Accuracy"][fold] == 1.0
+        assert entity_results.test[regex_extractor_name]["Precision"][fold] == 1.0
+        assert entity_results.test[regex_extractor_name]["F1-score"][fold] == 1.0
 
 
 def test_intent_evaluation_report(tmp_path: Path):

--- a/tests/nlu/test_evaluation.py
+++ b/tests/nlu/test_evaluation.py
@@ -625,7 +625,8 @@ async def test_run_cv_evaluation_lookup_tables():
     assert len(entity_results.test[regex_extractor_name]["Precision"]) == n_folds
     assert len(entity_results.test[regex_extractor_name]["F1-score"]) == n_folds
 
-    # All entities in the test set appear in the lookup table, so should get perfect scores
+    # All entities in the test set appear in the lookup table,
+    # so should get perfect scores
     for fold in range(n_folds):
         assert entity_results.test[regex_extractor_name]["Accuracy"][fold] == 1.0
         assert entity_results.test[regex_extractor_name]["Precision"][fold] == 1.0


### PR DESCRIPTION
Fixes #10448 

Since the lookup tables that are defined in the NLU training data, did not get copied to the `TrainingData` folds that are created by [generate_folds](https://github.com/RasaHQ/rasa/blob/3.0.x/rasa/nlu/test.py#L1442) for cross validation, the entities predicted by `RegexEntityExtractor` remained empty. Adding the `lookup_tables` parameter solves the issue and all expected entities in the lookup table are recognized.

**Proposed changes**:
- Add `lookup_tables` parameter to training data folds in `generate_folds` function.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
