### PR TITLE
Skip e2e tests on CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -628,7 +628,11 @@ def pytest_runtest_setup(item: Function) -> None:
         and sys.platform == "win32"
     ):
         pytest.skip("cannot run on Windows")
-
+    if (
+        "skip_on_ci" in [mark.name for mark in item.iter_markers()]
+        and os.environ.get("CI") in ["true", "True", "yes", "t", "1"]
+    ):
+        pytest.skip("cannot run on CI")
 
 class MockExporter(Exporter):
     """Mocked `Exporter` class."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -628,10 +628,9 @@ def pytest_runtest_setup(item: Function) -> None:
         and sys.platform == "win32"
     ):
         pytest.skip("cannot run on Windows")
-    if (
-        "skip_on_ci" in [mark.name for mark in item.iter_markers()]
-        and os.environ.get("CI") in ["true", "True", "yes", "t", "1"]
-    ):
+    if "skip_on_ci" in [mark.name for mark in item.iter_markers()] and os.environ.get(
+        "CI"
+    ) in ["true", "True", "yes", "t", "1"]:
         pytest.skip("cannot run on CI")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -634,6 +634,7 @@ def pytest_runtest_setup(item: Function) -> None:
     ):
         pytest.skip("cannot run on CI")
 
+
 class MockExporter(Exporter):
     """Mocked `Exporter` class."""
 

--- a/tests/core/test_evaluation.py
+++ b/tests/core/test_evaluation.py
@@ -54,6 +54,11 @@ async def restaurantbot_agent(trained_restaurantbot: Path) -> Agent:
     return await load_agent(str(trained_restaurantbot))
 
 
+def skip_on_CI() -> bool:
+    """Checks whether to skip this configuration on CI."""
+    return os.environ.get("CI") in ["true", "True", "yes", "t", "1"]
+
+
 async def test_evaluation_file_creation(
     tmpdir: Path, default_agent: Agent, stories_path: Text
 ):
@@ -350,6 +355,11 @@ async def test_retrieval_intent_wrong_prediction(
 
 @pytest.mark.timeout(240, func_only=True)
 async def test_e2e_with_entity_evaluation(e2e_bot_agent: Agent, tmp_path: Path):
+    if skip_on_CI():
+        pytest.skip(
+            "FIXME: these tests take too long to run in the CI, disabling them for now"
+        )
+
     test_file = "data/test_e2ebot/tests/test_stories.yml"
 
     await evaluate_stories(

--- a/tests/core/test_evaluation.py
+++ b/tests/core/test_evaluation.py
@@ -54,11 +54,6 @@ async def restaurantbot_agent(trained_restaurantbot: Path) -> Agent:
     return await load_agent(str(trained_restaurantbot))
 
 
-def skip_on_CI() -> bool:
-    """Checks whether to skip this configuration on CI."""
-    return os.environ.get("CI") in ["true", "True", "yes", "t", "1"]
-
-
 async def test_evaluation_file_creation(
     tmpdir: Path, default_agent: Agent, stories_path: Text
 ):
@@ -353,13 +348,10 @@ async def test_retrieval_intent_wrong_prediction(
     assert "# predicted: chitchat/ask_name" in failed_stories
 
 
+# FIXME: these tests take too long to run in the CI, disabling them for now
+@pytest.mark.skip_on_ci
 @pytest.mark.timeout(240, func_only=True)
 async def test_e2e_with_entity_evaluation(e2e_bot_agent: Agent, tmp_path: Path):
-    if skip_on_CI():
-        pytest.skip(
-            "FIXME: these tests take too long to run in the CI, disabling them for now"
-        )
-
     test_file = "data/test_e2ebot/tests/test_stories.yml"
 
     await evaluate_stories(

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -80,11 +80,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def skip_on_CI() -> bool:
-    """Checks whether to skip this configuration on CI."""
-    return os.environ.get("CI") in ["true", "True", "yes", "t", "1"]
-
-
 async def test_message_processor(
     default_channel: CollectingOutputChannel, default_processor: MessageProcessor
 ):
@@ -1483,12 +1478,9 @@ def test_get_tracker_adds_model_id(default_processor: MessageProcessor):
     assert tracker.model_id == model_id
 
 
+# FIXME: these tests take too long to run in the CI, disabling them for now
+@pytest.mark.skip_on_ci
 async def test_processor_e2e_slot_set(e2e_bot_agent: Agent, caplog: LogCaptureFixture):
-    if skip_on_CI():
-        pytest.skip(
-            "FIXME: these tests take too long to run in the CI, disabling them for now"
-        )
-
     processor = e2e_bot_agent.processor
     message = UserMessage("I am feeling sad.", CollectingOutputChannel(), "test")
     with caplog.at_level(logging.DEBUG):

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -80,6 +80,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def skip_on_CI() -> bool:
+    """Checks whether to skip this configuration on CI."""
+    return os.environ.get("CI") in ["true", "True", "yes", "t", "1"]
+
+
 async def test_message_processor(
     default_channel: CollectingOutputChannel, default_processor: MessageProcessor
 ):
@@ -1479,6 +1484,11 @@ def test_get_tracker_adds_model_id(default_processor: MessageProcessor):
 
 
 async def test_processor_e2e_slot_set(e2e_bot_agent: Agent, caplog: LogCaptureFixture):
+    if skip_on_CI():
+        pytest.skip(
+            "FIXME: these tests take too long to run in the CI, disabling them for now"
+        )
+
     processor = e2e_bot_agent.processor
     message = UserMessage("I am feeling sad.", CollectingOutputChannel(), "test")
     with caplog.at_level(logging.DEBUG):

--- a/tests/nlu/featurizers/test_lm_featurizer.py
+++ b/tests/nlu/featurizers/test_lm_featurizer.py
@@ -42,7 +42,7 @@ def create_language_model_featurizer(
     return inner
 
 
-def skip_on_CI(model_name: Text, model_weights: Text) -> bool:
+def skip_on_CI_with_bert(model_name: Text, model_weights: Text) -> bool:
     """Checks whether to skip this configuration on CI.
 
     Only applies when skip_model_load=False
@@ -67,7 +67,7 @@ def create_pretrained_transformers_config(
         model_name: model name
         model_weights: model weights name
     """
-    if skip_on_CI(model_name, model_weights):
+    if skip_on_CI_with_bert(model_name, model_weights):
         pytest.skip(
             "Reason: this model is too large, loading it results in"
             "crashing of GH action workers."


### PR DESCRIPTION
**Reasoning:** 
- As part of https://github.com/RasaHQ/rasa/issues/9734, we found some tests that cause resource exceptions on Windows CI
- this leads to errors with JOBS=2
- These tests take too long to run in the CI, disabling them for now

**Proposed changes**:
- Skip some tests on CI that take a lot of time

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
