### PR TITLE
Ross 18 log level libraries setting does not override default debug log level when running cli with debug

### DIFF
--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -34,7 +34,7 @@ Rasa produces log messages at several different levels (eg. warning, info, error
 
 In addition to CLI arguments, several environment variables allow you to control log output in a more granular way. With these environment variables, you can configure log levels for messages created by external libraries such as matplotlib, pika, and kafka. Currently, following environment variables are supported:
 
-1. LOG_LEVEL_LIBRARIES: This is the general environment variable to configure log level for all libraries.
+1. LOG_LEVEL_LIBRARIES: This is the general environment variable to configure log level for the main libraries Rasa Open Source uses. It covers Tensorflow, `asyncio`, APScheduler, SocketIO, Matplotlib and RabbitMQ.
 2. LOG_LEVEL_MATPLOTLIB: This is the specialized environment variable to configure log level only for Matplotlib.
 3. LOG_LEVEL_RABBITMQ: This is the specialized environment variable to configure log level only for AMQP libraries, at the moment it handles log levels from `aio_pika` and `aiormq`.
 4. LOG_LEVEL_KAFKA: This is the specialized environment variable to configure log level only for kafka.

--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -32,9 +32,9 @@ abstract: The command line interface (CLI) gives you easy-to-remember commands f
 
 Rasa produces log messages at several different levels (eg. warning, info, error and so on). You can control which level of logs you would like to see with `--verbose` (same as `-v`) or `--debug` (same as `-vv`) as optional command line arguments. See each command below for more explanation on what these arguments mean.
 
-In addition to CLI arguments, several environment variables allow you to control log output in a more granular way. With these environment variables, you can configure log levels for messages created by external libraries such as matplotlib, pika, and kafka. Currently, following environment variables are supported:
+In addition to CLI arguments, several environment variables allow you to control log output in a more granular way. With these environment variables, you can configure log levels for messages created by external libraries such as Matplotlib, Pika, and Kafka. These variables follow [standard logging level in Python](https://docs.python.org/3/library/logging.html#logging-levels). Currently, following environment variables are supported:
 
-1. LOG_LEVEL_LIBRARIES: This is the general environment variable to configure log level for the main libraries Rasa Open Source uses. It covers Tensorflow, `asyncio`, APScheduler, SocketIO, Matplotlib and RabbitMQ.
+1. LOG_LEVEL_LIBRARIES: This is the general environment variable to configure log level for the main libraries Rasa Open Source uses. It covers Tensorflow, `asyncio`, APScheduler, SocketIO, Matplotlib, RabbitMQ, Kafka.
 2. LOG_LEVEL_MATPLOTLIB: This is the specialized environment variable to configure log level only for Matplotlib.
 3. LOG_LEVEL_RABBITMQ: This is the specialized environment variable to configure log level only for AMQP libraries, at the moment it handles log levels from `aio_pika` and `aiormq`.
 4. LOG_LEVEL_KAFKA: This is the specialized environment variable to configure log level only for kafka.
@@ -45,15 +45,19 @@ General configuration (`LOG_LEVEL_LIBRARIES`) has less priority than library lev
 LOG_LEVEL_LIBRARIES=ERROR LOG_LEVEL_MATPLOTLIB=WARNING LOG_LEVEL_KAFKA=DEBUG rasa shell --debug
 ```
 
-Above command run will result seeing `DEBUG` level messages by default (due to `--debug`), `WARNING` level for Matplotlib,`DEBUG` level for kafka and `ERROR` level for other libraries not configured.
+The above command run will result in showing:
+- messages with `DEBUG` level and higher by default (due to `--debug`)
+- messages with `WARNING` level and higher for Matplotlib
+- messages with `DEBUG` level and higher for kafka
+- messages with `ERROR` level and higher for other libraries not configured
 
-Note that CLI config sets the lowest level log messages to be handled, hence following command will set log level to INFO (due to `--verbose`) and no debug messages will be seen (library level configuration will not have an effect):
+Note that CLI config sets the lowest level log messages to be handled, hence the following command will set the log level to `INFO` (due to `--verbose`) and no debug messages will be seen (library level configuration will not have any effect):
 
 ```bash
 LOG_LEVEL_LIBRARIES=DEBUG LOG_LEVEL_MATPLOTLIB=DEBUG rasa shell --verbose
 ```
 
-As an aside, CLI log level sets the level at the root logger (which has the important handler - coloredlogs handler); this means even if an environment variable sets a library logger to a lower level, root logger will reject messages from that library. By default CLI log level is set to `INFO` if not given.
+As an aside, CLI log level sets the level at the root logger (which has the important handler - `coloredlogs` handler); this means even if an environment variable sets a library logger to a lower level, the root logger will reject messages from that library. If not specified, the CLI log level is set to `INFO`.
 
 ## rasa init
 


### PR DESCRIPTION
**Proposed changes**:
- Fixes https://rasahq.atlassian.net/browse/ROSS-18
- Fixes https://rasahq.atlassian.net/browse/ROSS-34
- Fixes https://rasahq.atlassian.net/browse/ROSS-91
- Fixes https://rasahq.atlassian.net/browse/ROSS-90

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
