### PR TITLE
Regr Tests: Get VM type tag

### DIFF
--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -85,6 +85,9 @@ def get_vm_type() -> Dict[Text, Text]:
         machine_type_full = requests.get(
             metadata_server + "machine-type", headers=metadata_flavor
         ).text
+        print(f'machine_type_full: {machine_type_full}')
+        # Debug
+        print('gce_name', socket.gethostname())
 
     except requests.exceptions.ConnectionError:  # not a GCP instance
         print('This VM was identified as not being a GCP instance')

--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -87,8 +87,10 @@ def get_vm_type() -> Dict[Text, Text]:
         ).text
 
     except requests.exceptions.ConnectionError:  # not a GCP instance
+        print('This VM was identified as not being a GCP instance')
+        print(f'hostname: {hostname}')
         hostname = socket.gethostname()
-        if "-az-" in hostname:
+        if "-az" in hostname:
             machine_type_full = "azure/Standard_DS2_v2"
         else:  # neigther GCP nor Azure instance
             machine_type_full = "unknown"

--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -83,7 +83,7 @@ def get_vm_type() -> Dict[Text, Text]:
         metadata_server = "http://metadata/computeMetadata/v1/instance/"
         metadata_flavor = {'Metadata-Flavor' : 'Google'}
         machine_type_full = requests.get(metadata_server + 'machine-type',
-                                         headers = metadata_flavor).text
+                                         headers=metadata_flavor).text
 
     except ConnectionError:  # not a GCP instance
         hostname = socket.gethostname()

--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -86,7 +86,7 @@ def get_vm_type() -> Dict[Text, Text]:
             metadata_server + "machine-type", headers=metadata_flavor
         ).text
 
-    except ConnectionError:  # not a GCP instance
+    except requests.exceptions.ConnectionError:  # not a GCP instance
         hostname = socket.gethostname()
         if "-az-" in hostname:
             machine_type_full = "azure/Standard_DS2_v2"

--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -81,23 +81,24 @@ def get_vm_type() -> Dict[Text, Text]:
     try:
         # Stolen from https://stackoverflow.com/a/31689692/5497962
         metadata_server = "http://metadata/computeMetadata/v1/instance/"
-        metadata_flavor = {'Metadata-Flavor' : 'Google'}
-        machine_type_full = requests.get(metadata_server + 'machine-type',
-                                         headers=metadata_flavor).text
+        metadata_flavor = {"Metadata-Flavor": "Google"}
+        machine_type_full = requests.get(
+            metadata_server + "machine-type", headers=metadata_flavor
+        ).text
 
     except ConnectionError:  # not a GCP instance
         hostname = socket.gethostname()
-        if '-az-' in hostname:
-            machine_type_full = 'azure/Standard_DS2_v2'
+        if "-az-" in hostname:
+            machine_type_full = "azure/Standard_DS2_v2"
         else:  # neigther GCP nor Azure instance
-            machine_type_full = 'unknown'
+            machine_type_full = "unknown"
     except Exception as e:
         print(e)
-        machine_type_full = 'unknown'
+        machine_type_full = "unknown"
 
     return {
-        'machine_type': machine_type_full.split('/')[-1],
-        'machine_type_full': machine_type_full,
+        "machine_type": machine_type_full.split("/")[-1],
+        "machine_type_full": machine_type_full,
     }
 
 

--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -88,8 +88,8 @@ def get_vm_type() -> Dict[Text, Text]:
 
     except requests.exceptions.ConnectionError:  # not a GCP instance
         print('This VM was identified as not being a GCP instance')
-        print(f'hostname: {hostname}')
         hostname = socket.gethostname()
+        print(f'hostname: {hostname}')
         if "-az" in hostname:
             machine_type_full = "azure/Standard_DS2_v2"
         else:  # neigther GCP nor Azure instance


### PR DESCRIPTION
**Status quo**: We already some environment information:
- metrics: CPU cores, total memory available
- tags: zone, host name (e.g. kub cluster name/id) for most metrics

**Intention of this PR**: It would be good to also have the VM type (e.g. on GCP) available as a tag in Datadog. This would allow to filter/order the data in Datadog even better.

**Proposed changes**:
- Get VM type
- Add to datadog tags

**Caveats:**
- The current code about finding the GCP VM type doesn't work in our setup
- The current code we rely on the cloud provider API(s)
- The VM type of Azure is hardcode (would be incorrect if GitHub/azure ever changed there implementation)

Ideas for solutions are welcome