### PR TITLE
remove warning when running `rasa x --production`

### DIFF
--- a/changelog/10480.bugfix.md
+++ b/changelog/10480.bugfix.md
@@ -1,0 +1,1 @@
+Remove warning for Rasa X localmode not being supported when the `--production` flag is present.

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -350,17 +350,15 @@ def rasa_x(args: argparse.Namespace) -> None:
 
     _configure_logging(args)
 
-    if version.parse(rasa.version.__version__) >= version.parse("3.0.0"):
+    if args.production:
+        run_in_production(args)
+    else:
         rasa.shared.utils.io.raise_warning(
             f"Your version of rasa '{rasa.version.__version__}' is currently "
             f"not supported by Rasa X. Running `rasa x` CLI command with rasa "
             f"version higher or equal to 3.0.0 will result in errors.",
             UserWarning,
         )
-
-    if args.production:
-        run_in_production(args)
-    else:
         run_locally(args)
 
 

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -4,7 +4,6 @@ import importlib.util
 import logging
 from multiprocessing.process import BaseProcess
 from multiprocessing import get_context
-from packaging import version
 import os
 import signal
 import sys

--- a/tests/cli/test_rasa_x.py
+++ b/tests/cli/test_rasa_x.py
@@ -1,7 +1,6 @@
 import sys
 import argparse
 from pathlib import Path
-import warnings
 
 import pytest
 from typing import Callable, Dict

--- a/tests/cli/test_rasa_x.py
+++ b/tests/cli/test_rasa_x.py
@@ -174,7 +174,9 @@ def test_rasa_x_raises_warning_above_version_3(monkeypatch: MonkeyPatch):
     args = argparse.Namespace(loglevel=None, log_file=None, production=None)
     with pytest.warns(
         UserWarning,
-        match=f"Your version of rasa '{rasa.version.__version__}' is currently not supported by Rasa X.",
+        match=f"Your version of rasa '{rasa.version.__version__}' is currently "
+        f"not supported by Rasa X. Running `rasa x` CLI command with rasa "
+        f"version higher or equal to 3.0.0 will result in errors.",
     ):
         x.rasa_x(args)
 
@@ -193,6 +195,5 @@ def test_rasa_x_does_not_raise_warning_above_version_3_with_production_flag(
 
     args = argparse.Namespace(loglevel=None, log_file=None, production=True)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with pytest.warns(None):
         x.rasa_x(args)


### PR DESCRIPTION

**Proposed changes**:
- Move the warning raised for `rasa x` so that it does not warn for `rasa x --production` which does not start localmode.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
