### PR TITLE
Add optional `--endpoints` argument to `rasa train`

### DIFF
--- a/changelog/11102.improvement.md
+++ b/changelog/11102.improvement.md
@@ -1,0 +1,1 @@
+Add `--endpoints` command line parameter to `rasa train` parser.

--- a/rasa/cli/arguments/train.py
+++ b/rasa/cli/arguments/train.py
@@ -7,6 +7,7 @@ from rasa.cli.arguments.default_arguments import (
     add_nlu_data_param,
     add_out_param,
     add_domain_param,
+    add_endpoint_param,
 )
 from rasa.graph_components.providers.training_tracker_provider import (
     TrainingTrackerProvider,
@@ -33,6 +34,9 @@ def set_train_arguments(parser: argparse.ArgumentParser) -> None:
     add_persist_nlu_data_param(parser)
     add_force_param(parser)
     add_finetune_params(parser)
+    add_endpoint_param(
+        parser, help_text="Configuration file for the connectors as a yml file."
+    )
 
 
 def set_train_core_arguments(parser: argparse.ArgumentParser) -> None:

--- a/tests/cli/test_rasa_train.py
+++ b/tests/cli/test_rasa_train.py
@@ -35,6 +35,7 @@ import rasa.utils.io
     "optional_arguments",
     [
         ["--endpoints", "endpoints.yml"],
+        ["--endpoints", "non_existent_endpoints.yml"],
         [],
     ],
 )


### PR DESCRIPTION
**Proposed changes**:
- Add the `--endpoints` argument to rasa train to make endpoints available during training if needed.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
