### PR TITLE
DRY Regr Tests: Create reusable workflow

### DIFF
--- a/.github/workflows/ci-model-regression-test-helper.yml
+++ b/.github/workflows/ci-model-regression-test-helper.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
     secrets:
-      envPAT:
+      DD_API_KEY:
         required: true
 
 jobs:

--- a/.github/workflows/ci-model-regression-test-helper.yml
+++ b/.github/workflows/ci-model-regression-test-helper.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   reusable_workflow_job:
     runs-on: ubuntu-latest
-    environment: production  # remove
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-model-regression-test-helper.yml
+++ b/.github/workflows/ci-model-regression-test-helper.yml
@@ -3,11 +3,15 @@ name: MR Test Reusable workflow
 on:
   workflow_call:
     inputs:
-      username:
+      dataset_branch:
         required: true
         type: string
     secrets:
       DD_API_KEY:
+        required: true
+      ML_TEST_SA_PAT:
+        required: true
+      DATASET_REPOSITORY:
         required: true
 
 jobs:
@@ -18,15 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Print
-        run: |-
-          set -x
-          echo ${{ inputs.username }}
-          echo ${{ secrets.DD_API_KEY }}
       - name: Checkout dataset
         uses: actions/checkout@v2
         with:
           repository: ${{ secrets.DATASET_REPOSITORY }}
           token: ${{ secrets.ML_TEST_SA_PAT }}
           path: 'dataset'
-          ref: ${{ matrix.dataset_branch }}
+          ref: ${{ input.dataset_branch }}

--- a/.github/workflows/ci-model-regression-test-helper.yml
+++ b/.github/workflows/ci-model-regression-test-helper.yml
@@ -1,0 +1,33 @@
+name: MR Test Reusable workflow
+
+on:
+  workflow_call:
+    inputs:
+      username:
+        required: true
+        type: string
+    secrets:
+      envPAT:
+        required: true
+
+jobs:
+  reusable_workflow_job:
+    runs-on: ubuntu-latest
+    environment: production  # remove
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Print
+        run: |-
+          set -x
+          echo ${{ inputs.username }}
+          echo ${{ secrets.DD_API_KEY }}
+      - name: Checkout dataset
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ secrets.DATASET_REPOSITORY }}
+          token: ${{ secrets.ML_TEST_SA_PAT }}
+          path: 'dataset'
+          ref: ${{ matrix.dataset_branch }}

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -442,10 +442,16 @@ jobs:
     needs:
       - read_test_configuration
     uses: RasaHQ/rasa/.github/workflows/ci-model-regression-test-helper.yml@regr-test-dry
+    strategy:
+      max-parallel: 3
+      matrix: ${{fromJson(needs.read_test_configuration.outputs.matrix)}}
+      fail-fast: false
     with:
-      username: mona
+      dataset_branch: matrix.dataset_branch
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ML_TEST_SA_PAT: ${{ secrets.ML_TEST_SA_PAT }}
+      DATASET_REPOSITORY: ${{ secrets.DATASET_REPOSITORY }}
 
   model_regression_test_cpu:
     name: Model Regression Tests - CPU

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -439,7 +439,9 @@ jobs:
 
   model_regression_test_cpu_new:
     name: Model Regression Tests - CPU new
-    uses: ./.github/workflows/ci-model-regression-test-helper.yml
+    needs:
+      - read_test_configuration
+    uses: RasaHQ/rasa/.github/workflows/ci-model-regression-test-helper.yml@regr-test-dry
     with:
       username: mona
     secrets:

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -357,7 +357,7 @@ jobs:
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         run: poetry run pip install -U datadog-api-client ddtrace
 
-      - name: Validate that GPUs are working
+      - name: Validate that GPUs are working [SPECIAL]
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         run: |-
           poetry run python -c 'from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())' || true
@@ -437,6 +437,14 @@ jobs:
         run: |
           sudo service datadog-agent stop
 
+  model_regression_test_cpu_new:
+    name: Model Regression Tests - CPU new
+    uses: ./.github/workflows/ci-model-regression-test-helper.yml
+    with:
+      username: mona
+    secrets:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+
   model_regression_test_cpu:
     name: Model Regression Tests - CPU
     needs:
@@ -467,7 +475,7 @@ jobs:
           sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64
           sudo chmod +x /usr/local/bin/gomplate
 
-      - name: Set DATASET and CONFIG variables
+      - name: Set env variables
         id: set_dataset_config_vars
         env:
           DATASET_NAME: "${{ matrix.dataset }}"
@@ -490,6 +498,11 @@ jobs:
           echo "::set-output name=is_dataset_exists::true"
           echo "::set-output name=is_config_exists::true"
           echo "::set-output name=is_external::${IS_EXTERNAL}"
+
+          # Warn about job if dataset is Hermit and config is BERT + DIET(seq) + ResponseSelector(t2t) or Sparse + BERT + DIET(seq) + ResponseSelector(t2t)
+          if [[ "${{ matrix.dataset }}" == "Hermit" && "${{ matrix.config }}" =~ "BERT + DIET(seq) + ResponseSelector(t2t)" ]]; then
+            echo "::warning::This ${{ matrix.dataset }} dataset / ${{ matrix.config }} config is currently being skipped on scheduled tests due to OOM associated with the upgrade to TF 2.6. You may see OOM here."
+          fi
 
           if [[ "${IS_EXTERNAL}" == "true" ]]; then
             echo "DATASET_DIR=dataset_external" >> $GITHUB_ENV


### PR DESCRIPTION
**Proposed changes**:
- ...

**Resources:**
- https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#creating-a-reusable-workflow

**Limitation**
* https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations mentions
"The strategy property is not supported in any job that calls a reusable workflow.". This means we can't use it with `matrix` which we use for configuring multiple regression tests (multiple configs/datasets)
* https://github.community/t/reusable-workflow-with-strategy-matrix/205676/2

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
