### PR TITLE
use constant for training data version everywhere

### DIFF
--- a/rasa/core/migrate.py
+++ b/rasa/core/migrate.py
@@ -3,6 +3,8 @@ import shutil
 from pathlib import Path
 from typing import List, Dict, Text, Any, Tuple, Optional, Union
 
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
 import rasa.shared.utils.io
 import rasa.shared.utils.cli
 from rasa.shared.constants import REQUIRED_SLOTS_KEY, IGNORED_INTENTS
@@ -13,6 +15,7 @@ from rasa.shared.core.constants import (
     MAPPING_TYPE,
     SLOT_MAPPINGS,
 )
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.shared.core.domain import KEY_ENTITIES, KEY_SLOTS, KEY_FORMS, Domain
 from rasa.shared.exceptions import RasaException
 
@@ -172,7 +175,9 @@ def _assemble_new_domain(
         elif key == KEY_FORMS:
             new_domain.update({key: new_forms})
         elif key == "version":
-            new_domain.update({key: '"3.0"'})
+            new_domain.update(
+                {key: DoubleQuotedScalarString(LATEST_TRAINING_DATA_FORMAT_VERSION)}
+            )
         else:
             new_domain.update({key: value})
     return new_domain
@@ -226,7 +231,13 @@ def _migrate_domain_files(
 
         if KEY_SLOTS not in original_content and KEY_FORMS not in original_content:
             if isinstance(original_content, dict):
-                original_content.update({"version": '"3.0"'})
+                original_content.update(
+                    {
+                        "version": DoubleQuotedScalarString(
+                            LATEST_TRAINING_DATA_FORMAT_VERSION
+                        )
+                    }
+                )
 
             # this is done so that the other domain files can be moved
             # in the migrated directory

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -19,6 +19,8 @@ from typing import (
     Iterable,
 )
 
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
 from rasa.shared.constants import (
     DEFAULT_SESSION_EXPIRATION_TIME_IN_MINUTES,
     DEFAULT_CARRY_OVER_SLOTS_TO_NEW_SESSION,
@@ -1608,7 +1610,9 @@ class Domain:
         # thanks to the `should_preserve_key_order` argument
         # of `dump_obj_as_yaml_to_string`
         domain_data: Dict[Text, Any] = {
-            KEY_TRAINING_DATA_FORMAT_VERSION: LATEST_TRAINING_DATA_FORMAT_VERSION
+            KEY_TRAINING_DATA_FORMAT_VERSION: DoubleQuotedScalarString(
+                LATEST_TRAINING_DATA_FORMAT_VERSION
+            )
         }
         if clean_before_dump:
             domain_data.update(self.cleaned_domain())

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -9,6 +9,7 @@ from typing import Callable, Text
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import RunResult
 from rasa.cli import data
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.shared.importers.importer import TrainingDataImporter
 from rasa.validator import Validator
 import rasa.shared.utils.io
@@ -156,7 +157,7 @@ def test_validate_files_action_not_found_invalid_domain(
     file_name = tmp_path / f"{file_type}.yml"
     file_name.write_text(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         {file_type}:
         - {data_type}: test path
           steps:
@@ -183,7 +184,7 @@ def test_validate_files_form_not_found_invalid_domain(
     file_name = tmp_path / f"{file_type}.yml"
     file_name.write_text(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         {file_type}:
         - {data_type}: test path
           steps:
@@ -229,8 +230,8 @@ def test_validate_files_with_active_loop_null(tmp_path: Path):
 def test_validate_files_form_slots_not_matching(tmp_path: Path):
     domain_file_name = tmp_path / "domain.yml"
     domain_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         forms:
           name_form:
             required_slots:
@@ -290,7 +291,7 @@ def test_validate_files_invalid_slot_mappings(tmp_path: Path):
     slot_name = "started_booking_form"
     domain.write_text(
         f"""
-            version: "3.0"
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intents:
             - activate_booking
             entities:

--- a/tests/cli/test_rasa_test.py
+++ b/tests/cli/test_rasa_test.py
@@ -47,7 +47,7 @@ def test_test_core_warnings(run_in_simple_project_with_model: Callable[..., RunR
     )
 
     simple_test_story_yaml = """
-version: "3.0"
+version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: unlikely path
   steps:

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -10,7 +10,11 @@ from rasa.core.agent import Agent
 from rasa.core.policies.policy import PolicyPrediction
 from rasa.core.actions import action
 from rasa.core.actions.action import ActionExecutionRejection, ActionExtractSlots
-from rasa.shared.constants import REQUIRED_SLOTS_KEY, IGNORED_INTENTS
+from rasa.shared.constants import (
+    LATEST_TRAINING_DATA_FORMAT_VERSION,
+    REQUIRED_SLOTS_KEY,
+    IGNORED_INTENTS,
+)
 from rasa.shared.core.constants import ACTION_LISTEN_NAME, REQUESTED_SLOT
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel
@@ -119,7 +123,7 @@ async def test_switch_forms_with_same_slot(default_agent: Agent):
     utter_ask_form_2 = f"Please provide the value for {slot_a} of form 2"
 
     domain = f"""
-version: "3.0"
+version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 nlu:
 - intent: order_status
   examples: |
@@ -448,7 +452,7 @@ async def test_validate_slots(
     tracker = DialogueStateTracker.from_events(sender_id="bla", evts=events)
 
     domain = f"""
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
     entities:
     - num_tables
@@ -722,7 +726,7 @@ def test_temporary_tracker():
     sender_id = "test"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         slots:
           {extra_slot}:
             type: any
@@ -1407,8 +1411,8 @@ async def test_extract_other_slots_with_matched_mapping_conditions():
 
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intent:
             - greet
             - inform
@@ -1479,8 +1483,8 @@ async def test_extract_other_slots_raises_no_matched_conditions():
 
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intent:
             - greet
             - inform
@@ -1549,8 +1553,8 @@ async def test_extract_other_slots_raises_no_matched_conditions():
 
 async def test_action_extract_slots_custom_mapping_with_condition():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         slots:
           custom_slot:
@@ -1613,8 +1617,8 @@ async def test_action_extract_slots_custom_mapping_with_condition():
 async def test_form_slots_empty_with_restart():
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intent:
             - greet
             - inform

--- a/tests/core/actions/test_two_stage_fallback.py
+++ b/tests/core/actions/test_two_stage_fallback.py
@@ -4,7 +4,10 @@ import pytest
 
 from rasa.core.policies.policy import PolicyPrediction
 from rasa.core.processor import MessageProcessor
-from rasa.shared.constants import DEFAULT_NLU_FALLBACK_INTENT_NAME
+from rasa.shared.constants import (
+    DEFAULT_NLU_FALLBACK_INTENT_NAME,
+    LATEST_TRAINING_DATA_FORMAT_VERSION,
+)
 from rasa.core.actions.two_stage_fallback import TwoStageFallbackAction
 from rasa.core.channels import CollectingOutputChannel
 from rasa.shared.core.domain import Domain
@@ -156,7 +159,7 @@ async def test_ask_rephrase_after_failed_affirmation():
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
             utter_ask_rephrase:
             - text: {rephrase_text}

--- a/tests/core/nlg/test_response.py
+++ b/tests/core/nlg/test_response.py
@@ -5,6 +5,7 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 
 from rasa.core.nlg.response import TemplatedNaturalLanguageGenerator
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.slots import TextSlot, AnySlot, CategoricalSlot, BooleanSlot
 from rasa.shared.core.trackers import DialogueStateTracker
@@ -250,7 +251,7 @@ async def test_nlg_conditional_response_variations_with_diff_slot_types(
 async def test_nlg_non_matching_channel():
     domain = Domain.from_yaml(
         """
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     responses:
         utter_hi:
         - text: "Hello"
@@ -266,8 +267,8 @@ async def test_nlg_non_matching_channel():
 
 async def test_nlg_conditional_response_variations_with_none_slot():
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
             utter_action:
             - text: "text A"
@@ -288,8 +289,8 @@ async def test_nlg_conditional_response_variations_with_none_slot():
 
 async def test_nlg_conditional_response_variations_with_slot_not_a_constraint():
     domain = Domain.from_yaml(
-        """
-            version: "3.0"
+        f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             responses:
                 utter_action:
                 - text: "text A"
@@ -310,8 +311,8 @@ async def test_nlg_conditional_response_variations_with_slot_not_a_constraint():
 
 async def test_nlg_conditional_response_variations_with_null_slot():
     domain = Domain.from_yaml(
-        """
-                version: "3.0"
+        f"""
+                version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
                 responses:
                     utter_action:
                     - text: "text for null"
@@ -336,8 +337,8 @@ async def test_nlg_conditional_response_variations_with_null_slot():
 
 async def test_nlg_conditional_response_variations_channel_no_condition_met():
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
            utter_action:
              - text: "example with channel"
@@ -357,8 +358,8 @@ async def test_nlg_conditional_response_variations_channel_no_condition_met():
 
 async def test_nlg_conditional_response_variation_condition_met_channel_mismatch():
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
            utter_action:
              - text: "example with channel"
@@ -423,8 +424,8 @@ async def test_nlg_conditional_response_variation_condition_met_channel_mismatch
 )
 async def test_nlg_conditional_edgecases(slots, channel, expected_response):
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
            utter_action:
              - text: "condition example A with channel"
@@ -466,8 +467,8 @@ async def test_nlg_conditional_response_variations_condition_logging(
     caplog: LogCaptureFixture,
 ):
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
            utter_action:
              - text: "example"

--- a/tests/core/policies/test_rule_policy.py
+++ b/tests/core/policies/test_rule_policy.py
@@ -7,7 +7,10 @@ import pytest
 from rasa.engine.graph import ExecutionContext
 from rasa.engine.storage.resource import Resource
 from rasa.engine.storage.storage import ModelStorage
-from rasa.shared.constants import DEFAULT_NLU_FALLBACK_INTENT_NAME
+from rasa.shared.constants import (
+    DEFAULT_NLU_FALLBACK_INTENT_NAME,
+    LATEST_TRAINING_DATA_FORMAT_VERSION,
+)
 
 from rasa.core import training
 from rasa.core.actions.action import ActionDefaultFallback
@@ -149,7 +152,7 @@ def test_potential_contradiction_resolved_by_conversation_start(policy: RulePoli
     utter_anti_greet_action = "utter_anti_greet"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -202,7 +205,7 @@ def test_potential_contradiction_resolved_by_conversation_start_when_slot_initia
     some_slot_initial_value = "slot1value"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -275,7 +278,7 @@ def test_potential_contradiction_resolved_by_conversation_start_when_slot_initia
     some_slot_initial_value = "slot1value"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -340,7 +343,7 @@ def test_potential_contradiction_resolved_by_conversation_start_when_slot_initia
 def test_restrict_multiple_user_inputs_in_rules(policy: RulePolicy):
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -372,7 +375,7 @@ def test_incomplete_rules_due_to_slots(policy: RulePolicy):
     some_slot = "some_slot"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -442,7 +445,7 @@ def test_no_incomplete_rules_due_to_slots_after_listen(policy: RulePolicy):
     some_slot = "some_slot"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -504,7 +507,7 @@ def test_no_incomplete_rules_due_to_additional_slots_set(policy: RulePolicy):
     some_other_slot_value = "value2"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -559,7 +562,7 @@ def test_incomplete_rules_due_to_loops(policy: RulePolicy):
     some_form = "some_form"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         forms:
@@ -624,7 +627,7 @@ def test_contradicting_rules(policy: RulePolicy):
     utter_anti_greet_action = "utter_anti_greet"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -664,7 +667,7 @@ def test_contradicting_rules_and_stories(policy: RulePolicy):
     utter_anti_greet_action = "utter_anti_greet"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -808,7 +811,7 @@ def test_rule_policy_contradicting_rule_finetune(
 def test_faq_rule(policy: RulePolicy):
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -835,7 +838,7 @@ async def test_predict_form_action_if_in_form(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -880,7 +883,7 @@ async def test_predict_loop_action_if_in_loop_but_there_is_e2e_rule(policy: Rule
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -936,7 +939,7 @@ async def test_predict_form_action_if_multiple_turns(policy: RulePolicy):
     other_intent = "bye"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {other_intent}
@@ -1085,7 +1088,7 @@ async def test_predict_action_listen_after_form(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1132,7 +1135,7 @@ async def test_dont_predict_form_if_already_finished(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1183,7 +1186,7 @@ async def test_form_unhappy_path(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1228,7 +1231,7 @@ async def test_form_unhappy_path_from_general_rule(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1285,7 +1288,7 @@ async def test_form_unhappy_path_from_in_form_rule(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1361,7 +1364,7 @@ async def test_form_unhappy_path_from_story(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1438,7 +1441,7 @@ async def test_form_unhappy_path_no_validation_from_rule(
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1529,7 +1532,7 @@ async def test_form_unhappy_path_no_validation_from_story(policy: RulePolicy):
 
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1599,7 +1602,7 @@ async def test_form_unhappy_path_without_rule(policy: RulePolicy):
     other_intent = "bye"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {other_intent}
@@ -1645,7 +1648,7 @@ async def test_form_activation_rule(policy: RulePolicy):
     other_intent = "bye"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {other_intent}
@@ -1686,7 +1689,7 @@ async def test_failing_form_activation_due_to_no_rule(policy: RulePolicy):
     other_intent = "bye"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {other_intent}
@@ -1727,7 +1730,7 @@ def test_form_submit_rule(policy: RulePolicy):
     submit_action_name = "utter_submit"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1781,7 +1784,7 @@ def test_immediate_submit(policy: RulePolicy):
     slot = "some_slot"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1887,7 +1890,7 @@ async def test_rule_policy_slot_filling_from_text(
 async def test_one_stage_fallback_rule(policy: RulePolicy):
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {DEFAULT_NLU_FALLBACK_INTENT_NAME}
@@ -1970,7 +1973,7 @@ def test_default_actions(
 ):
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -1998,7 +2001,7 @@ def test_default_actions(
 def test_e2e_beats_default_actions(intent_name: Text, policy: RulePolicy):
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         actions:
@@ -2059,7 +2062,7 @@ def test_predict_core_fallback(
     other_intent = "other"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {other_intent}
@@ -2092,7 +2095,7 @@ def test_predict_nothing_if_fallback_disabled(
     other_intent = "other"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {other_intent}
@@ -2119,7 +2122,7 @@ def test_hide_rule_turn(policy: RulePolicy):
     action_chitchat = "action_chitchat"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {chitchat}
@@ -2199,7 +2202,7 @@ def test_hide_rule_turn_with_slots(
     some_other_slot_value = "value2"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {some_intent}
         - {some_other_intent}
@@ -2326,7 +2329,7 @@ def test_hide_rule_turn_no_last_action_listen(
     followup_on_chitchat = "followup_on_chitchat"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {chitchat}
         actions:
@@ -2414,7 +2417,7 @@ def test_hide_rule_turn_with_loops(
     action_chitchat = "action_chitchat"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {activate_form}
@@ -2522,7 +2525,7 @@ def test_do_not_hide_rule_turn_with_loops_in_stories(policy: RulePolicy):
     activate_form = "activate_form"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {activate_form}
         slots:
@@ -2577,7 +2580,7 @@ def test_hide_rule_turn_with_loops_as_followup_action(policy: RulePolicy):
     activate_form = "activate_form"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {GREET_INTENT_NAME}
         - {activate_form}
@@ -2681,7 +2684,7 @@ def test_remove_action_listen_prediction_if_contradicts_with_story(policy: RuleP
     utter_2 = "utter_2"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {intent_1}
         actions:
@@ -2726,7 +2729,7 @@ def test_keep_action_listen_prediction_after_predictable_action(policy: RulePoli
     utter_3 = "utter_3"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {intent_1}
         actions:
@@ -2772,7 +2775,7 @@ def test_keep_action_listen_prediction_if_last_prediction(policy: RulePolicy):
     utter_2 = "utter_2"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {intent_1}
         actions:
@@ -2813,7 +2816,7 @@ def test_keep_action_listen_prediction_if_contradicts_with_rule(policy: RulePoli
     utter_2 = "utter_2"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {intent_1}
         actions:
@@ -2856,7 +2859,7 @@ def test_raise_contradiction_if_rule_contradicts_with_story(policy: RulePolicy):
     utter_2 = "utter_2"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {intent_1}
         actions:
@@ -2898,7 +2901,7 @@ def test_rule_with_multiple_entities(policy: RulePolicy):
     utter_1 = "utter_1"
     domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {intent_1}
         entities:
@@ -2962,7 +2965,7 @@ def test_rule_with_multiple_slots(policy: RulePolicy):
     slot_2 = "slot_2"
     domain = Domain.from_yaml(
         f"""
-            version: "3.0"
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intents:
             - {intent_1}
             actions:
@@ -3030,7 +3033,7 @@ def test_include_action_unlikely_intent(policy: RulePolicy):
     slot_2 = "slot_2"
     domain = Domain.from_yaml(
         f"""
-                version: "3.0"
+                version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
                 intents:
                 - {intent_1}
                 actions:

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -55,7 +55,7 @@ from rasa.utils.tensorflow.constants import (
 from rasa.shared.nlu.constants import ACTION_NAME
 from rasa.utils.tensorflow import model_data_utils
 from tests.core.test_policies import PolicyTestCollection
-from rasa.shared.constants import DEFAULT_SENDER_ID
+from rasa.shared.constants import DEFAULT_SENDER_ID, LATEST_TRAINING_DATA_FORMAT_VERSION
 
 UTTER_GREET_ACTION = "utter_greet"
 GREET_INTENT_NAME = "greet"
@@ -226,8 +226,8 @@ class TestTEDPolicy(PolicyTestCollection):
     ):
         stories = tmp_path / "stories.yml"
         stories.write_text(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             stories:
             - story: test path
               steps:

--- a/tests/core/policies/test_unexpected_intent_policy.py
+++ b/tests/core/policies/test_unexpected_intent_policy.py
@@ -14,6 +14,7 @@ from rasa.core.featurizers.single_state_featurizer import (
 from rasa.core.featurizers.tracker_featurizers import TrackerFeaturizer
 from rasa.core.featurizers.tracker_featurizers import IntentMaxHistoryTrackerFeaturizer
 from rasa.nlu.classifiers import LABEL_RANKING_LENGTH
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.shared.core.generator import TrackerWithCachedStates
 from rasa.core.policies.ted_policy import PREDICTION_FEATURES
 from rasa.core.policies.unexpected_intent_policy import UnexpecTEDIntentPolicy
@@ -138,8 +139,8 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
     ):
         stories = tmp_path / "stories.yml"
         stories.write_text(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             stories:
             - story: test path
               steps:

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -27,7 +27,11 @@ from rasa.core.actions.action import (
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel, OutputChannel
 from rasa.core.nlg import NaturalLanguageGenerator
-from rasa.shared.constants import UTTER_PREFIX, REQUIRED_SLOTS_KEY
+from rasa.shared.constants import (
+    LATEST_TRAINING_DATA_FORMAT_VERSION,
+    UTTER_PREFIX,
+    REQUIRED_SLOTS_KEY,
+)
 from rasa.shared.core.domain import (
     ActionNotFoundException,
     SessionConfig,
@@ -1146,8 +1150,8 @@ async def test_action_extract_slots_predefined_mappings(
 ):
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intents:
             - inform
             - greet
@@ -1229,8 +1233,8 @@ async def test_action_extract_slots_predefined_mappings(
 async def test_action_extract_slots_with_from_trigger_mappings():
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intents:
             - greet
             - inform
@@ -1350,7 +1354,7 @@ async def test_action_extract_slots_with_list_slot(
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
     entities:
     - topping
@@ -1449,7 +1453,7 @@ async def test_action_extract_slots_with_matched_mapping_condition():
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
-            version: "3.0"
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intent:
             - greet
             - inform
@@ -1502,7 +1506,7 @@ async def test_action_extract_slots_no_matched_mapping_conditions():
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
-            version: "3.0"
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             intent:
             - greet
             - inform
@@ -1746,7 +1750,7 @@ async def test_extract_other_list_slot_from_entity(
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
     entities:
     - topping
@@ -1965,8 +1969,8 @@ async def test_action_extract_slots_execute_validation_action(
     expected_events: List[Event],
 ):
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         intents:
         - greet
@@ -2029,8 +2033,8 @@ async def test_action_extract_slots_execute_validation_action(
 
 async def test_action_extract_slots_custom_action_and_predefined_slot_validation():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         intents:
         - inform
@@ -2096,8 +2100,8 @@ async def test_action_extract_slots_custom_action_and_predefined_slot_validation
 
 async def test_action_extract_slots_with_duplicate_custom_actions():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         intents:
         - inform
@@ -2168,8 +2172,8 @@ async def test_action_extract_slots_with_duplicate_custom_actions():
 
 async def test_action_extract_slots_disallowed_events(caplog: LogCaptureFixture):
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         slots:
           custom_slot_one:
@@ -2232,8 +2236,8 @@ async def test_action_extract_slots_warns_custom_action_exceptions(
     caplog: LogCaptureFixture, exception: Exception
 ):
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         slots:
           custom_slot_one:
@@ -2278,8 +2282,8 @@ async def test_action_extract_slots_warns_custom_action_exceptions(
 
 async def test_action_extract_slots_with_empty_conditions():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         entities:
         - city
@@ -2312,8 +2316,8 @@ async def test_action_extract_slots_with_empty_conditions():
 
 async def test_action_extract_slots_with_not_existing_entity():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         entities:
         - city
@@ -2350,8 +2354,8 @@ async def test_action_extract_slots_with_not_existing_entity():
 
 async def test_action_extract_slots_with_not_existing_intent():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         intents:
         - greet
@@ -2389,8 +2393,8 @@ async def test_action_extract_slots_with_not_existing_intent():
 
 async def test_action_extract_slots_with_none_value_predefined_mapping():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         entities:
         - some_entity
@@ -2430,8 +2434,8 @@ async def test_action_extract_slots_with_none_value_predefined_mapping():
 
 async def test_action_extract_slots_with_none_value_custom_mapping():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         slots:
           custom_slot:
@@ -2473,8 +2477,8 @@ async def test_action_extract_slots_with_none_value_custom_mapping():
 
 async def test_action_extract_slots_returns_bot_uttered():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         slots:
           custom_slot:
@@ -2521,8 +2525,8 @@ async def test_action_extract_slots_does_not_raise_disallowed_warning_for_slot_e
     caplog: LogCaptureFixture,
 ):
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         slots:
           custom_slot_a:
@@ -2590,8 +2594,8 @@ async def test_action_extract_slots_does_not_raise_disallowed_warning_for_slot_e
 
 async def test_action_extract_slots_non_required_form_slot_with_from_entity_mapping():
     domain_yaml = textwrap.dedent(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         intents:
         - form_start

--- a/tests/core/test_evaluation.py
+++ b/tests/core/test_evaluation.py
@@ -184,7 +184,7 @@ async def test_end_to_evaluation_trips_circuit_breaker(
 ):
     config = textwrap.dedent(
         f"""
-    version: '{LATEST_TRAINING_DATA_FORMAT_VERSION}'
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     policies:
     - name: MemoizationPolicy
       max_history: 11

--- a/tests/core/test_migrate.py
+++ b/tests/core/test_migrate.py
@@ -12,6 +12,7 @@ import rasa.shared.utils.io
 from rasa.core import migrate
 from rasa.shared.core.domain import Domain
 from rasa.shared.exceptions import RasaException
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 
 def prepare_domain_path(directory: Path, domain_content: Text, file_name: Text) -> Path:
@@ -80,7 +81,7 @@ def test_migrate_domain_format_with_required_slots(
     migrated_domain = rasa.shared.utils.io.read_yaml_file(domain_out_file)
 
     migrated_training_data_version = migrated_domain.get("version")
-    assert migrated_training_data_version == '"3.0"'
+    assert migrated_training_data_version == LATEST_TRAINING_DATA_FORMAT_VERSION
 
     migrated_slots = migrated_domain.get("slots")
     expected_slots = {
@@ -348,7 +349,7 @@ def test_migrate_domain_format_from_dir(tmp_path: Path):
         migrated_file = rasa.shared.utils.io.read_yaml_file(file)
 
         migrated_training_data_version = migrated_file.get("version")
-        assert migrated_training_data_version == '"3.0"'
+        assert migrated_training_data_version == LATEST_TRAINING_DATA_FORMAT_VERSION
 
 
 def test_migrate_domain_all_keys(tmp_path: Path, domain_out_file: Path):
@@ -396,7 +397,7 @@ def test_migrate_domain_all_keys(tmp_path: Path, domain_out_file: Path):
     assert "action_check_time" in migrated_actions
 
     migrated_training_data_version = migrated_domain.get("version")
-    assert migrated_training_data_version == '"3.0"'
+    assert migrated_training_data_version == LATEST_TRAINING_DATA_FORMAT_VERSION
 
 
 def test_migrate_domain_format_with_custom_slot(tmp_path: Path, domain_out_file: Path):
@@ -767,7 +768,7 @@ def test_migrate_domain_from_dir_with_other_sections(tmp_path: Path):
         migrated = rasa.shared.utils.io.read_yaml_file(file)
 
         migrated_training_data_version = migrated.get("version")
-        assert migrated_training_data_version == '"3.0"'
+        assert migrated_training_data_version == LATEST_TRAINING_DATA_FORMAT_VERSION
 
         if file.name == domain_file_one:
             assert migrated.get("entities") == ["outdoor"]

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1247,7 +1247,7 @@ async def test_predict_next_action_with_hidden_rules(
     story_slot = "story_slot"
     domain_content = textwrap.dedent(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - {rule_intent}
         - {story_intent}

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -248,8 +248,8 @@ async def test_action_unlikely_intent_warning(
 
     file_name = tmp_path / "test_action_unlikely_intent_1.yml"
     file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: unlikely path
             steps:
@@ -297,8 +297,8 @@ async def test_action_unlikely_intent_correctly_predicted(
 
     file_name = tmp_path / "test_action_unlikely_intent_2.yml"
     file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: unlikely path (with action_unlikely_intent)
             steps:
@@ -342,8 +342,8 @@ async def test_wrong_action_after_action_unlikely_intent(
 
     test_file_name = tmp_path / "test.yml"
     test_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: happy path
             steps:
@@ -360,8 +360,8 @@ async def test_wrong_action_after_action_unlikely_intent(
 
     train_file_name = tmp_path / "train.yml"
     train_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: happy path
             steps:
@@ -411,8 +411,8 @@ async def test_action_unlikely_intent_not_found(
 ):
     test_file_name = tmp_path / "test_action_unlikely_intent_complete.yml"
     test_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: happy path
             steps:
@@ -430,8 +430,8 @@ async def test_action_unlikely_intent_not_found(
 
     train_file_name = tmp_path / "train_without_action_unlikely_intent.yml"
     train_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: happy path
             steps:
@@ -478,8 +478,8 @@ async def test_action_unlikely_intent_warning_and_story_error(
 
     test_file_name = tmp_path / "test.yml"
     test_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: happy path
             steps:
@@ -496,8 +496,8 @@ async def test_action_unlikely_intent_warning_and_story_error(
 
     train_file_name = tmp_path / "train.yml"
     train_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: happy path
             steps:
@@ -545,8 +545,8 @@ async def test_fail_on_prediction_errors(
 
     file_name = tmp_path / "test_action_unlikely_intent_2.yml"
     file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
           - story: unlikely path (with action_unlikely_intent)
             steps:

--- a/tests/core/training/test_interactive.py
+++ b/tests/core/training/test_interactive.py
@@ -21,6 +21,7 @@ from rasa.shared.constants import (
     INTENT_MESSAGE_PREFIX,
     DEFAULT_SENDER_ID,
     DOCS_URL_POLICIES,
+    LATEST_TRAINING_DATA_FORMAT_VERSION,
 )
 from rasa.shared.core.constants import ACTION_LISTEN_NAME, ACTION_UNLIKELY_INTENT_NAME
 from rasa.shared.core.domain import Domain
@@ -573,7 +574,7 @@ async def test_write_domain_to_file_with_form(tmp_path: Path):
     form_name = "my_form"
     old_domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         actions:
         - utter_greet
         - utter_goodbye

--- a/tests/nlu/extractors/test_extractor.py
+++ b/tests/nlu/extractors/test_extractor.py
@@ -1,6 +1,7 @@
 from typing import Any, Text, Dict, List
 
 import pytest
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 from rasa.shared.nlu.constants import TEXT, SPLIT_ENTITIES_BY_COMMA
 from rasa.shared.nlu.training_data.message import Message
@@ -419,7 +420,7 @@ def test_split_entities_by_comma(
     "text, warnings",
     [
         (
-            'version: "3.0"\n'
+            f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"\n'
             "nlu:\n"
             "- intent: test\n"
             "  examples: |\n"
@@ -427,7 +428,7 @@ def test_split_entities_by_comma(
             1,
         ),
         (
-            'version: "3.0"\n'
+            f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"\n'
             "nlu:\n"
             "- intent: test\n"
             "  examples: |\n"
@@ -435,7 +436,7 @@ def test_split_entities_by_comma(
             1,
         ),
         (
-            'version: "3.0"\n'
+            f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"\n'
             "nlu:\n"
             "- intent: test\n"
             "  examples: |\n"
@@ -444,7 +445,7 @@ def test_split_entities_by_comma(
             1,
         ),
         (
-            'version: "3.0"\n'
+            f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"\n'
             "nlu:\n"
             "- intent: test\n"
             "  examples: |\n"
@@ -453,7 +454,7 @@ def test_split_entities_by_comma(
             1,
         ),
         (
-            'version: "3.0"\n'
+            f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"\n'
             "nlu:\n"
             "- intent: test\n"
             "  examples: |\n"

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -178,8 +178,8 @@ def test_domain_from_template(domain: Domain):
 
 def test_avoid_action_repetition(domain: Domain):
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         actions:
         - utter_greet
         responses:
@@ -494,8 +494,8 @@ session_config:
 
 def test_merge_with_empty_domain():
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         config:
           store_entities_as_slots: false
         session_config:
@@ -526,8 +526,8 @@ def test_merge_with_empty_domain():
 @pytest.mark.parametrize("other", [Domain.empty(), None])
 def test_merge_with_empty_other_domain(other: Optional[Domain]):
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         config:
           store_entities_as_slots: false
         session_config:
@@ -1171,7 +1171,7 @@ def test_not_add_knowledge_base_slots():
 def test_add_knowledge_base_slots():
     test_domain = Domain.from_yaml(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         actions:
         - {DEFAULT_KNOWLEDGE_BASE_ACTION}
         """
@@ -1488,8 +1488,8 @@ def test_form_invalid_mappings(domain_as_dict: Dict[Text, Any]):
 def test_form_invalid_required_slots_raises():
     with pytest.raises(YamlValidationException):
         Domain.from_yaml(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             entities:
             - some_entity
             forms:
@@ -1557,23 +1557,23 @@ def test_slot_invalid_mappings(domain_as_dict: Dict[Text, Any]):
     [
         # Wrong type for slots
         (
-            """
-        version: "3.0"
+            f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         slots:
           []
         """
         ),
         # Wrong type for slot names
         (
-            """
-        version: "3.0"
+            f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         slots:
           some_slot: 5
         """
         ),
         (
-            """
-        version: "3.0"
+            f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         slots:
           some_slot: []
         """
@@ -1586,7 +1586,7 @@ def test_invalid_slots_raises_yaml_exception(domain_yaml: Text):
 
 
 def test_slot_order_is_preserved():
-    test_yaml = f"""version: '{LATEST_TRAINING_DATA_FORMAT_VERSION}'
+    test_yaml = f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 session_config:
   session_expiration_time: 60
   carry_over_slots_to_new_session: true
@@ -1675,7 +1675,7 @@ slots:{slot_1}
 slots:{slot_2}
 """
 
-    test_yaml_merged = f"""version: '{LATEST_TRAINING_DATA_FORMAT_VERSION}'
+    test_yaml_merged = f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 session_config:
   session_expiration_time: 60
   carry_over_slots_to_new_session: true
@@ -1690,7 +1690,7 @@ slots:{slot_2}{slot_1}
 
 
 def test_responses_text_multiline_is_preserved():
-    test_yaml = f"""version: '{LATEST_TRAINING_DATA_FORMAT_VERSION}'
+    test_yaml = f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 session_config:
   session_expiration_time: 60
   carry_over_slots_to_new_session: true
@@ -1792,8 +1792,8 @@ def test_domain_count_conditional_response_variations():
 
 def test_domain_with_no_form_slots():
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         forms:
          contract_form:
           required_slots: []
@@ -1805,8 +1805,8 @@ def test_domain_with_no_form_slots():
 def test_domain_with_empty_required_slots():
     with pytest.raises(YamlException):
         Domain.from_yaml(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             forms:
               contract_form:
             """
@@ -1881,8 +1881,8 @@ def test_domain_duplicates_when_one_domain_file():
 
 
 def test_domain_fingerprint_consistency_across_runs():
-    domain_yaml = """
-         version: "3.0"
+    domain_yaml = f"""
+         version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
          intents:
          - greet
          - goodbye
@@ -1914,8 +1914,8 @@ def test_domain_fingerprint_consistency_across_runs():
 
 def test_domain_fingerprint_uniqueness():
     domain = Domain.from_yaml(
-        """
-         version: "3.0"
+        f"""
+         version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
          intents:
          - greet
          - goodbye
@@ -1926,8 +1926,8 @@ def test_domain_fingerprint_uniqueness():
     f1 = domain.fingerprint()
 
     domain_with_extra_intent = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - greet
         - goodbye
@@ -1940,8 +1940,8 @@ def test_domain_fingerprint_uniqueness():
     assert f1 != f2
 
     domain_with_extra_action = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - greet
         - goodbye
@@ -1954,8 +1954,8 @@ def test_domain_fingerprint_uniqueness():
     assert f1 != f3
 
     domain_with_extra_responses = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - greet
         - goodbye
@@ -1973,8 +1973,8 @@ def test_domain_fingerprint_uniqueness():
 def test_domain_slots_for_entities_with_mapping_conditions_no_slot_set():
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             entities:
             - city
             slots:
@@ -2000,8 +2000,8 @@ def test_domain_slots_for_entities_with_mapping_conditions_no_slot_set():
 def test_domain_slots_for_entities_sets_valid_slot():
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             entities:
             - city
             slots:
@@ -2021,8 +2021,8 @@ def test_domain_slots_for_entities_sets_valid_slot():
 def test_domain_slots_for_entities_sets_valid_list_slot():
     domain = Domain.from_yaml(
         textwrap.dedent(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             entities:
             - topping
             slots:
@@ -2046,8 +2046,8 @@ def test_domain_slots_for_entities_sets_valid_list_slot():
 
 def test_domain_slots_for_entities_with_entity_mapping_to_multiple_slots():
     domain = Domain.from_yaml(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         entities:
         - city
         slots:

--- a/tests/shared/core/test_slot_mappings.py
+++ b/tests/shared/core/test_slot_mappings.py
@@ -1,6 +1,7 @@
 from typing import Text
 
 import pytest
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import UserUttered, ActiveLoop
@@ -68,7 +69,7 @@ def test_slot_mapping_intent_is_desired(domain: Domain):
 def test_slot_mappings_ignored_intents_during_active_loop():
     domain = Domain.from_yaml(
         """
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     intents:
     - greet
     - chitchat
@@ -104,8 +105,8 @@ def test_slot_mappings_ignored_intents_during_active_loop():
 def test_missing_slot_mappings_raises():
     with pytest.raises(YamlValidationException):
         Domain.from_yaml(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             slots:
               some_slot:
                 type: text
@@ -117,8 +118,8 @@ def test_missing_slot_mappings_raises():
 def test_slot_mappings_invalid_type_raises():
     with pytest.raises(YamlValidationException):
         Domain.from_yaml(
-            """
-            version: "3.0"
+            f"""
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             entities:
             - from_entity
             slots:

--- a/tests/shared/core/test_trackers.py
+++ b/tests/shared/core/test_trackers.py
@@ -25,7 +25,7 @@ from rasa.shared.core.constants import (
     REQUESTED_SLOT,
     LOOP_INTERRUPTED,
 )
-from rasa.shared.constants import DEFAULT_SENDER_ID
+from rasa.shared.constants import DEFAULT_SENDER_ID, LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.core.agent import Agent
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
@@ -1378,7 +1378,7 @@ async def test_fill_slots_for_policy_entities():
     domain = Domain.from_yaml(
         textwrap.dedent(
             f"""
-            version: "3.0"
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             entities:
             - {nlu_entity}
             - {policy_entity}

--- a/tests/shared/core/training_data/story_writer/test_yaml_story_writer.py
+++ b/tests/shared/core/training_data/story_writer/test_yaml_story_writer.py
@@ -3,6 +3,7 @@ import textwrap
 from typing import Text
 from collections import OrderedDict
 import pytest
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 from rasa.shared.core.constants import (
     ACTION_SESSION_START_NAME,
@@ -87,8 +88,8 @@ def test_yaml_writer_dumps_user_messages():
     assert (
         dump.strip()
         == textwrap.dedent(
-            """
-        version: "3.0"
+            f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: default
           steps:
@@ -115,8 +116,8 @@ def test_yaml_writer_doesnt_dump_action_unlikely_intent():
     assert (
         dump.strip()
         == textwrap.dedent(
-            """
-    version: "3.0"
+            f"""
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     stories:
     - story: default
       steps:
@@ -139,8 +140,8 @@ def test_yaml_writer_avoids_dumping_not_existing_user_messages():
     assert (
         dump.strip()
         == textwrap.dedent(
-            """
-        version: "3.0"
+            f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: default
           steps:
@@ -198,7 +199,7 @@ def test_yaml_writer_stories_to_yaml_with_null_entities(domain: Domain):
     writer = YAMLStoryWriter()
     stories = textwrap.dedent(
         """
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     stories:
     - story: happy path
       steps:
@@ -251,7 +252,7 @@ def test_writing_end_to_end_stories(domain: Domain):
         dump.strip()
         == textwrap.dedent(
             f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: {story_name}
           steps:
@@ -298,7 +299,7 @@ stories:
         dump.strip()
         == textwrap.dedent(
             f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: {story_name}
           steps:

--- a/tests/shared/core/training_data/test_structures.py
+++ b/tests/shared/core/training_data/test_structures.py
@@ -1,4 +1,5 @@
 import rasa.core
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.shared.core.constants import ACTION_SESSION_START_NAME
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.events import (
@@ -41,7 +42,7 @@ def test_session_start_is_not_serialised(domain: Domain):
         Story.from_events(tracker.events, "some-story01").story_steps
     )
 
-    expected = """version: "3.0"
+    expected = f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-story01
   steps:

--- a/tests/shared/utils/test_validation.py
+++ b/tests/shared/utils/test_validation.py
@@ -50,8 +50,8 @@ def test_validate_yaml_schema_raise_exception(file: Text, schema: Text):
 
 
 def test_validate_yaml_schema_raise_exception_null_text():
-    domain = """
-    version: "3.0"
+    domain = f"""
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     responses:
       utter_ask_email:
       - text: What is your email ID?
@@ -68,8 +68,8 @@ def test_validate_yaml_schema_raise_exception_null_text():
 
 
 def test_validate_yaml_schema_raise_exception_extra_hyphen_for_image():
-    domain = """
-        version: "3.0"
+    domain = f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         responses:
           utter_cheer_up:
           - image: https://i.imgur.com/nGF1K8f.jpg
@@ -225,8 +225,8 @@ def test_concurrent_schema_validation():
     successful_results = []
 
     def validate() -> None:
-        payload = """
-version: "3.0"
+        payload = f"""
+version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 nlu:
 - intent: greet
   examples: |

--- a/tests/test_model_testing.py
+++ b/tests/test_model_testing.py
@@ -32,6 +32,7 @@ from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_TYPE,
     ENTITY_ATTRIBUTE_TEXT,
 )
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 
 def monkeypatch_get_latest_model(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -382,8 +383,8 @@ def test_write_classification_errors():
     assert (
         dump.strip()
         == textwrap.dedent(
-            """
-        version: "3.0"
+            f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: default
           steps:

--- a/tests/test_model_training.py
+++ b/tests/test_model_training.py
@@ -33,6 +33,7 @@ from rasa.shared.data import TrainingType
 
 
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 import rasa.shared.utils.io
 from rasa.shared.core.domain import Domain
 from rasa.shared.exceptions import InvalidConfigException
@@ -963,7 +964,7 @@ def test_invalid_graph_schema(
 ):
     config = textwrap.dedent(
         """
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     recipe: "default.v1"
 
     pipeline:
@@ -1003,7 +1004,7 @@ def test_fingerprint_changes_if_module_changes(
 
     config = textwrap.dedent(
         f"""
-    version: "3.0"
+    version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
     recipe: "default.v1"
 
     policies:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,6 +70,7 @@ from rasa.shared.nlu.constants import (
     ENTITY_ATTRIBUTE_VALUE,
     PREDICTED_CONFIDENCE_KEY,
 )
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.model_training import TrainingResult
 from rasa.utils.endpoints import EndpointConfig
 from tests.conftest import AsyncMock, with_model_id, with_model_ids
@@ -576,8 +577,8 @@ def assert_trained_model(
 async def test_train_with_yaml(
     rasa_app: SanicASGITestClient, tmp_path_factory: TempPathFactory
 ):
-    training_data = """
-version: "3.0"
+    training_data = f"""
+version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
 stories:
 - story: My story
@@ -1811,7 +1812,7 @@ def test_app_when_app_has_no_input_channels():
             ],
             None,
             True,
-            """version: "3.0"
+            f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID
   steps:
@@ -1834,7 +1835,7 @@ stories:
             ],
             None,
             True,
-            """version: "3.0"
+            f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID, story 1
   steps:
@@ -1864,7 +1865,7 @@ stories:
             ],
             None,
             False,
-            """version: "3.0"
+            f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID
   steps:
@@ -1888,7 +1889,7 @@ stories:
             ],
             None,
             None,
-            """version: "3.0"
+            f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID
   steps:
@@ -1911,7 +1912,7 @@ stories:
             ],
             4,
             True,
-            """version: "3.0"
+            f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID
   steps:
@@ -1921,7 +1922,7 @@ stories:
   - action: utter_greet""",
         ),
         # empty conversation
-        ([], None, True, 'version: "3.0"'),
+        ([], None, True, f'version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"'),
         # Conversation with slot
         (
             [
@@ -1933,7 +1934,7 @@ stories:
             ],
             None,
             True,
-            """version: "3.0"
+            f"""version: "{rasa.shared.constants.LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID
   steps:
@@ -2037,7 +2038,7 @@ async def test_get_story_does_not_update_conversation_session(
     # expected story is returned
     assert (
         response.content.decode().strip()
-        == """version: "3.0"
+        == f"""version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 stories:
 - story: some-conversation-ID
   steps:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,6 +2,7 @@ from typing import Text, Any, Optional, List, Dict
 
 import pytest
 from _pytest.logging import LogCaptureFixture
+from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 
 from rasa.validator import Validator
 
@@ -111,8 +112,8 @@ def test_verify_bad_story_structure():
 def test_verify_bad_e2e_story_structure_when_text_identical(tmp_path: Path):
     story_file_name = tmp_path / "stories.yml"
     story_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: path 1
           steps:
@@ -310,8 +311,8 @@ def test_verify_there_is_not_example_repetition_in_intents():
 def test_verify_actions_in_stories_not_in_domain(tmp_path: Path, domain_path: Text):
     story_file_name = tmp_path / "stories.yml"
     story_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         stories:
         - story: story path 1
           steps:
@@ -337,8 +338,8 @@ def test_verify_actions_in_stories_not_in_domain(tmp_path: Path, domain_path: Te
 def test_verify_actions_in_rules_not_in_domain(tmp_path: Path, domain_path: Text):
     rules_file_name = tmp_path / "rules.yml"
     rules_file_name.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         rules:
         - rule: rule path 1
           steps:
@@ -435,8 +436,8 @@ def test_verify_domain_with_duplicates(
 def test_verify_form_slots_invalid_domain(tmp_path: Path):
     domain = tmp_path / "domain.yml"
     domain.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         forms:
           name_form:
             required_slots:
@@ -494,8 +495,8 @@ def test_valid_stories_rules_actions_in_domain(
 ):
     domain = tmp_path / "domain.yml"
     domain.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - greet
         actions:
@@ -505,7 +506,7 @@ def test_valid_stories_rules_actions_in_domain(
     file_name = tmp_path / f"{file_name}.yml"
     file_name.write_text(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         {file_name}:
         - {data_type}: test path
           steps:
@@ -526,8 +527,8 @@ def test_valid_stories_rules_default_actions(
 ):
     domain = tmp_path / "domain.yml"
     domain.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - greet
         """
@@ -535,7 +536,7 @@ def test_valid_stories_rules_default_actions(
     file_name = tmp_path / f"{file_name}.yml"
     file_name.write_text(
         f"""
-            version: "3.0"
+            version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
             {file_name}:
             - {data_type}: test path
               steps:
@@ -551,8 +552,8 @@ def test_valid_stories_rules_default_actions(
 def test_valid_form_slots_in_domain(tmp_path: Path):
     domain = tmp_path / "domain.yml"
     domain.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         forms:
           name_form:
             required_slots:
@@ -579,7 +580,7 @@ def test_verify_slot_mappings_mapping_active_loop_not_in_forms(tmp_path: Path):
     slot_name = "some_slot"
     domain.write_text(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         entities:
         - some_entity
         slots:
@@ -615,7 +616,7 @@ def test_verify_slot_mappings_from_trigger_intent_mapping_slot_not_in_forms(
     slot_name = "started_booking_form"
     domain.write_text(
         f"""
-        version: "3.0"
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - activate_booking
         entities:
@@ -652,8 +653,8 @@ def test_verify_slot_mappings_from_trigger_intent_mapping_slot_not_in_forms(
 def test_verify_slot_mappings_slot_with_mapping_conditions_not_in_form(tmp_path: Path):
     domain = tmp_path / "domain.yml"
     domain.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - activate_booking
         entities:
@@ -693,8 +694,8 @@ def test_verify_slot_mappings_slot_with_mapping_conditions_not_in_form(tmp_path:
 def test_verify_slot_mappings_valid(tmp_path: Path):
     domain = tmp_path / "domain.yml"
     domain.write_text(
-        """
-        version: "3.0"
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
         intents:
         - activate_booking
         entities:


### PR DESCRIPTION
**Proposed changes**:
- Reference the constant `LATEST_TRAINING_DATA_FORMAT_VERSION` everywhere instead of hardcoding `"3.0"`. This makes it simpler to bump the training data version in the future (will be required soon).

**Status (please check what you already did)**:
- [x] updated some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
