### PR TITLE
update error message for cli regex parse error

### DIFF
--- a/rasa/shared/constants.py
+++ b/rasa/shared/constants.py
@@ -1,7 +1,7 @@
 DOCS_BASE_URL = "https://rasa.com/docs/rasa"
 LEGACY_DOCS_BASE_URL = "https://legacy-docs-v1.rasa.com"
 DOCS_URL_TRAINING_DATA = DOCS_BASE_URL + "/training-data-format"
-DOCS_URL_TRAINING_DATA_NLU = DOCS_URL_TRAINING_DATA + "#nlu-training-data"
+DOCS_URL_TRAINING_DATA_NLU = DOCS_BASE_URL + "/nlu-training-data"
 DOCS_URL_DOMAINS = DOCS_BASE_URL + "/domain"
 DOCS_URL_SLOTS = DOCS_URL_DOMAINS + "#slots"
 DOCS_URL_INTENTS = DOCS_URL_DOMAINS + "#intents"

--- a/rasa/shared/nlu/interpreter.py
+++ b/rasa/shared/nlu/interpreter.py
@@ -6,7 +6,7 @@ from typing import Text, Optional, Dict, Any, Union, List, Tuple
 
 import rasa.shared
 from rasa.shared.core.trackers import DialogueStateTracker
-from rasa.shared.constants import INTENT_MESSAGE_PREFIX, DOCS_URL_STORIES
+from rasa.shared.constants import INTENT_MESSAGE_PREFIX
 from rasa.shared.nlu.constants import INTENT_NAME_KEY
 from rasa.shared.nlu.training_data.message import Message
 
@@ -74,11 +74,10 @@ class RegexInterpreter(NaturalLanguageInterpreter):
         except (JSONDecodeError, ValueError) as e:
             rasa.shared.utils.io.raise_warning(
                 f"Failed to parse arguments in line "
-                f"'{user_input}'. Failed to decode parameters "
-                f"as a json object. Make sure the intent "
-                f"is followed by a proper json object. "
+                f"'{user_input}'. Failed to decode parameters. "
+                f"Make sure your regex message is in the format:"
+                f"\<intent_name>@<confidence-value><dictionary of entities> "
                 f"Error: {e}",
-                docs=DOCS_URL_STORIES,
             )
             return []
 
@@ -95,7 +94,6 @@ class RegexInterpreter(NaturalLanguageInterpreter):
                 f"'{confidence_str}'. Make sure the intent confidence is an "
                 f"@ followed by a decimal number. "
                 f"Error: {e}",
-                docs=DOCS_URL_STORIES,
             )
             return 0.0
 

--- a/rasa/shared/nlu/interpreter.py
+++ b/rasa/shared/nlu/interpreter.py
@@ -76,7 +76,7 @@ class RegexInterpreter(NaturalLanguageInterpreter):
                 f"Failed to parse arguments in line "
                 f"'{user_input}'. Failed to decode parameters. "
                 f"Make sure your regex message is in the format:"
-                f"\<intent_name>@<confidence-value><dictionary of entities> "
+                f"\<intent_name>@<confidence-value><dictionary of entities>"  # noqa:  W505, W605, E501
                 f"Error: {e}",
             )
             return []


### PR DESCRIPTION
**Proposed changes**:
partially closes #9619 
- This is a small change that updates the error message returned when a regex message is used within `rasa shell` and `rasa interactive`. 
- This change is for `2.8.x`, a separate PR for `main` will be raised.


