### PR TITLE
Fix incomplete graph config docs example

### DIFF
--- a/data/graph_schemas/graph_config_short_train_schema.yml
+++ b/data/graph_schemas/graph_config_short_train_schema.yml
@@ -25,3 +25,61 @@ nodes:
     is_target: false
     is_input: true
     resource: null
+  domain_provider:
+    needs:
+      importer: finetuning_validator
+    uses: rasa.graph_components.providers.domain_provider.DomainProvider
+    constructor_name: create
+    fn: provide_train
+    config: {}
+    eager: false
+    is_target: true
+    is_input: true
+    resource: null
+  domain_for_core_training_provider:
+    needs:
+      domain: domain_provider
+    uses: rasa.graph_components.providers.domain_for_core_training_provider.DomainForCoreTrainingProvider
+    constructor_name: create
+    fn: provide
+    config: {}
+    eager: false
+    is_target: false
+    is_input: true
+    resource: null
+  story_graph_provider:
+    needs:
+      importer: finetuning_validator
+    uses: rasa.graph_components.providers.story_graph_provider.StoryGraphProvider
+    constructor_name: create
+    fn: provide
+    config:
+      exclusion_percentage: null
+    eager: false
+    is_target: false
+    is_input: true
+    resource: null
+  training_tracker_provider:
+    needs:
+      story_graph: story_graph_provider
+      domain: domain_for_core_training_provider
+    uses: rasa.graph_components.providers.training_tracker_provider.TrainingTrackerProvider
+    constructor_name: create
+    fn: provide
+    config: {}
+    eager: false
+    is_target: false
+    is_input: false
+    resource: null
+  train_MemoizationPolicy0:
+    needs:
+      training_trackers: training_tracker_provider
+      domain: domain_for_core_training_provider
+    uses: rasa.core.policies.memoization.MemoizationPolicy
+    constructor_name: create
+    fn: train
+    config: {}
+    eager: false
+    is_target: true
+    is_input: false
+    resource: null

--- a/data/test_config/graph_config_short.yml
+++ b/data/test_config/graph_config_short.yml
@@ -38,6 +38,64 @@ train_schema:
       is_target: false
       is_input: true
       resource: null
+    domain_provider:
+      needs:
+        importer: finetuning_validator
+      uses: rasa.graph_components.providers.domain_provider.DomainProvider
+      constructor_name: create
+      fn: provide_train
+      config: { }
+      eager: false
+      is_target: true
+      is_input: true
+      resource: null
+    domain_for_core_training_provider:
+      needs:
+        domain: domain_provider
+      uses: rasa.graph_components.providers.domain_for_core_training_provider.DomainForCoreTrainingProvider
+      constructor_name: create
+      fn: provide
+      config: { }
+      eager: false
+      is_target: false
+      is_input: true
+      resource: null
+    story_graph_provider:
+      needs:
+        importer: finetuning_validator
+      uses: rasa.graph_components.providers.story_graph_provider.StoryGraphProvider
+      constructor_name: create
+      fn: provide
+      config:
+        exclusion_percentage: null
+      eager: false
+      is_target: false
+      is_input: true
+      resource: null
+    training_tracker_provider:
+      needs:
+        story_graph: story_graph_provider
+        domain: domain_for_core_training_provider
+      uses: rasa.graph_components.providers.training_tracker_provider.TrainingTrackerProvider
+      constructor_name: create
+      fn: provide
+      config: { }
+      eager: false
+      is_target: false
+      is_input: false
+      resource: null
+    train_MemoizationPolicy0:
+      needs:
+        training_trackers: training_tracker_provider
+        domain: domain_for_core_training_provider
+      uses: rasa.core.policies.memoization.MemoizationPolicy
+      constructor_name: create
+      fn: train
+      config: { }
+      eager: false
+      is_target: true
+      is_input: false
+      resource: null
 
 predict_schema:
   nodes:

--- a/docs/docs/graph-recipe.mdx
+++ b/docs/docs/graph-recipe.mdx
@@ -45,7 +45,7 @@ Graph recipes share `recipe` and `language` keys with the same meaning. Similari
 
 Here's an example graph recipe:
 
-```yaml-rasa (docs/sources/data/test_config/graph_config_short.yml)
+```yaml-rasa (../data/test_config/graph_config_short.yml)
 ```
 
 :::note graph targets


### PR DESCRIPTION
**Proposed changes**:
- The graph config example in the [graph recipe docs page](https://rasa.com/docs/rasa/graph-recipe/#graph-configuration-file-structure) is incomplete in the `train_schema` section and could cause confusion. Added missing nodes for a complete config file.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [X] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
