### PR TITLE
Regr Tests: Add GPU NVML Interval

### DIFF
--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -12,6 +12,7 @@ env:
   TF_FORCE_GPU_ALLOW_GROWTH: true
   GITHUB_ISSUE_LABELS: '["type:bug :bug:", "tool:model-regression-tests"]'
   PERFORMANCE_DROP_THRESHOLD: -0.05
+  NVML_INTERVAL_IN_SEC: 1
 
 jobs:
   read_test_configuration:
@@ -240,7 +241,7 @@ jobs:
           TYPE: "${{ matrix.type }}"
           DATASET_REPOSITORY_BRANCH: "main"
         run: |
-          .github/scripts/start_dd_agent.sh "${{ secrets.DD_API_KEY }}" "${{ env.ACCELERATOR_TYPE }}"
+          .github/scripts/start_dd_agent.sh "${{ secrets.DD_API_KEY }}" "${{ env.ACCELERATOR_TYPE }}" ${{ env.NVML_INTERVAL_IN_SEC }}
 
       - name: Set up Python 3.8 🐍
         uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -21,6 +21,7 @@ env:
   GCLOUD_VERSION: "318.0.0"
   DD_PROFILING_ENABLED: false
   TF_FORCE_GPU_ALLOW_GROWTH: true
+  NVML_INTERVAL_IN_SEC: 1
 
 jobs:
   read_test_configuration:
@@ -339,7 +340,7 @@ jobs:
           DATASET_REPOSITORY_BRANCH: ${{ needs.read_test_configuration.outputs.dataset_branch }}
         run: |
           export PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${{ github.event.number }}"
-          .github/scripts/start_dd_agent.sh "${{ secrets.DD_API_KEY }}" "${{ env.ACCELERATOR_TYPE }}"
+          .github/scripts/start_dd_agent.sh "${{ secrets.DD_API_KEY }}" "${{ env.ACCELERATOR_TYPE }}" ${{ env.NVML_INTERVAL_IN_SEC }}
 
       - name: Set up Python 3.8 🐍
         uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
@@ -581,7 +582,7 @@ jobs:
           DATASET_REPOSITORY_BRANCH: ${{ matrix.dataset_branch }}
         run: |
           export PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${{ github.event.number }}"
-          .github/scripts/start_dd_agent.sh "${{ secrets.DD_API_KEY }}" "${{ env.ACCELERATOR_TYPE }}"
+          .github/scripts/start_dd_agent.sh "${{ secrets.DD_API_KEY }}" "${{ env.ACCELERATOR_TYPE }}" ${{ env.NVML_INTERVAL_IN_SEC }}
 
       - name: Set up Python 3.8 🐍
         uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a


### PR DESCRIPTION
After a [small investigation](https://app.datadoghq.eu/notebook/24825/interval-of-gpu-nvml-metrics-measurement), we see that it is possible to see more fine-grained GPU measurements. The datadog default interval was 15 seconds, in this PR we can set it to 1 second.

**Proposed changes**:
- Add `NVML_INTERVAL_IN_SEC` param to `start_dd_agent.sh`
- The `NVML_INTERVAL_IN_SEC` param can be set as a global env variable in regression tests

**Future work:**
- Consider putting parameter into `/modeltest` comment (to improve easy of use)

**Question for reviewers**
- What should the default interval be?

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
