### PR TITLE
Change Rule to match actions.py

### DIFF
--- a/docs/docs/reaching-out-to-user.mdx
+++ b/docs/docs/reaching-out-to-user.mdx
@@ -251,7 +251,7 @@ rules:
   - intent: ask_remind_call
     entities:
     - PERSON
-  - action: action_schedule_reminder
+  - action: action_set_reminder
 ```
 
 


### PR DESCRIPTION
**Proposed changes**:
- Example rule had `action_schedule_reminder` which is not consistent with example reminder bot, nor the actions.py above in this page.

**Status (please check what you already did)**:

- [x] updated the documentation