### PR TITLE
Fix on-schedule regression tests

### DIFF
--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -472,8 +472,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - deploy_runner_gpu
       - model_regression_test_gpu
+      - combine_reports
     env:
       GITHUB_ISSUE_TITLE: 'Scheduled Model Regression Test Performance Drops'
 


### PR DESCRIPTION
**Bug**: Last weekend the on-schedule regression tests failed, see https://github.com/RasaHQ/rasa/actions/runs/1599710132, because `report.json` didn't exist when the `analyse_performance` job would be looking

**Proposed changes**:
- Make `analyse_performance` job wait for `combine_reports` job to finish to find `report.json`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
