### PR TITLE
Analyse fluctuations on CPU

### DIFF
--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -3,6 +3,7 @@
 # - https://www.notion.so/rasa/Datadog-Usage-Documentation-422099c9a3a24f5a99d92d904537dd0b
 name: CI - Model Regression
 
+
 on:
   push:
     branches:

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -187,7 +187,7 @@ jobs:
           echo "GitHub runner image tag for TensorFlow ${{ env.TF_VERSION }} is ${GH_RUNNER_IMAGE_TAG}"
           echo GH_RUNNER_IMAGE_TAG=$GH_RUNNER_IMAGE_TAG >> $GITHUB_ENV
 
-          num_max_replicas=3
+          num_max_replicas=5
           matrix_length=${{ needs.read_test_configuration.outputs.matrix_length }}
           if [[ $matrix_length -gt $num_max_replicas ]]; then
             NUM_REPLICAS=$num_max_replicas
@@ -471,7 +471,7 @@ jobs:
       ACCELERATOR_TYPE: "CPU"
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
+      max-parallel: 10
       matrix: ${{fromJson(needs.read_test_configuration.outputs.matrix)}}
       fail-fast: false
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'runner:gpu') && github.repository == 'RasaHQ/rasa' && contains(github.event.pull_request.labels.*.name, 'status:model-regression-tests') && needs.read_test_configuration.outputs.configuration_id != '' }}


### PR DESCRIPTION
After [excluding downloading times](https://github.com/RasaHQ/rasa/pull/10834), we can re-investigate fluctuations in CPU vs GPU runtimes (train, test, total)

Related GPU PR: https://github.com/RasaHQ/rasa/pull/10876

**Findings:**
I analyzed fluctuations in CPU and GPU again, this time without the downloading of pretrained models (which isn't actually what we consider "training time").

High-level findings are:
- During training, running MR tests on github-hosted CPU fluctuates a lot (11%)
- During training, running MR tests on rasa-hosted GPU fluctuates moderately (4%)
- I see a similar trend during testing (CPU 10%, GPU 4%)
- The downloading pretrained influenced fluctuations only a little bit, but at least now it fluctuates approx. 1% less (in both CPU and GPU).

Here is the detailed analysis:
https://gist.github.com/markus-hinsche/a42cc4902eec1a893937262e0552fcfc

These findings will influence if/how well we can measure potential speedups of model training or testing that we are aiming to achieve.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
