### PR TITLE
update towncrier command to new API

### DIFF
--- a/changelog/_template.md.jinja2
+++ b/changelog/_template.md.jinja2
@@ -1,5 +1,5 @@
 {# Based on https://github.com/hawkowl/towncrier/blob/master/src/towncrier/templates/default.rst #}
-{% for section in sections %}{% if section %}{{section}}{% endif %}{% if sections[section] %}{% for category, val in definitions.items() if category in sections[section] %}
+{% if top_line %}{{ top_line }} {{ top_underline * ((top_line)|length)}} {% elif versiondata.name %}{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }}) {{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}{% else %}{{ versiondata.version }} ({{ versiondata.date }}) {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}{% endif %}{% for section in sections %}{% if section %}{{section}}{% endif %}{% if sections[section] %}{% for category, val in definitions.items() if category in sections[section] %}
 
 {{ "### " + definitions[category]['name'] }}
 {% if definitions[category]['showcontent'] %}{% for text, values in sections[section][category]|dictsort(by='value') %}{% set issue_joiner = joiner(', ') %}- {% for value in values|sort %}{{ issue_joiner() }}{{ value }}{% endfor %}: {{ text }}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -285,7 +285,8 @@ def next_version(args: argparse.Namespace) -> Version:
 def generate_changelog(version: Version) -> None:
     """Call tonwcrier and create a changelog from all available changelog entries."""
     check_call(
-        ["towncrier", "--yes", "--version", str(version)], cwd=str(project_root())
+        ["towncrier", "build", "--yes", "--version", str(version)],
+        cwd=str(project_root()),
     )
 
 


### PR DESCRIPTION
**Proposed changes**:
- Update release script to use `towncrier` API that changed in `21.9.0`
  - `towncrier` [changelog](https://github.com/twisted/towncrier/blob/master/NEWS.rst)
  - Here is the [blame of the poetry.lock file on main](https://github.com/RasaHQ/rasa/blame/main/poetry.lock#L3077)). The changes in `rasa` codebase are recent (I guess I was lucky to find the issue, [the 3.0.8 changelog seems to be fine](https://github.com/RasaHQ/rasa/blob/main/CHANGELOG.mdx)!)
  - They added a new `--version` option that prints `towncrier` version and exits, which makes our changelog generation fail silently. In addition they introduced a `build` command.
- Update changelog template to fix missing title issues

**In order to test**, you can run `make generate-pending-changelog` to see how this looks like now (no changes from before). To cleanup up your local directory after this, you can run `make cleanup-generated-changelog`