### PR TITLE
Overwrite final weights with checkpoint weights before persisting

### DIFF
--- a/changelog/10516.bugfix.md
+++ b/changelog/10516.bugfix.md
@@ -1,0 +1,1 @@
+Checkpoint weights were never loaded before. Implements overwriting checkpoint weights to the final model weights after training of `DIETClassifier`, `ResponseSelector` and `TEDPolicy`. 

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -913,7 +913,7 @@ class TEDPolicy(Policy):
 
             self.featurizer.persist(model_path)
 
-            if self.config[CHECKPOINT_MODEL]:
+            if self.config[CHECKPOINT_MODEL] and self.tmp_checkpoint_dir:
                 self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
                 # For testing purposes only
                 rasa.utils.io.pickle_dump(

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -915,10 +915,10 @@ class TEDPolicy(Policy):
 
             if self.config[CHECKPOINT_MODEL] and self.tmp_checkpoint_dir:
                 self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
-                # For testing purposes only
-                rasa.utils.io.pickle_dump(
-                    model_path / f"{model_filename}.from_checkpoint.pkl", None
-                )
+                # Save an empty file to flag that this model has been
+                # produced using checkpointing
+                checkpoint_marker = model_path / f"{model_filename}.from_checkpoint.pkl"
+                checkpoint_marker.touch()
 
             self.model.save(str(tf_model_file))
 

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -915,7 +915,11 @@ class TEDPolicy(Policy):
             self.featurizer.persist(model_path)
 
             if self.config[CHECKPOINT_MODEL]:
-                shutil.move(self.tmp_checkpoint_dir, model_path / "checkpoints")
+                self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
+                rasa.utils.io.pickle_dump(
+                    model_path / f"{model_filename}.from_checkpoint.pkl", None
+                )
+
             self.model.save(str(tf_model_file))
 
             self.persist_model_utilities(model_path)

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import logging
 
 from rasa.engine.recipes.default_recipe import DefaultV1Recipe
-import shutil
 from pathlib import Path
 from collections import defaultdict
 
@@ -916,6 +915,7 @@ class TEDPolicy(Policy):
 
             if self.config[CHECKPOINT_MODEL]:
                 self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
+                # For testing purposes only
                 rasa.utils.io.pickle_dump(
                     model_path / f"{model_filename}.from_checkpoint.pkl", None
                 )

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1043,10 +1043,10 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
 
             if self.component_config[CHECKPOINT_MODEL] and self.tmp_checkpoint_dir:
                 self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
-                # For testing purposes only
-                rasa.utils.io.pickle_dump(
-                    model_path / f"{file_name}.from_checkpoint.pkl", None
-                )
+                # Save an empty file to flag that this model has been
+                # produced using checkpointing
+                checkpoint_marker = model_path / f"{file_name}.from_checkpoint.pkl"
+                checkpoint_marker.touch()
 
             self.model.save(str(tf_model_file))
 

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1032,8 +1032,6 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
 
     def persist(self) -> None:
         """Persist this model into the passed directory."""
-        import shutil
-
         if self.model is None:
             return None
 
@@ -1045,6 +1043,7 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
 
             if self.component_config[CHECKPOINT_MODEL]:
                 self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
+                # For testing purposes only
                 rasa.utils.io.pickle_dump(
                     model_path / f"{file_name}.from_checkpoint.pkl", None
                 )

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1041,7 +1041,7 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
 
             rasa.shared.utils.io.create_directory_for_file(tf_model_file)
 
-            if self.component_config[CHECKPOINT_MODEL]:
+            if self.component_config[CHECKPOINT_MODEL] and self.tmp_checkpoint_dir:
                 self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
                 # For testing purposes only
                 rasa.utils.io.pickle_dump(

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -1044,7 +1044,11 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
             rasa.shared.utils.io.create_directory_for_file(tf_model_file)
 
             if self.component_config[CHECKPOINT_MODEL]:
-                shutil.move(self.tmp_checkpoint_dir, model_path / "checkpoints")
+                self.model.load_weights(self.tmp_checkpoint_dir / "checkpoint.tf_model")
+                rasa.utils.io.pickle_dump(
+                    model_path / f"{file_name}.from_checkpoint.pkl", None
+                )
+
             self.model.save(str(tf_model_file))
 
             io_utils.pickle_dump(

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -129,12 +129,10 @@ class TestTEDPolicy(PolicyTestCollection):
         )
 
         storage_dir = tmp_path_factory.mktemp("storage dir")
-        storage, _ = LocalModelStorage.from_model_archive(
-            storage_dir, tmp_path / "my_model.tar.gz"
-        )
-
-        checkpoint_dir = get_checkpoint_dir_path(storage_dir)
-        assert checkpoint_dir.is_dir()
+        LocalModelStorage.from_model_archive(storage_dir, tmp_path / "my_model.tar.gz")
+        model_dir = storage_dir / f"train_TEDPolicy0"
+        all_files = list(model_dir.rglob("*.*"))
+        assert any(["from_checkpoint" in str(filename) for filename in all_files])
 
     def test_doesnt_checkpoint_with_no_checkpointing(
         self, tmp_path: Path, tmp_path_factory: TempPathFactory
@@ -148,18 +146,14 @@ class TestTEDPolicy(PolicyTestCollection):
         )
 
         storage_dir = tmp_path_factory.mktemp("storage dir")
-        storage, _ = LocalModelStorage.from_model_archive(
-            storage_dir, tmp_path / "my_model.tar.gz"
-        )
-
-        checkpoint_dir = get_checkpoint_dir_path(storage_dir)
-        assert not checkpoint_dir.is_dir()
+        LocalModelStorage.from_model_archive(storage_dir, tmp_path / "my_model.tar.gz")
+        model_dir = storage_dir / f"train_TEDPolicy0"
+        all_files = list(model_dir.rglob("*.*"))
+        assert not any(["from_checkpoint" in str(filename) for filename in all_files])
 
     def test_doesnt_checkpoint_with_zero_eval_num_examples(
         self, tmp_path: Path, tmp_path_factory: TempPathFactory
     ):
-        checkpoint_dir = get_checkpoint_dir_path(tmp_path)
-        assert not checkpoint_dir.is_dir()
         config_file = "config_ted_policy_model_checkpointing_zero_eval_num_examples.yml"
         with pytest.warns(UserWarning) as warning:
             train_core(
@@ -178,12 +172,10 @@ class TestTEDPolicy(PolicyTestCollection):
         assert len([w for w in warning if warn_text in str(w.message)]) == 1
 
         storage_dir = tmp_path_factory.mktemp("storage dir")
-        storage, _ = LocalModelStorage.from_model_archive(
-            storage_dir, tmp_path / "my_model.tar.gz"
-        )
-
-        checkpoint_dir = get_checkpoint_dir_path(storage_dir)
-        assert not checkpoint_dir.is_dir()
+        LocalModelStorage.from_model_archive(storage_dir, tmp_path / "my_model.tar.gz")
+        model_dir = storage_dir / f"train_TEDPolicy0"
+        all_files = list(model_dir.rglob("*.*"))
+        assert not any(["from_checkpoint" in str(filename) for filename in all_files])
 
     @pytest.mark.parametrize(
         "should_finetune, epoch_override, expected_epoch_value",

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -67,20 +67,6 @@ actions:
 """
 
 
-def get_checkpoint_dir_path(train_path: Path, ted_pos: Optional[int] = 0) -> Path:
-    """
-    Produce the path of the checkpoint directory for TED.
-
-    This is very tightly coupled to the persist methods of PolicyEnsemble, Agent, and
-    TEDPolicy.
-    Args:
-        train_path: the path passed to model_training.train_core for training output.
-        ted_pos: the position of TED in the policies listed in the config.
-    """
-    policy_path = train_path / f"train_TEDPolicy{ted_pos}"
-    return policy_path / "checkpoints"
-
-
 def test_diagnostics(
     default_model_storage: ModelStorage, default_execution_context: ExecutionContext
 ):
@@ -130,7 +116,7 @@ class TestTEDPolicy(PolicyTestCollection):
 
         storage_dir = tmp_path_factory.mktemp("storage dir")
         LocalModelStorage.from_model_archive(storage_dir, tmp_path / "my_model.tar.gz")
-        model_dir = storage_dir / f"train_TEDPolicy0"
+        model_dir = storage_dir / "train_TEDPolicy0"
         all_files = list(model_dir.rglob("*.*"))
         assert any(["from_checkpoint" in str(filename) for filename in all_files])
 
@@ -147,7 +133,7 @@ class TestTEDPolicy(PolicyTestCollection):
 
         storage_dir = tmp_path_factory.mktemp("storage dir")
         LocalModelStorage.from_model_archive(storage_dir, tmp_path / "my_model.tar.gz")
-        model_dir = storage_dir / f"train_TEDPolicy0"
+        model_dir = storage_dir / "train_TEDPolicy0"
         all_files = list(model_dir.rglob("*.*"))
         assert not any(["from_checkpoint" in str(filename) for filename in all_files])
 
@@ -173,7 +159,7 @@ class TestTEDPolicy(PolicyTestCollection):
 
         storage_dir = tmp_path_factory.mktemp("storage dir")
         LocalModelStorage.from_model_archive(storage_dir, tmp_path / "my_model.tar.gz")
-        model_dir = storage_dir / f"train_TEDPolicy0"
+        model_dir = storage_dir / "train_TEDPolicy0"
         all_files = list(model_dir.rglob("*.*"))
         assert not any(["from_checkpoint" in str(filename) for filename in all_files])
 

--- a/tests/nlu/selectors/test_selectors.py
+++ b/tests/nlu/selectors/test_selectors.py
@@ -315,7 +315,7 @@ def test_train_model_checkpointing(
     )
 
     config_params = {
-        EPOCHS: 5,
+        EPOCHS: 2,
         MODEL_CONFIDENCE: "softmax",
         CONSTRAIN_SIMILARITIES: True,
         CHECKPOINT_MODEL: True,
@@ -329,15 +329,8 @@ def test_train_model_checkpointing(
     resource = response_selector.train(training_data=training_data)
 
     with default_model_storage.read_from(resource) as model_dir:
-        checkpoint_dir = model_dir / "checkpoints"
-        assert checkpoint_dir.is_dir()
-        checkpoint_files = list(checkpoint_dir.rglob("*.*"))
-        """
-        there should be min 2 `tf_model` files in the `checkpoints` directory:
-        - tf_model.data
-        - tf_model.index
-        """
-        assert len(checkpoint_files) >= 2
+        all_files = list(model_dir.rglob("*.*"))
+        assert any(["from_checkpoint" in str(filename) for filename in all_files])
 
 
 @pytest.mark.skip_on_windows


### PR DESCRIPTION
**Proposed changes**:
- Fixes #10516 
- Implements overwriting the final model weights with the checkpoint weights after training of `DIETClassifier`, `ResponseSelector` and `TEDPolicy`. 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
