### PR TITLE
ci: Upload diagnostic data as artifact

### DIFF
--- a/.github/configs/mr-test-schedule.json
+++ b/.github/configs/mr-test-schedule.json
@@ -1,3 +1,3 @@
 {
-  "body": "```yml\r\ninclude:\r\n  - dataset: [\"Sara\", \"financial-demo\"]\r\n    config: [\"Sparse + DIET(bow) + ResponseSelector(bow)\", \"Rules + TED\"]\r\n```"
+  "body": "```yml\r\ninclude:\r\n  - dataset: [\"all\"]\r\n    config: [\"all\"]\r\n```"
 }

--- a/.github/configs/mr-test-schedule.json
+++ b/.github/configs/mr-test-schedule.json
@@ -1,3 +1,3 @@
 {
-  "body": "```yml\r\ninclude:\r\n  - dataset: [\"all\"]\r\n    config: [\"all\"]\r\n```"
+  "body": "```yml\r\ninclude:\r\n  - dataset: [\"Sara\", \"financial-demo\"]\r\n    config: [\"Sparse + DIET(bow) + ResponseSelector(bow)\", \"Rules + TED\"]\r\n```"
 }

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -357,15 +357,15 @@ jobs:
       - name: Prepare diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         run: |
-          mkdir diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}
+          mkdir "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}"
 
           # Create files to preserve directory structure when uploading artifacts
           # See: https://github.com/actions/upload-artifact/issues/174
-          touch diagnostic_data/${{ matrix.dataset }}/.keep
-          touch diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}/.keep
+          touch "diagnostic_data/${{ matrix.dataset }}/.keep"
+          touch "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}/.keep"
 
           # Move results to the desired destination
-          mv -t diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }} results/failed_test_stories.yml results/story_confmat.png
+          mv -t "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}" results/failed_test_stories.yml results/story_confmat.png
 
       - name: Upload an artifact with diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -356,8 +356,8 @@ jobs:
       # DEBUG: delete later
       - name: find results data
         run: |
-          locate -i failed_test_stories.yml
-          locate -i story_confmat.png
+          find . -iname failed_test_stories.yml
+          find . -iname story_confmat.png
 
       # Prepare diagnostic data for the configs which evaluate dialog policy performance
       - name: Prepare diagnostic data

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -301,11 +301,11 @@ jobs:
           fi
 
           if [[ "${{ matrix.type }}" == "nlu" ]]; then
-            poetry run rasa train nlu --quiet -u ${DATASET_DIR}/${DATASET}/${TRAIN_DIR} -c dataset/configs/${CONFIG} --out ${DATASET_DIR}/models/${DATASET}/${CONFIG}
+            poetry run rasa train nlu --quiet -u "${DATASET_DIR}/${DATASET}/${TRAIN_DIR}" -c "dataset/configs/${CONFIG}" --out "${DATASET_DIR}/models/${DATASET}/${CONFIG}"
             echo "::set-output name=train_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
 
             export NOW_TEST=$(gomplate -i '{{ (time.Now).Format time.RFC3339}}');
-            poetry run rasa test nlu --quiet -u ${DATASET_DIR}/$DATASET/${TEST_DIR} -m ${DATASET_DIR}/models/$DATASET/$CONFIG --out ${{ github.workspace }}/results/$DATASET/$CONFIG
+            poetry run rasa test nlu --quiet -u "${DATASET_DIR}/$DATASET/${TEST_DIR}" -m "${DATASET_DIR}/models/$DATASET/$CONFIG" --out "${{ github.workspace }}/results/$DATASET/$CONFIG"
 
             echo "::set-output name=test_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TEST") }}{{ (time.Since $t).Round (time.Second 1) }}')"
             echo "::set-output name=total_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
@@ -315,7 +315,7 @@ jobs:
             echo "::set-output name=train_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
 
             export NOW_TEST=$(gomplate -i '{{ (time.Now).Format time.RFC3339}}');
-            poetry run rasa test core -s ${DATASET_DIR}/${DATASET}/${TEST_DIR} --out ${{ github.workspace }}/results/${{ matrix.dataset }}/${CONFIG}
+            poetry run rasa test core -s "${DATASET_DIR}/${DATASET}/${TEST_DIR}" --out "${{ github.workspace }}/results/${{ matrix.dataset }}/${CONFIG}"
 
             echo "::set-output name=test_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TEST") }}{{ (time.Since $t).Round (time.Second 1) }}')"
             echo "::set-output name=total_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -357,7 +357,7 @@ jobs:
       - name: Prepare diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         run: |
-          mkdir "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}"
+          mkdir -p "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}"
 
           # Create files to preserve directory structure when uploading artifacts
           # See: https://github.com/actions/upload-artifact/issues/174

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -355,7 +355,7 @@ jobs:
 
       # Collect diagnostic data for the configs which evaluate dialog policy performance
       - name: Prepare diagnostic data
-        if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == "core"
+        if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         run: |
           mkdir diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}
 
@@ -368,7 +368,7 @@ jobs:
           mv -t diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }} results/failed_test_stories.yml results/story_confmat.png
 
       - name: Upload an artifact with diagnostic data
-        if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == "core"
+        if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         uses: actions/upload-artifact@v2
         with:
           name: diagnostic_data

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -359,15 +359,15 @@ jobs:
         run: |
           # Create dummy files to preserve directory structure when uploading artifacts
           # See: https://github.com/actions/upload-artifact/issues/174
-          touch "results/$DATASET/.keep"
-          touch "results/$DATASET/$CONFIG/.keep"
+          touch "${{ github.workspace }}/results/${DATASET}/.keep"
+          touch "${{ github.workspace }}/results/${DATASET}/${CONFIG}/.keep"
 
       - name: Upload an artifact with diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         uses: actions/upload-artifact@v2
         with:
           name: diagnostic_data
-          path: results/*
+          path: ${{ github.workspace }}/results/*
 
       - name: Stop Datadog Agent
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -357,22 +357,17 @@ jobs:
       - name: Prepare diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         run: |
-          mkdir -p "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}"
-
-          # Create files to preserve directory structure when uploading artifacts
+          # Create dummy files to preserve directory structure when uploading artifacts
           # See: https://github.com/actions/upload-artifact/issues/174
-          touch "diagnostic_data/${{ matrix.dataset }}/.keep"
-          touch "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}/.keep"
-
-          # Move results to the desired destination
-          mv -t "diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}" results/failed_test_stories.yml results/story_confmat.png
+          touch "results/$DATASET/.keep"
+          touch "results/$DATASET/$CONFIG/.keep"
 
       - name: Upload an artifact with diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         uses: actions/upload-artifact@v2
         with:
           name: diagnostic_data
-          path: diagnostic_data/*
+          path: results/*
 
       - name: Stop Datadog Agent
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -353,7 +353,13 @@ jobs:
           name: report-${{ matrix.dataset }}-${{ matrix.config }}
           path: report.json
 
-      # Collect diagnostic data for the configs which evaluate dialog policy performance
+      # DEBUG: delete later
+      - name: find results data
+        run: |
+          locate -i failed_test_stories.yml
+          locate -i story_confmat.png
+
+      # Prepare diagnostic data for the configs which evaluate dialog policy performance
       - name: Prepare diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         run: |

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -369,8 +369,8 @@ jobs:
           name: diagnostic_data
           path: |
             results/**/.keep
-            results/${DATASET}/${CONFIG}/failed_test_stories.yml
-            results/${DATASET}/${CONFIG}/story_confusion_matrix.png
+            results/${{ matrix.dataset }}/${{ matrix.config }}/failed_test_stories.yml
+            results/${{ matrix.dataset }}/${{ matrix.config }}/story_confusion_matrix.png
 
       - name: Stop Datadog Agent
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Run once a week
     - cron: '1 23 * * */7'
+  pull_request: # TODO test
 
 env:
   GKE_ZONE: us-central1

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -357,7 +357,7 @@ jobs:
       - name: find results data
         run: |
           find . -iname failed_test_stories.yml
-          find . -iname story_confmat.png
+          find . -iname story_confusion_matrix.png
 
       # Prepare diagnostic data for the configs which evaluate dialog policy performance
       - name: Prepare diagnostic data
@@ -365,15 +365,18 @@ jobs:
         run: |
           # Create dummy files to preserve directory structure when uploading artifacts
           # See: https://github.com/actions/upload-artifact/issues/174
-          touch "${{ github.workspace }}/results/${DATASET}/.keep"
-          touch "${{ github.workspace }}/results/${DATASET}/${CONFIG}/.keep"
+          touch "results/${{ matrix.dataset }}/.keep"
+          touch "results/${{ matrix.dataset }}/${{ matrix.config }}/.keep"
 
       - name: Upload an artifact with diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'
         uses: actions/upload-artifact@v2
         with:
           name: diagnostic_data
-          path: ${{ github.workspace }}/results/*
+          path: |
+            results/**/.keep
+            results/${DATASET}/${CONFIG}/failed_test_stories.yml
+            results/${DATASET}/${CONFIG}/story_confusion_matrix.png
 
       - name: Stop Datadog Agent
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -352,6 +352,27 @@ jobs:
           name: report-${{ matrix.dataset }}-${{ matrix.config }}
           path: report.json
 
+      # Collect diagnostic data for the configs which evaluate dialog policy performance
+      - name: Prepare diagnostic data
+        if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == "core"
+        run: |
+          mkdir diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}
+
+          # Create files to preserve directory structure when uploading artifacts
+          # See: https://github.com/actions/upload-artifact/issues/174
+          touch diagnostic_data/${{ matrix.dataset }}/.keep
+          touch diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }}/.keep
+
+          # Move results to the desired destination
+          mv -t diagnostic_data/${{ matrix.dataset }}/${{ matrix.config }} results/failed_test_stories.yml results/story_confmat.png
+
+      - name: Upload an artifact with diagnostic data
+        if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == "core"
+        uses: actions/upload-artifact@v2
+        with:
+          name: diagnostic_data
+          path: diagnostic_data/*
+
       - name: Stop Datadog Agent
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         run: |

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -380,7 +380,7 @@ jobs:
           sudo service datadog-agent stop
 
       - name: Check duplicate issue
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293  # v4
         id: issue-exists
         with:
@@ -409,7 +409,7 @@ jobs:
 
       - name: Create GitHub Issue 📬
         id: create-issue
-        if: failure() && steps.issue-exists.outputs.result == 'false'
+        if: failure() && steps.issue-exists.outputs.result == 'false' && github.event_name == 'schedule'
         uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293  # v4
         with:
           # do not use GITHUB_TOKEN here because it wouldn't trigger subsequent workflows
@@ -425,7 +425,7 @@ jobs:
             return issue.data.number
 
       - name: Notify Slack of Failure 😱
-        if: failure()  && steps.issue-exists.outputs.result == 'false'
+        if: failure()  && steps.issue-exists.outputs.result == 'false' && github.event_name == 'schedule'
         uses: 8398a7/action-slack@a74b761b4089b5d730d813fbedcd2ec5d394f3af  # v3
         with:
           status: custom
@@ -506,7 +506,7 @@ jobs:
   analyse_performance:
     name: Analyse Performance
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && github.event_name == 'schedule'
     needs:
       - model_regression_test_gpu
       - combine_reports

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -5,7 +5,6 @@ on:
   schedule:
     # Run once a week
     - cron: '1 23 * * */7'
-  pull_request: # TODO test
 
 env:
   GKE_ZONE: us-central1

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -353,12 +353,6 @@ jobs:
           name: report-${{ matrix.dataset }}-${{ matrix.config }}
           path: report.json
 
-      # DEBUG: delete later
-      - name: find results data
-        run: |
-          find . -iname failed_test_stories.yml
-          find . -iname story_confusion_matrix.png
-
       # Prepare diagnostic data for the configs which evaluate dialog policy performance
       - name: Prepare diagnostic data
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true' && matrix.type == 'core'

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -315,7 +315,7 @@ jobs:
             echo "::set-output name=train_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
 
             export NOW_TEST=$(gomplate -i '{{ (time.Now).Format time.RFC3339}}');
-            poetry run rasa test core -s "${DATASET_DIR}/${DATASET}/${TEST_DIR}" --out "${{ github.workspace }}/results/${{ matrix.dataset }}/${CONFIG}"
+            poetry run rasa test core -s "${DATASET_DIR}/${DATASET}/${TEST_DIR}" --out "${{ github.workspace }}/results/${{ matrix.dataset }}/${{ matrix.config }}"
 
             echo "::set-output name=test_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TEST") }}{{ (time.Since $t).Round (time.Second 1) }}')"
             echo "::set-output name=total_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"


### PR DESCRIPTION
This PR made multiple changes on the schedule version of Model Regression Tests workflow:
- Quote path strings
  When passing dataset/config path to `rasa test core/nlu`, paths with whitespaces will break at whitespace which leads to unexpected results, e.g., not being able to locate stories to test on. 
- Upload diagnostic data to artifact if tests that test `rasa test core`. 
  Resolves https://github.com/RasaHQ/rasa/issues/10730
  
- Skip Slack notifications on github events other than `on schedule`
  We don't want to make noise while testing on PR 🙃


TODOs:
- [x] Remove test lines, specifically, revert 2baed07dacd27885fe0ec0956a9323699a111ce9