### PR TITLE
Update stale bot configuration to also cover PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,26 +1,39 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - "type:enhancement ✨"
-  - "type:enhancement :sparkles:"
-  - "type:discussion 👨‍👧‍👦"
-  - "type:discussion :family_man_girl_boy:"
-  - "type:docs 📖"
-  - "type:docs :book:"
 # Label to use when marking an issue as stale
 staleLabel: stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: >
-  This issue has been automatically closed due to inactivity. Please create
-  a new issue if you need more help.
 
-# limit to only issues
-only: issues
+issues:
+  # Number of days of inactivity before a stale issue is closed
+  daysUntilClose: 7
+  # Issues with these labels will never be considered stale
+  exemptLabels:
+    - "type:enhancement ✨"
+    - "type:enhancement :sparkles:"
+    - "type:discussion 👨‍👧‍👦"
+    - "type:discussion :family_man_girl_boy:"
+    - "type:docs 📖"
+    - "type:docs :book:"
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This issue has been automatically closed due to inactivity. Please create
+    a new issue if you need more help.
+
+pulls:
+  # Give more time before closing PRs
+  daysUntilClose: 21
+  # Comment to post when marking a PR as stale. Set to `false` to disable
+  markComment: >
+    This PR has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  # Comment to post when closing a stale PR. Set to `false` to disable
+  closeComment: >
+    This PR has been automatically closed due to inactivity. Please reopen
+    this PR or a new one if you plan to follow-up on it. Thank you for your
+    contributions.


### PR DESCRIPTION
**Proposed changes**:
- Addresses one discussion point from https://github.com/RasaHQ/enable_squad/issues/76
- Mark PRs as stale if they didn't receive activity in the past 90 days
- Close stale PRs 21 days after they're marked as stale

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
