### PR TITLE
fix: :bug: fix repeating session start when appending events via serv…

### DIFF
--- a/changelog/10865.bugfix.md
+++ b/changelog/10865.bugfix.md
@@ -1,0 +1,2 @@
+Fixed a bug where the `POST /conversations/testid/tracker/events` endpoint repeated
+session start events when appending events to a new tracker.

--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -226,12 +226,21 @@ def do_events_begin_with_session_start(events: List["Event"]) -> bool:
         events: The events to inspect.
 
     Returns:
-        Whether or not `events` begins with a session start sequence.
+        Whether `events` begins with a session start sequence.
     """
-    return len(events) > 1 and events[:2] == [
-        ActionExecuted(ACTION_SESSION_START_NAME),
-        SessionStarted(),
-    ]
+    if len(events) < 2:
+        return False
+
+    first = events[0]
+    second = events[1]
+
+    # We are not interested in specific metadata or timestamps. Action name and event
+    # type are sufficient for this check
+    return (
+        isinstance(first, ActionExecuted)
+        and first.action_name == ACTION_SESSION_START_NAME
+        and isinstance(second, SessionStarted)
+    )
 
 
 class Event(ABC):

--- a/tests/shared/core/test_events.py
+++ b/tests/shared/core/test_events.py
@@ -49,7 +49,7 @@ from rasa.shared.core.events import (
     LegacyFormValidation,
     format_message,
 )
-from rasa.shared.nlu.constants import INTENT_NAME_KEY
+from rasa.shared.nlu.constants import INTENT_NAME_KEY, METADATA_MODEL_ID
 from tests.core.policies.test_rule_policy import GREET_INTENT_NAME, UTTER_GREET_ACTION
 
 
@@ -552,6 +552,21 @@ def test_split_events(
                 ActionExecuted(ACTION_SESSION_START_NAME, timestamp=1),
                 SessionStarted(timestamp=2),
                 ActionExecuted(ACTION_LISTEN_NAME, timestamp=3),
+            ],
+            True,
+        ),
+        # also a session start, but with metadata
+        (
+            [
+                ActionExecuted(
+                    ACTION_SESSION_START_NAME,
+                    timestamp=1,
+                    metadata={METADATA_MODEL_ID: "123"},
+                ),
+                SessionStarted(timestamp=2, metadata={METADATA_MODEL_ID: "123"}),
+                ActionExecuted(
+                    ACTION_LISTEN_NAME, timestamp=3, metadata={METADATA_MODEL_ID: "123"}
+                ),
             ],
             True,
         ),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2122,3 +2122,40 @@ async def test_update_conversation_with_events(
         conversation_id, agent.processor, domain, events_to_append
     )
     assert list(fetched_tracker.events) == with_model_ids(expected_events, model_id)
+
+
+async def test_append_events_does_not_repeat_session_start(
+    rasa_app: SanicASGITestClient,
+):
+    session_start_events = [
+        {
+            "event": "action",
+            "timestamp": 1644577572.9639301,
+            "metadata": {"model_id": "f90a69066e4a438aa6edfbed5b529919"},
+            "name": "action_session_start",
+            "policy": None,
+            "confidence": 1.0,
+            "action_text": None,
+            "hide_rule_turn": False,
+        },
+        {
+            "event": "session_started",
+            "timestamp": 1644577572.963996,
+            "metadata": {"model_id": "f90a69066e4a438aa6edfbed5b529919"},
+        },
+        {
+            "event": "action",
+            "timestamp": 1644577572.964009,
+            "metadata": {"model_id": "f90a69066e4a438aa6edfbed5b529919"},
+            "name": "action_listen",
+            "policy": None,
+            "confidence": None,
+            "action_text": None,
+            "hide_rule_turn": False,
+        },
+    ]
+    _, response = await rasa_app.post(
+        "/conversations/testid/tracker/events", json=session_start_events
+    )
+
+    assert response.json["events"] == session_start_events


### PR DESCRIPTION
**Proposed changes**:
- Rasa Open Source failed to detect whether a session start was already part of a tracker when checking the events in the payload for the `POST "/conversations/<id>/tracker/events"` endpoint. The reason was that these events included metadata which made the equality check fail. We now only check for the required attributes

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
