### PR TITLE
Add a command-line option to specify domain for `rasa test`

### DIFF
--- a/changelog/10518.feature.md
+++ b/changelog/10518.feature.md
@@ -1,1 +1,1 @@
-Add an command-line option to specify domain file or a directory (`--domain`) for `rasa test` and `rasa test nlu`.
+Add a command-line option to specify domain file or a directory (`--domain`) for `rasa test` and `rasa test nlu`.

--- a/changelog/10518.feature.md
+++ b/changelog/10518.feature.md
@@ -1,0 +1,1 @@
+Add an command-line option to specify domain file or a directory (`--domain`) for `rasa test` and `rasa test nlu`.

--- a/changelog/10518.feature.md
+++ b/changelog/10518.feature.md
@@ -1,1 +1,1 @@
-Add a command-line option to specify domain file or a directory (`--domain`) for `rasa test` and `rasa test nlu`.
+Add a command-line option to specify domain file or a directory (`--domain` or `-d`) for `rasa test` and `rasa test nlu`.

--- a/rasa/cli/arguments/test.py
+++ b/rasa/cli/arguments/test.py
@@ -9,6 +9,7 @@ from rasa.cli.arguments.default_arguments import (
     add_nlu_data_param,
     add_endpoint_param,
     add_out_param,
+    add_domain_param,
 )
 from rasa.model import get_latest_model
 
@@ -113,7 +114,7 @@ def add_test_nlu_argument_group(
         "multiple configs or a folder of configs are passed, models "
         "will be trained and compared directly.",
     )
-
+    add_domain_param(parser)
     cross_validation_arguments = parser.add_argument_group("Cross Validation")
     cross_validation_arguments.add_argument(
         "--cross-validation",

--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -21,7 +21,6 @@ from rasa.shared.constants import (
     DEFAULT_MODELS_PATH,
     DEFAULT_DATA_PATH,
     DEFAULT_RESULTS_PATH,
-    DEFAULT_DOMAIN_PATH,
 )
 import rasa.shared.utils.validation as validation_utils
 import rasa.cli.utils
@@ -155,6 +154,7 @@ async def run_nlu_test_async(
     percentages: List[int],
     runs: int,
     no_errors: bool,
+    domain_path: Text,
     all_args: Dict[Text, Any],
 ) -> None:
     """Runs NLU tests.
@@ -173,6 +173,8 @@ async def run_nlu_test_async(
         runs: number of comparison runs to make.
         no_errors: indicates if incorrect predictions should be written to a file
                    or not.
+        domain_path: path to a domain file or a directory containing domain
+                     specifications.
     """
     from rasa.model_testing import (
         compare_nlu_models,
@@ -182,7 +184,7 @@ async def run_nlu_test_async(
 
     data_path = rasa.cli.utils.get_validated_path(data_path, "nlu", DEFAULT_DATA_PATH)
     test_data_importer = TrainingDataImporter.load_from_dict(
-        training_data_paths=[data_path], domain_path=DEFAULT_DOMAIN_PATH,
+        training_data_paths=[data_path], domain_path=domain_path,
     )
     nlu_data = await test_data_importer.get_nlu_data()
 
@@ -249,6 +251,7 @@ def run_nlu_test(args: argparse.Namespace) -> None:
             args.percentages,
             args.runs,
             args.no_errors,
+            args.domain,
             vars(args),
         )
     )

--- a/tests/cli/test_rasa_test.py
+++ b/tests/cli/test_rasa_test.py
@@ -234,9 +234,10 @@ def test_test_help(run: Callable[..., RunResult]):
                  [--max-stories MAX_STORIES] [--endpoints ENDPOINTS]
                  [--fail-on-prediction-errors] [--url URL]
                  [--evaluate-model-directory] [-u NLU]
-                 [-c CONFIG [CONFIG ...]] [--cross-validation] [-f FOLDS]
-                 [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]] [--no-plot]
-                 [--successes] [--no-errors] [--no-warnings] [--out OUT]
+                 [-c CONFIG [CONFIG ...]] [-d DOMAIN] [--cross-validation]
+                 [-f FOLDS] [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]]
+                 [--no-plot] [--successes] [--no-errors] [--no-warnings]
+                 [--out OUT]
                  {core,nlu} ..."""
 
     lines = help_text.split("\n")
@@ -250,9 +251,9 @@ def test_test_nlu_help(run: Callable[..., RunResult]):
     output = run("test", "nlu", "--help")
 
     help_text = """usage: rasa test nlu [-h] [-v] [-vv] [--quiet] [-m MODEL] [-u NLU] [--out OUT]
-                     [-c CONFIG [CONFIG ...]] [--cross-validation] [-f FOLDS]
-                     [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]] [--no-plot]
-                     [--successes] [--no-errors] [--no-warnings]"""
+                     [-c CONFIG [CONFIG ...]] [-d DOMAIN] [--cross-validation]
+                     [-f FOLDS] [-r RUNS] [-p PERCENTAGES [PERCENTAGES ...]]
+                     [--no-plot] [--successes] [--no-errors] [--no-warnings]"""
 
     lines = help_text.split("\n")
     # expected help text lines should appear somewhere in the output


### PR DESCRIPTION
**Proposed changes**:
- Adds a command-line option to specify domain file or a directory (`--domain` or `-d`) for `rasa test` and `rasa test nlu`.
- Fixes  #10518 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
