### PR TITLE
Clarify limitations of LanguageModelFeaturizer in docs

### DIFF
--- a/changelog/10385.misc.md
+++ b/changelog/10385.misc.md
@@ -1,1 +1,1 @@
-Improve documentation of `LanguageModelFeaturizer` to clarify which HuffingFace models can be loaded.
+Improve documentation of `LanguageModelFeaturizer` to clarify which HuggingFace models can be loaded.

--- a/changelog/10385.misc.md
+++ b/changelog/10385.misc.md
@@ -1,0 +1,1 @@
+Improve documentation of `LanguageModelFeaturizer` to clarify which HuffingFace models can be loaded.

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -555,13 +555,6 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
   currently supported language models. The weights to be loaded can be specified by the additional parameter
   `model_weights`. If left empty, it uses the default model weights listed in the table.
 
-  Apart from the default pretrained model weights, further models can be used from
-  [HuggingFace models](https://huggingface.co/models) provided the following conditions are met:
-
-  * The model architecture is one of the supported language models
-  * The model has pretrained Tensorflow weights (check for `tf_model.h5` in the "Files and versions" section)
-  * The model uses the default tokenizer (e.g. `TFBertModel` must use `BertTokenizer`)
-
   ```
   +----------------+--------------+-------------------------+
   | Language Model | Parameter    | Default value for       |
@@ -581,7 +574,25 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
   +----------------+--------------+-------------------------+
   ```
 
-  The following configuration loads the language model BERT:
+  Apart from the default pretrained model weights, further models can be used from
+  [HuggingFace models](https://huggingface.co/models) provided the following conditions are met (the mentioned
+  files can be found in the "Files and versions" section of the model website):
+
+  * The model architecture is one of the supported language models (check that the `model_type` in `config.json` is
+    listed in the table's column `model_name`)
+  * The model has pretrained Tensorflow weights (check that the file `tf_model.h5` exists)
+  * The model uses the default tokenizer (`config.json` should not contain a custom `tokenizer_class` setting)
+
+  :::note
+  The `LaBSE` weights that are loaded as default for the `bert` architecture provide a multi-lingual model trained on
+  112 languages (see the original paper [here](https://arxiv.org/pdf/2007.01852.pdf)). We strongly encourage using this
+  as a baseline and testing your bot end-to-end before trying to optimize this component with other
+  weights/architectures.
+  :::
+
+
+  The following configuration loads the language model BERT with `rasa/LaBSE` weights, which can be found
+  [here](https://huggingface.co/rasa/LaBSE/tree/main):
 
   ```yaml-rasa
   pipeline:

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -585,9 +585,9 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
 
   :::note
   The `LaBSE` weights that are loaded as default for the `bert` architecture provide a multi-lingual model trained on
-  112 languages (see the original paper [here](https://arxiv.org/pdf/2007.01852.pdf)). We strongly encourage using this
-  as a baseline and testing your bot end-to-end before trying to optimize this component with other
-  weights/architectures.
+  112 languages (see our [tutorial](https://www.youtube.com/watch?v=7tAWk_Coj-s) and the original
+  [paper](https://arxiv.org/pdf/2007.01852.pdf)). We strongly encourage using this as a baseline and testing your bot
+  end-to-end before trying to optimize this component with other weights/architectures.
   :::
 
 

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -552,12 +552,15 @@ Note: The `feature-dimension` for sequence and sentence features does not have t
   Include a [Tokenizer](./components.mdx#tokenizers) component before this component.
 
   You should specify what language model to load via the parameter `model_name`. See the below table for the
-  available language models.
-  Additionally, you can also specify the architecture variation of the chosen language model by specifying the
-  parameter `model_weights`.
-  The full list of supported architectures can be found in the
-  [HuggingFace documentation](https://huggingface.co/transformers/pretrained_models.html).
-  If left empty, it uses the default model architecture that original Transformers library loads (see table below).
+  currently supported language models. The weights to be loaded can be specified by the additional parameter
+  `model_weights`. If left empty, it uses the default model weights listed in the table.
+
+  Apart from the default pretrained model weights, further models can be used from
+  [HuggingFace models](https://huggingface.co/models) provided the following conditions are met:
+
+  * The model architecture is one of the supported language models
+  * The model has pretrained Tensorflow weights (check for `tf_model.h5` in the "Files and versions" section)
+  * The model uses the default tokenizer (e.g. `TFBertModel` must use `BertTokenizer`)
 
   ```
   +----------------+--------------+-------------------------+


### PR DESCRIPTION
This docs update aims to clarify some details around which HuggingFace models can be used with `LanguageModelFeaturizer`. Despite the supported architectures being listed in our docs, users often try others and report errors in the forum. Furthermore, not all pretrained weights from the HF models hub for the supported architectures can be used (e.g. due to missing TF weights or non-standard tokenizers being used), which results in error messages that are hard to interpret.

A related ticket with links to forum issues can be found here [here](https://github.com/RasaHQ/rasa/issues/10385).

**Proposed changes**:
- Clarify the limitations of the current implementation of `LanguageModelFeaturizer` w.r.t. model architectures and weights from HuggingFace

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
