### PR TITLE
Rename thread to process

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -322,12 +322,12 @@ jobs:
       if: needs.changes.outputs.backend == 'true'
       run: poetry run pip install -U ddtrace
 
-    - name: Test Code 🔍 (monothread)
+    - name: Test Code 🔍 (mono-process)
       # This is a temporary workaround for OOM on Windows caused by increased memory
       # consumption associated with the upgrade of our tensorflow dependency
       # see https://github.com/RasaHQ/rasa/issues/9734 for more information.
       # Once the memory issues have been addressed, all configurations should be run on
-      # multiple threads
+      # multiple processes
       if: needs.changes.outputs.backend == 'true' && (matrix.os == 'windows-2019' && (matrix.test == 'test-nlu-predictors' || matrix.test == 'test-other-unit-tests'))
       env:
         JOBS: 1
@@ -339,7 +339,7 @@ jobs:
         make ${{ matrix.test }}
         poetry run coverage xml -o ${{ github.workspace }}/tests/${{ matrix.test }}-coverage.xml --include="rasa/*"
 
-    - name: Test Code 🔍 (multithread)
+    - name: Test Code 🔍 (multi-process)
       if: needs.changes.outputs.backend == 'true' && !(matrix.os == 'windows-2019' && (matrix.test == 'test-nlu-predictors' || matrix.test == 'test-other-unit-tests'))
       env:
         JOBS: 2


### PR DESCRIPTION
**Motivation**: We use pytest-xdist to run multiple tests in parallel.  https://pypi.org/project/pytest-xdist/ mentions that "pytest will spawn a number of workers processes", therefore our naming with "threads" is slightly confusing

**Proposed changes**:
- Rename "thread" to "process"

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
