### PR TITLE
Only add rasa_environment header to kafka message if it is set

### DIFF
--- a/changelog/10634.bugfix.md
+++ b/changelog/10634.bugfix.md
@@ -1,0 +1,1 @@
+Add `RASA_ENVIRONMENT` header in Kafka only if the environmental variable is set.

--- a/rasa/core/brokers/kafka.py
+++ b/rasa/core/brokers/kafka.py
@@ -192,12 +192,14 @@ class KafkaEventBroker(EventBroker):
         else:
             partition_key = None
 
-        headers = [
-            (
-                "RASA_ENVIRONMENT",
-                bytes(self.rasa_environment, encoding=DEFAULT_ENCODING),
-            )
-        ]
+        headers = []
+        if self.rasa_environment:
+            headers = [
+                (
+                    "RASA_ENVIRONMENT",
+                    bytes(self.rasa_environment, encoding=DEFAULT_ENCODING),
+                )
+            ]
 
         logger.debug(
             f"Calling kafka send({self.topic}, value={event},"


### PR DESCRIPTION
**Proposed changes**:
- Only add `RASA_ENVIRONMENT` header if the env var is set
- Resolves problem [here](https://github.com/RasaHQ/rasa/pull/10614#discussion_r777035191)

**Status (please check what you already did)**:
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
