### PR TITLE
fix: :bug: fix server startup with JWT secret

### DIFF
--- a/changelog/10840.bugfix.md
+++ b/changelog/10840.bugfix.md
@@ -1,0 +1,2 @@
+Fix issue with missing running event loop in `MainThread` when starting Rasa Open 
+Source for Rasa X with JWT secrets.

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -644,6 +644,15 @@ def create_app(
 
     # Setup the Sanic-JWT extension
     if jwt_secret and jwt_method:
+        # `sanic-jwt` depends on having an available event loop when making the call to
+        # `Initialize`. If there is non, the server startup will fail with
+        # `There is no current event loop in thread 'MainThread'`.
+        try:
+            _ = asyncio.get_running_loop()
+        except RuntimeError:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+
         # since we only want to check signatures, we don't actually care
         # about the JWT method and set the passed secret as either symmetric
         # or asymmetric key. jwt lib will choose the right one based on method


### PR DESCRIPTION

**Proposed changes**:
- When bumping Rasa Enterprise to Rasa Open Source, Rasa Open Source crashed during startup due to a missing asyncio loop. This creates the event loop in case it's not yet initialized.

```
Starting Rasa X in production mode... 🚀
deployment-rasa-production-1  | Traceback (most recent call last):
deployment-rasa-production-1  |   File "/opt/venv/bin/rasa", line 8, in <module>
deployment-rasa-production-1  |     sys.exit(main())
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/__main__.py", line 121, in main
deployment-rasa-production-1  |     cmdline_arguments.func(cmdline_arguments)
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/cli/x.py", line 364, in rasa_x
deployment-rasa-production-1  |     run_in_production(args)
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/cli/x.py", line 423, in run_in_production
deployment-rasa-production-1  |     _rasa_service(args, endpoints, None, credentials_path)
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/cli/x.py", line 90, in _rasa_service
deployment-rasa-production-1  |     serve_application(
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/core/run.py", line 178, in serve_application
deployment-rasa-production-1  |     app = configure_app(
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/core/run.py", line 103, in configure_app
deployment-rasa-production-1  |     app = server.create_app(
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/rasa/server.py", line 651, in create_app
deployment-rasa-production-1  |     Initialize(
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/sanic_jwt/initialization.py", line 133, in __init__
deployment-rasa-production-1  |     self.__load_configuration()
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/sanic_jwt/initialization.py", line 306, in __load_configuration
deployment-rasa-production-1  |     self.config = self.configuration_class(self.app.config, **self.kwargs)
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/sanic_jwt/configuration.py", line 283, in __init__
deployment-rasa-production-1  |     self._validate_secret()
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/sanic_jwt/configuration.py", line 308, in _validate_secret
deployment-rasa-production-1  |     if self.secret() is None or (
deployment-rasa-production-1  |   File "/opt/venv/lib/python3.8/site-packages/sanic_jwt/configuration.py", line 134, in __call__
deployment-rasa-production-1  |     if asyncio.get_event_loop().is_running():
deployment-rasa-production-1  |   File "/usr/lib/python3.8/asyncio/events.py", line 639, in get_event_loop
deployment-rasa-production-1  |     raise RuntimeError('There is no current event loop in thread %r.'
deployment-rasa-production-1  | RuntimeError: There is no current event loop in thread 'MainThread'.
```

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
