### PR TITLE
redirect to 1.0.x rasa x docs for removed installation methods

### DIFF
--- a/docs/docs/how-to-deploy.mdx
+++ b/docs/docs/how-to-deploy.mdx
@@ -32,15 +32,15 @@ For more details on deployment methods see the [Rasa X Installation Guide](https
 The Server Quick-Install script is the easiest way to deploy Rasa X and your assistant. It installs a Kubernetes
 cluster on your machine with sensible defaults, getting you up and running in one command.
 
-* Default: Make sure you meet the [OS Requirements](https://rasa.com/docs/rasa-x/installation-and-setup/install/quick-install-script/#hardware-os-requirements),
+* Default: Make sure you meet the [OS Requirements](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/install/quick-install-script/#hardware-os-requirements),
   then run:
 
   ```bash
   curl -s get-rasa-x.rasa.com | sudo bash
   ```
 
-* Custom: See [Customizing the Script](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#server-quick-install)
-  and the [Server Quick-Install docs](https://rasa.com/docs/rasa-x/installation-and-setup/install/quick-install-script) docs.
+* Custom: See [Customizing the Script](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/customize/#server-quick-install)
+  and the [Server Quick-Install docs](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/install/quick-install-script) docs.
 
 ### Helm Chart
 
@@ -48,9 +48,9 @@ For assistants that will receive a lot of user traffic, setting up a Kubernetes 
 our Helm charts is the best option. This provides a scalable architecture that is also straightforward to deploy.
 However, you can also customize the Helm charts if you have specific requirements.
 
-* Default: Read the [Helm Chart Installation](https://rasa.com/docs/rasa-x/installation-and-setup/install/helm-chart-installation/introduction) docs.
+* Default: Read the [Helm Chart Installation](https://rasa.com/docs/rasa-x/installation-and-setup/install/helm-chart-installation/installation) docs.
 
-* Custom: Read the above, as well as the [Advanced Configuration](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#helm-chart)
+* Custom: Read the above, as well as the [Advanced Configuration](https://rasa.com/docs/rasa-x/installation-and-setup/install/helm-chart-installation/installation#using-helm-to-generate-object-configurations)
   documentation, and customize the [open source Helm charts](https://github.com/RasaHQ/rasa-x-helm) to your needs.
 
 ## Alternative Deployment Methods
@@ -60,9 +60,9 @@ However, you can also customize the Helm charts if you have specific requirement
 You can also run Rasa X in a Docker Compose setup, without the cluster environment. We have an install script
 for doing so, as well as manual instructions for any custom setups.
 
-* Default: Read the [Docker Compose Install Script](https://rasa.com/docs/rasa-x/installation-and-setup/install/docker-compose/#docker-compose-install-script) docs or watch the [Masterclass Video](https://www.youtube.com/watch?v=IUYdwy8HPVc) on deploying Rasa X.
+* Default: Read the [Docker Compose Install Script](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/install/docker-compose/#docker-compose-install-script) docs or watch the [Masterclass Video](https://www.youtube.com/watch?v=IUYdwy8HPVc) on deploying Rasa X.
 
-* Custom: Read the [Docker Compose Manual Install](https://rasa.com/docs/rasa-x/installation-and-setup/install/docker-compose/#docker-compose-manual-install) documentation for full customization options.
+* Custom: Read the [Docker Compose Manual Install](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/install/docker-compose/#docker-compose-manual-install) documentation for full customization options.
 
 ### Rasa Open Source Only Deployment
 
@@ -141,7 +141,7 @@ jobs:
 
 4. Now, you can use your new brand docker image.
 
-5. You can also extend your workflow, so that you do not have to manually update your Rasa X deployment. The example below shows how to extend your workflow with an additional step that updates a Rasa X [Helm Chart](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#adding-a-custom-action-server) deployment.
+5. You can also extend your workflow, so that you do not have to manually update your Rasa X deployment. The example below shows how to extend your workflow with an additional step that updates a Rasa X [Helm Chart](https://rasa.com/docs/rasa-x/installation-and-setup/configure/add-action-server) deployment.
 
 ```yaml
 on:
@@ -242,10 +242,10 @@ your chosen container registry.
 How you reference the custom action image will depend on your deployment. Pick the relevant documentation for
 your deployment:
 
-* [Server Quick-Install](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#quick-install-script-customizing)
+* [Server Quick-Install](https://rasa.com/docs/1.0.x/installation-and-setup/customize/#quick-install-script-customizing)
 
-* [Helm Chart](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#adding-a-custom-action-server)
+* [Helm Chart](https://rasa.com/docs/rasa-x/installation-and-setup/configure/add-action-server)
 
-* [Docker Compose](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#connecting-a-custom-action-server)
+* [Docker Compose](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/customize/#connecting-a-custom-action-server)
 
 * [Rasa Open Source Only](./docker/deploying-in-docker-compose.mdx#using-docker-compose-to-run-multiple-services)

--- a/docs/docs/how-to-deploy.mdx
+++ b/docs/docs/how-to-deploy.mdx
@@ -242,7 +242,7 @@ your chosen container registry.
 How you reference the custom action image will depend on your deployment. Pick the relevant documentation for
 your deployment:
 
-* [Server Quick-Install](https://rasa.com/docs/1.0.x/installation-and-setup/customize/#quick-install-script-customizing)
+* [Server Quick-Install](https://rasa.com/docs/rasa-x/1.0.x/installation-and-setup/customize/#quick-install-script-customizing)
 
 * [Helm Chart](https://rasa.com/docs/rasa-x/installation-and-setup/configure/add-action-server)
 


### PR DESCRIPTION
**Proposed changes**:
- Redirects URLs to removed Rasa X installation methods to Rasa X 1.0.x docs. 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
