### PR TITLE
Sorting lookup elements on bases of length in descending order

### DIFF
--- a/rasa/nlu/extractors/regex_entity_extractor.py
+++ b/rasa/nlu/extractors/regex_entity_extractor.py
@@ -99,6 +99,9 @@ class RegexEntityExtractor(GraphComponent, EntityExtractorMixin):
         Args:
             training_data: the training data
         """
+        for lookup in training_data.lookup_tables:
+            lookup["elements"] = sorted(lookup["elements"], key=len, reverse=True)
+
         self.patterns = pattern_utils.extract_patterns(
             training_data,
             use_lookup_tables=self._config["use_lookup_tables"],


### PR DESCRIPTION
Sorting lookup elements on bases of length in descending order, so the larger value of lookup should be matched first. The generator matches the first value and return.

## Unsorted lookup

lookup:
- one
- twenty
- twenty one

**if input is "twenty one"**. it matched with **"one"** and **"twenty"**

## After storing in descending order
- twenty one
- one
- twenty

now if if input is "twenty one", it matched with **"twenty one"**
