### PR TITLE
[ATO-54] Add make target to lint changelog filenames at PR level

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -178,6 +178,10 @@ jobs:
       if: needs.changes.outputs.backend == 'true'
       run: make types
 
+    - name: Lint Changelog Filenames 📝
+      if: needs.changes.outputs.backend == 'true' && github.event_name == 'pull_request'
+      run: make lint-changelog
+
     - name: Test CLI 🖥
       if: needs.changes.outputs.backend == 'true'
       # makes sure we catch any dependency error early. they will create strange

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ endif
 	git diff HEAD -- rasa | poetry run flake8 --select D --diff
 
 lint-changelog:
-# Lint changelog filenames to avoid merging of incorrectly named changelog fragment files
-# For more info about proper changelog file naming, see https://github.com/RasaHQ/rasa/blob/main/changelog/README.md
+	# Lint changelog filenames to avoid merging of incorrectly named changelog fragment files
+	# For more info about proper changelog file naming, see https://github.com/RasaHQ/rasa/blob/main/changelog/README.md
 	poetry run flake8 --exclude=*.feature.md,*.improvement.md,*.bugfix.md,*.doc.md,*.removal.md,*.misc.md,README.md,_template.md.jinja2  changelog/* -q
 
 lint-security:

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 lint-changelog:
 # Lint changelog filenames to avoid merging of incorrectly named changelog fragment files
 # For more info about proper changelog file naming, see https://github.com/RasaHQ/rasa/blob/main/changelog/README.md
-	poetry run flake8 --filename  rasa/changelog/
+	poetry run flake8 --exclude=*.feature.md,*.improvement.md,*.bugfix.md,*.doc.md,*.removal.md,*.misc.md,README.md,_template.md.jinja2  changelog/* -q
 
 lint-security:
 	poetry run bandit -ll -ii -r --config bandit.yml rasa/*

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ endif
 	# Diff of uncommitted changes for running locally
 	git diff HEAD -- rasa | poetry run flake8 --select D --diff
 
+lint-changelog:
+# Lint changelog filenames to avoid merging of incorrectly named changelog fragment files
+# For more info about proper changelog file naming, see https://github.com/RasaHQ/rasa/blob/main/changelog/README.md
+	poetry run flake8 --filename  rasa/changelog/
+
 lint-security:
 	poetry run bandit -ll -ii -r --config bandit.yml rasa/*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,13 @@ ignore = W503, # line break before binary operator (https://black.readthedocs.io
 docstring-convention = google
 per-file-ignores = tests/test_telemetry.py:E501,
     tests/shared/core/test_domain.py:E501,
+filename =
+    *.feature.md,
+    *.improvement.md,
+    *.bugfix.md,
+    *.doc.md,
+    *.removal.md,
+    *.misc.md
 
 [mypy]
 # some libraries do not have type hints; ideally we remove

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,13 +31,6 @@ ignore = W503, # line break before binary operator (https://black.readthedocs.io
 docstring-convention = google
 per-file-ignores = tests/test_telemetry.py:E501,
     tests/shared/core/test_domain.py:E501,
-filename =
-    *.feature.md,
-    *.improvement.md,
-    *.bugfix.md,
-    *.doc.md,
-    *.removal.md,
-    *.misc.md
 
 [mypy]
 # some libraries do not have type hints; ideally we remove


### PR DESCRIPTION
**Proposed changes**:
- [ATO-54](https://rasahq.atlassian.net/browse/ATO-54)
- Added a make target to check changelog fragment filenames are in the expected format at the PR level.

**Tested with error filename**:

![Screenshot 2022-05-11 at 18 39 05](https://user-images.githubusercontent.com/2388088/167902724-36769dfb-cf7e-458d-873c-af55101243a6.png)

