### PR TITLE
Sunset Segment/Metabase for regression tests

### DIFF
--- a/.github/scripts/mr_publish_results.py
+++ b/.github/scripts/mr_publish_results.py
@@ -1,4 +1,4 @@
-# Send model regression test results to Segment and Datadog
+# Send model regression test results to Datadog
 # with a summary of all test results.
 # Also write them into a report file.
 import copy
@@ -7,7 +7,6 @@ import json
 import os
 from typing import Any, Dict, List, Text, Tuple
 
-import analytics
 from datadog_api_client.v1 import ApiClient, Configuration
 from datadog_api_client.v1.api.metrics_api import MetricsApi
 from datadog_api_client.v1.model.metrics_payload import MetricsPayload
@@ -26,14 +25,6 @@ TASK_MAPPING = {
     "DIETClassifier_report.json": "entity_prediction",
     "response_selection_report.json": "response_selection",
     "story_report.json": "story_prediction",
-}
-
-TASK_MAPPING_SEGMENT = {
-    "intent_report.json": "Intent Classification",
-    "CRFEntityExtractor_report.json": "Entity Prediction",
-    "DIETClassifier_report.json": "Entity Prediction",
-    "response_selection_report.json": "Response Selection",
-    "story_report.json": "Story Prediction",
 }
 
 METRICS = {
@@ -226,27 +217,6 @@ def send_to_datadog(results: List[Dict[Text, Any]]) -> None:
             print(response)
 
 
-def _send_to_segment(context: Dict[Text, Any]) -> None:
-    jobID = os.environ["GITHUB_RUN_ID"]
-    analytics.identify(
-        jobID, {"name": "model-regression-tests", "created_at": datetime.datetime.now()}
-    )
-
-    analytics.track(
-        jobID,
-        "results",
-        {
-            "config_repository": CONFIG_REPOSITORY,
-            **prepare_datasetrepo_and_external_tags(),
-            **create_dict_of_env(METRICS),
-            **create_dict_of_env(MAIN_TAGS),
-            **create_dict_of_env(OTHER_TAGS),
-            **create_dict_of_env(GIT_RELATED_TAGS),
-            **context,
-        },
-    )
-
-
 def read_results(file: Text) -> Dict[Text, Any]:
     with open(file) as json_file:
         data = json.load(json_file)
@@ -270,12 +240,6 @@ def get_result(file_name: Text, file: Text) -> Dict[Text, Any]:
     return result
 
 
-def _push_results_to_segment(file_name: Text, file: Text) -> None:
-    result = get_result(file_name, file)
-    result["task"] = TASK_MAPPING_SEGMENT[file_name]
-    _send_to_segment(result)
-
-
 def send_all_to_datadog() -> None:
     results = []
     for dirpath, dirnames, files in os.walk(os.environ["RESULT_DIR"]):
@@ -284,17 +248,6 @@ def send_all_to_datadog() -> None:
                 result = get_result(f, os.path.join(dirpath, f))
                 results.append(result)
     send_to_datadog(results)
-
-
-def send_all_results_to_segment() -> None:
-    analytics.write_key = os.environ["SEGMENT_TOKEN"]
-    for dirpath, dirnames, files in os.walk(os.environ["RESULT_DIR"]):
-        for f in files:
-            if any(
-                f.endswith(valid_name) for valid_name in TASK_MAPPING_SEGMENT.keys()
-            ):
-                _push_results_to_segment(f, os.path.join(dirpath, f))
-    analytics.flush()
 
 
 def generate_json(file: Text, task: Text, data: dict) -> dict:
@@ -336,5 +289,4 @@ def create_report_file() -> None:
 
 if __name__ == "__main__":
     send_all_to_datadog()
-    send_all_results_to_segment()
     create_report_file()

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -324,7 +324,7 @@ jobs:
             echo "::set-output name=total_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
           fi
 
-      - name: Generate a JSON file with a report / Publish results to Segment + Datadog
+      - name: Generate a JSON file with a report / Publish results to Datadog
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         env:
           SUMMARY_FILE: "./report.json"

--- a/.github/workflows/ci-model-regression-on-schedule.yml
+++ b/.github/workflows/ci-model-regression-on-schedule.yml
@@ -328,7 +328,6 @@ jobs:
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         env:
           SUMMARY_FILE: "./report.json"
-          SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
           DATASET_NAME: ${{ matrix.dataset }}
           RESULT_DIR: "${{ github.workspace }}/results"
           CONFIG: ${{ matrix.config }}

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -427,7 +427,6 @@ jobs:
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         env:
           SUMMARY_FILE: "./report.json"
-          SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
           DATASET_NAME: ${{ matrix.dataset }}
           RESULT_DIR: "${{ github.workspace }}/results"
           CONFIG: ${{ matrix.config }}
@@ -665,11 +664,10 @@ jobs:
             echo "::set-output name=total_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
           fi
 
-      - name: Generate a JSON file with a report / Publish results to Segment + Datadog
+      - name: Generate a JSON file with a report / Publish results to Datadog
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         env:
           SUMMARY_FILE: "./report.json"
-          SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
           DATASET_NAME: ${{ matrix.dataset }}
           RESULT_DIR: "${{ github.workspace }}/results"
           CONFIG: ${{ matrix.config }}

--- a/.github/workflows/ci-model-regression.yml
+++ b/.github/workflows/ci-model-regression.yml
@@ -423,7 +423,7 @@ jobs:
             echo "::set-output name=total_run_time::$(gomplate -i '{{ $t := time.Parse time.RFC3339 (getenv "NOW_TRAIN") }}{{ (time.Since $t).Round (time.Second 1) }}')"
           fi
 
-      - name: Generate a JSON file with a report / Publish results to Segment + Datadog
+      - name: Generate a JSON file with a report / Publish results to Datadog
         if: steps.set_dataset_config_vars.outputs.is_dataset_exists == 'true' && steps.set_dataset_config_vars.outputs.is_config_exists == 'true'
         env:
           SUMMARY_FILE: "./report.json"


### PR DESCRIPTION
**Motivation:** 🌆  We used this Metabase page https://metabase.rasa.com/dashboard/166-research-model-performance :chart_with_upwards_trend: for tracking ML model performance. However, we also have Datadog for the same purpose right now basically containing the same (even more) information: [This](https://app.datadoghq.eu/dashboard/xsh-dvk-jca/rasaoss-regrtest-model-performance-runtimes?tpl_var_config=%2A&tpl_var_dataset=%2A&from_ts=1642427639416&to_ts=1645106039416&live=true) comparable Datadog dashboard can be used.

**Proposed changes**:
- Deprecate the Metabase regression test page (the page will stay online in case we need to inspect historical data, but not receive any new data)
- Simplify the regression test implementation

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
