### PR TITLE
Replaced dead link in ci-model-regression

### DIFF
--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -1,4 +1,4 @@
-# The docs: https://www.notion.so/rasa/The-CI-for-model-regression-tests-92af7185e08e4fb2a0c764770a8e9095
+# The docs: https://www.notion.so/rasa/The-CI-for-model-regression-tests-aa579d5524a544af992f97d132bcc2de
 name: CI - Model Regression
 
 on:


### PR DESCRIPTION
I think I found a dead link, so I figured I'd do the right thing and replace it. 