### PR TITLE
deprecate: deprecate NLU JSON format

### DIFF
--- a/changelog/10989.removal.md
+++ b/changelog/10989.removal.md
@@ -1,0 +1,4 @@
+[NLU training data](nlu-training-data.mdx) in JSON format is deprecated and will be
+removed in Rasa Open Source 4.0.
+Please use `rasa data convert nlu -f yaml --data <path to NLU data>` to convert your
+NLU JSON data to YAML format before support for NLU JSON data is removed.

--- a/docs/docs/migration-guide.mdx
+++ b/docs/docs/migration-guide.mdx
@@ -28,6 +28,13 @@ this new version for inference.
 
 Please check whether your trained model still performs as expected and retrain if needed.
 
+### NLU JSON Format
+
+[NLU training data](nlu-training-data.mdx) in JSON format is deprecated and will be
+removed in Rasa Open Source 4.0.
+Please use `rasa data convert nlu -f yaml --data <path to NLU data>` to convert your
+NLU JSON data to YAML format before support for NLU JSON data is removed.
+
 ## Rasa 2.x to 3.0
 
 ### Markdown Data

--- a/rasa/shared/nlu/training_data/formats/rasa.py
+++ b/rasa/shared/nlu/training_data/formats/rasa.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from typing import Any, Dict, Text
 
+from rasa.shared.constants import DOCS_URL_MIGRATION_GUIDE
 from rasa.shared.nlu.constants import TEXT, INTENT, ENTITIES
 from rasa.shared.nlu.training_data.formats.readerwriter import (
     JsonTrainingDataReader,
@@ -12,11 +13,55 @@ from rasa.shared.utils.io import json_to_string
 
 from rasa.shared.nlu.training_data.training_data import TrainingData
 from rasa.shared.nlu.training_data.message import Message
+import rasa.shared.utils.io
 
 logger = logging.getLogger(__name__)
 
 
 class RasaReader(JsonTrainingDataReader):
+    """Reader for Rasa NLU training data in JSON format.
+
+    Example:
+        {
+          "rasa_nlu_data": {
+            "regex_features": [
+              {
+                "name": "zipcode",
+                "pattern": "[0-9]{5}"
+              }
+            ],
+            "entity_synonyms": [
+              {
+                "value": "chinese",
+                "synonyms": ["Chinese", "Chines", "chines"]
+              }
+            ],
+            "common_examples": [
+              {
+                "text": "hey",
+                "intent": "greet",
+                "entities": []
+              },
+              {
+                "text": "howdy",
+                "intent": "greet",
+                "entities": []
+              }
+            ]
+          }
+        }
+    """
+
+    def __init__(self) -> None:
+        """Creates reader."""
+        super().__init__()
+        rasa.shared.utils.io.raise_deprecation_warning(
+            "NLU data in Rasa JSON format is deprecated and will be removed in Rasa "
+            "Open Source 4.0.0. Please convert your JSON NLU data to the "
+            "Rasa YAML format.",
+            docs=DOCS_URL_MIGRATION_GUIDE,
+        )
+
     def read_from_json(self, js: Dict[Text, Any], **_: Any) -> "TrainingData":
         """Loads training data stored in the rasa NLU data format."""
         import rasa.shared.nlu.training_data.schemas.data_schema as schema
@@ -49,9 +94,20 @@ class RasaReader(JsonTrainingDataReader):
 
 
 class RasaWriter(TrainingDataWriter):
+    """Dumps NLU data as Rasa JSON string."""
+
+    def __init__(self) -> None:
+        """Creates writer."""
+        super().__init__()
+        rasa.shared.utils.io.raise_deprecation_warning(
+            "NLU data in Rasa JSON format is deprecated and will be removed in Rasa "
+            "Open Source 4.0.0. Please convert your JSON NLU data to the "
+            "Rasa YAML format.",
+            docs=DOCS_URL_MIGRATION_GUIDE,
+        )
+
     def dumps(self, training_data: "TrainingData", **kwargs: Any) -> Text:
         """Writes Training Data to a string in json format."""
-
         js_entity_synonyms = defaultdict(list)
         for k, v in training_data.entity_synonyms.items():
             if k != v:

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -55,7 +55,7 @@ def test_data_split_nlu(run_in_simple_project: Callable[..., RunResult]):
 
 
 def test_data_convert_nlu(run_in_simple_project: Callable[..., RunResult]):
-    run_in_simple_project(
+    result = run_in_simple_project(
         "data",
         "convert",
         "nlu",
@@ -67,6 +67,7 @@ def test_data_convert_nlu(run_in_simple_project: Callable[..., RunResult]):
         "json",
     )
 
+    assert "NLU data in Rasa JSON format is deprecated" in str(result.stderr)
     assert os.path.exists("out_nlu_data.json")
 
 


### PR DESCRIPTION
**Proposed changes**:
- NLU data in JSON format is deprecated and will be removed in Rasa Open Source 4.0.
- fix ATO-26

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
