### PR TITLE
update message for regexp parsing error

### DIFF
--- a/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
+++ b/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
@@ -646,8 +646,9 @@ class YAMLStoryReader(StoryReader):
             rasa.shared.utils.io.raise_warning(
                 f"Failed to parse arguments in line '{match.string}'. "
                 f"Failed to interpret some parts. "
+                f"Make sure your regex string is in the following format:"
+                f"\<intent_name>@<confidence-value><dictionary of entities> "
                 f"Continuing without {match.group('rest')}. ",
-                docs=DOCS_URL_STORIES,
             )
 
         # Add the results to the message.

--- a/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
+++ b/rasa/shared/core/training_data/story_reader/yaml_story_reader.py
@@ -647,7 +647,7 @@ class YAMLStoryReader(StoryReader):
                 f"Failed to parse arguments in line '{match.string}'. "
                 f"Failed to interpret some parts. "
                 f"Make sure your regex string is in the following format:"
-                f"\<intent_name>@<confidence-value><dictionary of entities> "
+                f"\<intent_name>@<confidence-value><dictionary of entities> "  # noqa:  W505, W605, E501
                 f"Continuing without {match.group('rest')}. ",
             )
 


### PR DESCRIPTION
**Proposed changes**:
partially closes #9619

This is a small change that updates the error message returned when a regex message is used within rasa shell and rasa interactive.
This change is for `main`, a separate PR for `2.8.x` has been raised.