### PR TITLE
Update readerwriter.py

### DIFF
--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -33,17 +33,17 @@ def _raise_on_same_start_and_different_end_positions(
     Args:
         aggregated_entities: Entities for each start position
     """
-     for entity_list in aggregated_entities.values():
-            end = entity_list[0].get("end")
-            for entity in entity_list[1:]:
-                # By construction, start positions of all entities in `entity_list` are
-                # identical
-                if entity.get("end") != end:
-                    raise ValueError(
-                        f"Entities '{entity}' and "
-                        f"'{entity_list[0]}' have identical "
-                        f"start but different end positions"
-                    )
+    for entity_list in aggregated_entities.values():
+        end = entity_list[0].get("end")
+        for entity in entity_list[1:]:
+            # By construction, start positions of all entities in `entity_list` are
+            # identical
+            if entity.get("end") != end:
+                raise ValueError(
+                    f"Entities '{entity}' and "
+                    f"'{entity_list[0]}' have identical "
+                    f"start but different end positions"
+                )
 
 
 class TrainingDataReader(abc.ABC):

--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -33,17 +33,18 @@ def _raise_on_same_start_and_different_end_positions(
     Args:
         aggregated_entities: Entities for each start position
     """
-    for entity_list in aggregated_entities.values():
-        end = entity_list[0]["end"]
-        for entity in entity_list[1:]:
-            # By construction, start positions of all entities in `entity_list` are
-            # identical
-            if entity["end"] != end:
-                raise ValueError(
-                    f"Entities '{entity}' and "
-                    f"'{aggregated_entities[entity['start']][0]}' have identical "
-                    f"start but different end positions"
-                )
+     for entity_list in aggregated_entities.values():
+        if len(entity_list) > 0:
+            end = entity_list[0].get("end", None)
+            for entity in entity_list[1:]:
+                # By construction, start positions of all entities in `entity_list` are
+                # identical
+                if entity.get("end", None) != end:
+                    raise ValueError(
+                        f"Entities '{entity}' and "
+                        f"'{entity_list[0]}' have identical "
+                        f"start but different end positions"
+                    )
 
 
 class TrainingDataReader(abc.ABC):

--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -34,11 +34,11 @@ def _raise_on_same_start_and_different_end_positions(
         aggregated_entities: Entities for each start position
     """
     for entity_list in aggregated_entities.values():
-        end = entity_list[0].get("end")
+        end = entity_list[0]["end"]
         for entity in entity_list[1:]:
             # By construction, start positions of all entities in `entity_list` are
             # identical
-            if entity.get("end") != end:
+            if entity["end"] != end:
                 raise ValueError(
                     f"Entities '{entity}' and "
                     f"'{entity_list[0]}' have identical "

--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -41,7 +41,7 @@ def _raise_on_same_start_and_different_end_positions(
             if entity["end"] != end:
                 raise ValueError(
                     f"Entities '{entity}' and "
-                    f"'{aggregated_entities[entity['start']][-1]}' have identical "
+                    f"'{aggregated_entities[entity['start']][0]}' have identical "
                     f"start but different end positions"
                 )
 

--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -34,12 +34,11 @@ def _raise_on_same_start_and_different_end_positions(
         aggregated_entities: Entities for each start position
     """
      for entity_list in aggregated_entities.values():
-        if len(entity_list) > 0:
-            end = entity_list[0].get("end", None)
+            end = entity_list[0].get("end")
             for entity in entity_list[1:]:
                 # By construction, start positions of all entities in `entity_list` are
                 # identical
-                if entity.get("end", None) != end:
+                if entity.get("end") != end:
                     raise ValueError(
                         f"Entities '{entity}' and "
                         f"'{entity_list[0]}' have identical "


### PR DESCRIPTION
Aggregated_entities [entity['start']][0] : represents the 0 entity element in aggregated_entities whose entity['start'] is the key.

Aggregated_entities [entity['start']][-1] : indicates the last entity element in aggregated_entities with entity['start'] as the key.

The log prompt here should be to compare the end position of the current entity with the end position of the 0th entity, and raise an exception if they are inconsistent, so change -1 to 0.
