### PR TITLE
Increase cache size for RulePolicy

### DIFF
--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -835,7 +835,7 @@ class RulePolicy(MemoizationPolicy):
     @staticmethod
     # This function is called a lot (e.g. for checking contradictions) so we cache
     # its results.
-    @functools.lru_cache(maxsize=1000)
+    @functools.lru_cache(maxsize=100000)
     def _rule_key_to_state(rule_key: Text) -> List[State]:
         return json.loads(rule_key)
 


### PR DESCRIPTION
Fixes https://github.com/RasaHQ/rasa/issues/10703

**Proposed changes**:
- Increase cache size for RulePolicy

**Context for the fix**:

This actually came up on the on-point Slack channel after a customer reported higher CPU usage when they upgraded Rasa from 1.5.1 to 2.5.0. Further investigation revealed the source to be rule policy in which they revealed:

> This bot's dialogue is 100% rule based so they have a lot of rules. The RulePolicy's lookup table has 4,082 keys and looping over them to determine if a rule is applicable to a state  consumes a lot of CPU cycles

@JEM-Mosig mentioned

> The OR-statements are in the bot's rule yml files. When the rules are loaded, each rule with an OR is copied - once for each alternative. RulePolicy itself doesn't know anything about OR statements. But it could maybe "compress" the rule dict again in a way that acknowledges this. I'll re-post this on the issue.

I've quickly increased cache size to a huge number to allow for rule fan out if that happens and customer tested this branch. 

What needs to be done: 

- [ ] Test memory usage
- [ ] Check if we can better utilize memory especially with regards to OR statements in rules
- [ ] We also do `list(reversed(state_list)` on each run and this can be cached too, explore this also


**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
