### PR TITLE
Fix domain slot schema

### DIFF
--- a/changelog/10782.bugfix.md
+++ b/changelog/10782.bugfix.md
@@ -1,0 +1,1 @@
+Allow arbitrary keys under each slot in the domain to allow for custom slot types.

--- a/data/test_classes/custom_slots.py
+++ b/data/test_classes/custom_slots.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Any, Dict, List, Text, Optional
+
+from rasa.shared.core.slots import Slot
+
+logger = logging.getLogger(__name__)
+
+
+class LimitSlot(Slot):
+    """
+    A slot for featurizing an amount as greater than or equal to vs. less than a given value.
+
+    Example of configuration in the domain.yml file:
+    slots:
+        my_slot:
+          type: custom.slots.LimitSlot
+          limit: 100
+    """
+
+    def __init__(
+        self,
+        name: Text,
+        limit: int,
+        mappings: List[Dict[Text, Any]],
+        initial_value: Any = None,
+        value_reset_delay: Optional[int] = None,
+        influence_conversation: bool = True,
+    ) -> None:
+
+        super().__init__(
+            name=name,
+            initial_value=initial_value,
+            mappings=mappings,
+            value_reset_delay=value_reset_delay,
+            influence_conversation=influence_conversation,
+        )
+        self.limit = limit
+
+    def _as_feature(self) -> List[float]:
+        try:
+            greater_than_limit = float(self.value >= self.limit)
+            return [1.0, greater_than_limit]
+        except (TypeError, ValueError):
+            return [0.0, 0.0]
+
+    def persistence_info(self) -> Dict[Text, Any]:
+        """Returns relevant information to persist this slot."""
+        d = super().persistence_info()
+        d["limit"] = self.limit
+        return d
+
+    def _feature_dimensionality(self) -> int:
+        return len(self.as_feature())

--- a/data/test_domains/custom_slot_domain.yml
+++ b/data/test_domains/custom_slot_domain.yml
@@ -1,0 +1,18 @@
+intents:
+ - inform
+ - greet
+
+entities:
+  - limit
+
+slots:
+  limit:
+    type: data.test_classes.custom_slots.LimitSlot
+    limit: 1000
+    mappings:
+    - type: from_entity
+      entity: limit
+
+actions:
+- action_greet
+

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -47,6 +47,8 @@ mapping:
       regex;([A-Za-z]+):
         type: "map"
         mapping:
+          regex;([A-Za-z]+):
+            type: "any"
           influence_conversation:
             type: "bool"
             required: False

--- a/rasa/shared/utils/schemas/domain.yml
+++ b/rasa/shared/utils/schemas/domain.yml
@@ -46,9 +46,8 @@ mapping:
     mapping:
       regex;([A-Za-z]+):
         type: "map"
+        allowempty: True
         mapping:
-          regex;([A-Za-z]+):
-            type: "any"
           influence_conversation:
             type: "bool"
             required: False

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -248,7 +248,7 @@ def test_custom_slot_type_with_custom_key():
 
 
 @pytest.mark.parametrize(
-    "domain_unkown_slot_type",
+    "domain_invalid_type_for_slot_key",
     [
     """slots:
             limit:
@@ -280,9 +280,9 @@ def test_custom_slot_type_with_custom_key():
                   entity: limit""",
     ],
 )
-def test_domain_fails_on_invalid_type_for_known_slot_key(tmpdir, domain_unkown_slot_type):
+def test_domain_fails_on_invalid_type_for_known_slot_key(tmpdir, domain_invalid_type_for_slot_key):
     domain_path = str(tmpdir / "domain.yml")
-    rasa.shared.utils.io.write_text_file(domain_unkown_slot_type, domain_path)
+    rasa.shared.utils.io.write_text_file(domain_invalid_type_for_slot_key, domain_path)
     with pytest.raises(YamlValidationException):
         Domain.load(domain_path)
 

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -241,6 +241,52 @@ def test_domain_fails_on_unknown_custom_slot_type(tmpdir, domain_unkown_slot_typ
         Domain.load(domain_path)
 
 
+def test_custom_slot_type_with_custom_key():
+    domain = Domain.load("data/test_domains/custom_slot_domain.yml")
+
+    assert domain.slots[0].limit == 1000
+
+
+@pytest.mark.parametrize(
+    "domain_unkown_slot_type",
+    [
+    """slots:
+            limit:
+                type: text
+                influence_conversation: yes
+                mappings:
+                - type: from_entity
+                  entity: limit""",
+    """slots:
+            limit:
+                type: text
+                values: notalist
+                mappings:
+                - type: from_entity
+                  entity: limit""",
+    """slots:
+            limit:
+                type: text
+                min_value: notanumber
+                mappings:
+                - type: from_entity
+                  entity: limit""",
+    """slots:
+            limit:
+                type: text
+                max_value: notanumber
+                mappings:
+                - type: from_entity
+                  entity: limit""",
+    ],
+)
+def test_domain_fails_on_invalid_type_for_known_slot_key(tmpdir, domain_unkown_slot_type):
+    domain_path = str(tmpdir / "domain.yml")
+    rasa.shared.utils.io.write_text_file(domain_unkown_slot_type, domain_path)
+    with pytest.raises(YamlValidationException):
+        Domain.load(domain_path)
+
+
 def test_domain_to_dict():
     test_yaml = textwrap.dedent(
         f"""
@@ -859,10 +905,6 @@ def test_load_domain_with_entity_roles_groups():
     assert "origin" in domain.roles["GPE"]
     assert "destination" in domain.roles["GPE"]
 
-def test_load_domain_with_custom_slot():
-    domain = Domain.load("data/test_domains/custom_slot_domain.yml")
-
-    assert domain.slots is not None
 
 def test_is_empty():
     assert Domain.empty().is_empty()

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -859,6 +859,10 @@ def test_load_domain_with_entity_roles_groups():
     assert "origin" in domain.roles["GPE"]
     assert "destination" in domain.roles["GPE"]
 
+def test_load_domain_with_custom_slot():
+    domain = Domain.load("data/test_domains/custom_slot_domain.yml")
+
+    assert domain.slots is not None
 
 def test_is_empty():
     assert Domain.empty().is_empty()

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -256,14 +256,14 @@ def test_custom_slot_type_with_custom_key():
                 influence_conversation: yes
                 mappings:
                 - type: from_entity
-                    entity: limit""",
+                  entity: limit""",
         """slots:
             limit:
                 type: text
                 values: notalist
                 mappings:
                 - type: from_entity
-                    entity: limit""",
+                  entity: limit""",
         """slots:
             limit:
                 type: text

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -250,28 +250,28 @@ def test_custom_slot_type_with_custom_key():
 @pytest.mark.parametrize(
     "domain_invalid_type_for_slot_key",
     [
-    """slots:
+        """slots:
             limit:
                 type: text
                 influence_conversation: yes
                 mappings:
                 - type: from_entity
-                  entity: limit""",
-    """slots:
+                    entity: limit""",
+        """slots:
             limit:
                 type: text
                 values: notalist
                 mappings:
                 - type: from_entity
-                  entity: limit""",
-    """slots:
+                    entity: limit""",
+        """slots:
             limit:
                 type: text
                 min_value: notanumber
                 mappings:
                 - type: from_entity
                   entity: limit""",
-    """slots:
+        """slots:
             limit:
                 type: text
                 max_value: notanumber
@@ -280,7 +280,9 @@ def test_custom_slot_type_with_custom_key():
                   entity: limit""",
     ],
 )
-def test_domain_fails_on_invalid_type_for_known_slot_key(tmpdir, domain_invalid_type_for_slot_key):
+def test_domain_fails_on_invalid_type_for_known_slot_key(
+    tmpdir, domain_invalid_type_for_slot_key
+):
     domain_path = str(tmpdir / "domain.yml")
     rasa.shared.utils.io.write_text_file(domain_invalid_type_for_slot_key, domain_path)
     with pytest.raises(YamlValidationException):


### PR DESCRIPTION
**Proposed changes**:
- Allow arbitrary keys under a slot in the domain as was allowed in 2.x
- closes https://github.com/RasaHQ/rasa/issues/10765

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
