### PR TITLE
ATO-36 Optionally pass domain path into nlu test

### DIFF
--- a/rasa/cli/test.py
+++ b/rasa/cli/test.py
@@ -235,7 +235,7 @@ async def run_nlu_test_async(
             models_path, "model", DEFAULT_MODELS_PATH
         )
 
-        await test_nlu(model_path, data_path, output, all_args)
+        await test_nlu(model_path, data_path, output, all_args, domain_path=domain_path)
 
 
 def run_nlu_test(args: argparse.Namespace) -> None:

--- a/rasa/model_testing.py
+++ b/rasa/model_testing.py
@@ -191,6 +191,7 @@ async def test_nlu(
     nlu_data: Optional[Text],
     output_directory: Text = DEFAULT_RESULTS_PATH,
     additional_arguments: Optional[Dict] = None,
+    domain_path: Optional[Text] = None,
 ) -> None:
     """Tests the NLU Model."""
     from rasa.nlu.test import run_evaluation
@@ -214,7 +215,11 @@ async def test_nlu(
         )
         _agent = Agent.load(model_path=model)
         await run_evaluation(
-            nlu_data, _agent.processor, output_directory=output_directory, **kwargs
+            nlu_data,
+            _agent.processor,
+            output_directory=output_directory,
+            domain_path=domain_path,
+            **kwargs,
         )
     else:
         rasa.shared.utils.cli.print_error(

--- a/rasa/nlu/test.py
+++ b/rasa/nlu/test.py
@@ -1373,6 +1373,7 @@ async def run_evaluation(
     errors: bool = False,
     disable_plotting: bool = False,
     report_as_dict: Optional[bool] = None,
+    domain_path: Optional[Text] = None,
 ) -> Dict:  # pragma: no cover
     """Evaluate intent classification, response selection and entity extraction.
 
@@ -1387,6 +1388,7 @@ async def run_evaluation(
             If `False` the report is returned in a human-readable text format. If `None`
             `report_as_dict` is considered as `True` in case an `output_directory` is
             given.
+        domain_path: Path to the domain file(s).
 
     Returns: dictionary containing evaluation results
     """
@@ -1394,7 +1396,8 @@ async def run_evaluation(
     from rasa.shared.constants import DEFAULT_DOMAIN_PATH
 
     test_data_importer = TrainingDataImporter.load_from_dict(
-        training_data_paths=[data_path], domain_path=DEFAULT_DOMAIN_PATH
+        training_data_paths=[data_path],
+        domain_path=domain_path if domain_path else DEFAULT_DOMAIN_PATH,
     )
     test_data = test_data_importer.get_nlu_data()
 


### PR DESCRIPTION
Optionally pass the domain path into `nlu test`. This fixes user warnings that from when a non default domain location is used.
Fixes: https://rasahq.atlassian.net/browse/ATO-36