### PR TITLE
Regression Test Failure Comment

### DIFF
--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -706,7 +706,7 @@ jobs:
     needs:
       - model_regression_test_cpu
       - model_regression_test_gpu
-    if: always()
+    if: (needs.model_regression_test_cpu.result != 'skipped' || needs.model_regression_test_gpu.result != 'skipped') && always()
 
     steps:
       - name: Checkout git repository 🕝

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -231,10 +231,6 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
-          if [[ "${{ env.DATASET_NAME }}" == "helpdesk-assistant" ]]; then
-            exit 1
-          fi
-
           # determine extra environment variables
           # - CONFIG
           # - DATASET
@@ -477,10 +473,6 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
-          if [[ "${{ env.DATASET_NAME }}" == "helpdesk-assistant" ]]; then
-            exit 1
-          fi
-
           # determine extra environment variables
           # - CONFIG
           # - DATASET

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -673,33 +673,6 @@ jobs:
         run: |
           sudo service datadog-agent stop
 
-  set_job_success_status:
-    name: Set job success status
-    runs-on: ubuntu-latest
-    needs:
-      - model_regression_test_cpu
-      - model_regression_test_gpu
-    if: always()
-    steps:
-      - name: Set return code
-        run: |
-          set -x  # Debug
-          echo ${{ needs.model_regression_test_cpu.result == 'success' || needs.model_regression_test_gpu.result == 'success' }}
-          echo ${{ needs.model_regression_test_cpu.result == 'success'}}
-          echo ${{ needs.model_regression_test_gpu.result == 'success'}}
-
-          succeeded=${{ needs.model_regression_test_cpu.result == 'success' || needs.model_regression_test_gpu.result == 'success' }}
-          if [[ $succeeded == "false" ]]; then
-            echo "Status: Failed"
-            exit 1
-          elif [[ $succeeded == "true" ]]; then
-            echo "Status: Succeeded"
-            exit 0
-          else
-            echo "Status: Not sure what happened"
-            exit 2
-          fi
-
   combine_reports:
     name: Combine reports
     runs-on: ubuntu-latest
@@ -707,8 +680,25 @@ jobs:
       - model_regression_test_cpu
       - model_regression_test_gpu
     if: (needs.model_regression_test_cpu.result != 'skipped' || needs.model_regression_test_gpu.result != 'skipped') && always()
+    outputs:
+      success_status: ${{ steps.set-success-status.outputs.success_status }}
 
     steps:
+      - name: Set success status
+        id: set-success-status
+        run: |-
+          succeeded=${{ needs.model_regression_test_cpu.result == 'success' || needs.model_regression_test_gpu.result == 'success' }}
+          if [[ $succeeded == "false" ]]; then
+            success_status="Failed"
+          elif [[ $succeeded == "true" ]]; then
+            echo "Status: Succeeded"
+            success_status="Succeeded"
+          else
+            success_status="Not sure what happened"
+          fi
+          echo $success_status
+          echo "::set-output name=success_status::$success_status"
+
       - name: Checkout git repository 🕝
         uses: actions/checkout@v2
 
@@ -740,6 +730,28 @@ jobs:
         with:
           name: report.json
           path: ./report.json
+
+
+  set_job_success_status:
+    name: Set job success status
+    runs-on: ubuntu-latest
+    needs:
+      - combine_reports
+    if: always() && needs.combine_reports.result == 'success'
+    steps:
+      - name: Set return code
+        run: |
+          set -x  # Debug
+          success_status=${{ needs.combine_reports.outputs.success_status }}
+          echo "Status: $success_status"
+          if [[ $success_status == "Failed" ]]; then
+            echo "Status: Failed"
+            exit 1
+          elif [[ $success_status == "Succeeded" ]]; then
+            exit 0
+          else
+            exit 2
+          fi
 
   add_comment_results:
     name: Add a comment with the results
@@ -797,6 +809,7 @@ jobs:
           header: ${{ github.run_id }}
           append: true
           message: |-
+            Success status of the run: ${{ needs.combine_reports.outputs.success_status }}
 
             Commit: ${{ github.sha }}, [The full report is available as an artifact.](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -231,6 +231,10 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
+          if [[ "${{ env.DATASET_NAME }}" == "helpdesk-assistant" ]]; then
+            exit 1
+          fi
+
           # determine extra environment variables
           # - CONFIG
           # - DATASET
@@ -473,6 +477,10 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
+          if [[ "${{ env.DATASET_NAME }}" == "helpdesk-assistant" ]]; then
+            exit 1
+          fi
+
           # determine extra environment variables
           # - CONFIG
           # - DATASET

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -683,7 +683,7 @@ jobs:
     needs:
       - model_regression_test_cpu
       - model_regression_test_gpu
-    if: (needs.model_regression_test_cpu.result != 'skipped' || needs.model_regression_test_gpu.result != 'skipped') && always()
+    if: ((needs.model_regression_test_cpu.result != 'skipped') != (needs.model_regression_test_gpu.result != 'skipped')) && always()
     outputs:
       success_status: ${{ steps.set-success-status.outputs.success_status }}
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -695,10 +695,9 @@ jobs:
           if [[ $succeeded == "false" ]]; then
             success_status="Failed"
           elif [[ $succeeded == "true" ]]; then
-            echo "Status: Succeeded"
             success_status="Succeeded"
           else
-            success_status="Not sure what happened"
+            success_status="Unknown"
           fi
           echo $success_status
           echo "::set-output name=success_status::$success_status"
@@ -735,7 +734,6 @@ jobs:
           name: report.json
           path: ./report.json
 
-
   set_job_success_status:
     name: Set job success status
     runs-on: ubuntu-latest
@@ -745,16 +743,12 @@ jobs:
     steps:
       - name: Set return code
         run: |
-          set -x  # Debug
           success_status=${{ needs.combine_reports.outputs.success_status }}
           echo "Status: $success_status"
-          if [[ $success_status == "Failed" ]]; then
-            echo "Status: Failed"
-            exit 1
-          elif [[ $success_status == "Succeeded" ]]; then
+          if [[ $success_status == "Succeeded" ]]; then
             exit 0
           else
-            exit 2
+            exit 1
           fi
 
   add_comment_results:

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -231,8 +231,6 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
-          exit 1
-
           # determine extra environment variables
           # - CONFIG
           # - DATASET
@@ -475,8 +473,6 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
-          exit 1
-
           # determine extra environment variables
           # - CONFIG
           # - DATASET
@@ -809,7 +805,7 @@ jobs:
           header: ${{ github.run_id }}
           append: true
           message: |-
-            Success status of the run: ${{ needs.combine_reports.outputs.success_status }}
+            Status of the run: ${{ needs.combine_reports.outputs.success_status }}
 
             Commit: ${{ github.sha }}, [The full report is available as an artifact.](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -231,6 +231,8 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
+          exit 1
+
           # determine extra environment variables
           # - CONFIG
           # - DATASET
@@ -473,6 +475,8 @@ jobs:
           DATASET_NAME: "${{ matrix.dataset }}"
           CONFIG_NAME: "${{ matrix.config }}"
         run: |-
+          exit 1
+
           # determine extra environment variables
           # - CONFIG
           # - DATASET
@@ -669,13 +673,40 @@ jobs:
         run: |
           sudo service datadog-agent stop
 
+  set_job_success_status:
+    name: Set job success status
+    runs-on: ubuntu-latest
+    needs:
+      - model_regression_test_cpu
+      - model_regression_test_gpu
+    if: always()
+    steps:
+      - name: Set return code
+        run: |
+          set -x  # Debug
+          echo ${{ needs.model_regression_test_cpu.result == 'success' || needs.model_regression_test_gpu.result == 'success' }}
+          echo ${{ needs.model_regression_test_cpu.result == 'success'}}
+          echo ${{ needs.model_regression_test_gpu.result == 'success'}}
+
+          succeeded=${{ needs.model_regression_test_cpu.result == 'success' || needs.model_regression_test_gpu.result == 'success' }}
+          if [[ $succeeded == "false" ]]; then
+            echo "Status: Failed"
+            exit 1
+          elif [[ $succeeded == "true" ]]; then
+            echo "Status: Succeeded"
+            exit 0
+          else
+            echo "Status: Not sure what happened"
+            exit 2
+          fi
+
   combine_reports:
     name: Combine reports
     runs-on: ubuntu-latest
     needs:
       - model_regression_test_cpu
       - model_regression_test_gpu
-    if: always() && (needs.model_regression_test_cpu.result == 'success' || needs.model_regression_test_gpu.result == 'success')
+    if: always()
 
     steps:
       - name: Checkout git repository 🕝


### PR DESCRIPTION
**Motivation:** Since https://github.com/RasaHQ/rasa/pull/10574, summary comments after a MR test run are gone, if a job is failing

**Proposed changes**:
- Add comment also in case of (partial) failure (also send email in the same cases)
- GH labels (`status:model-regression-tests` and `runner: gpu`) are now removed in both cases: success and failure
- `result.json` artifact contains (only) results from those jobs that succeeded
- Implementation: Introduce `set_job_success_status` job to set the overall run status to failed if one of the jobs failed
- keep on-schedule as is (doesn't have comments)

**Checked:**
- [x] Case: only fail
- [x] Case: all succeed
- [x] Case: some fail
- [x] works for CPU and GPU

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
