### PR TITLE
Validate incoming JWT tokens from the bot framework

### DIFF
--- a/changelog/11129.bugfix.md
+++ b/changelog/11129.bugfix.md
@@ -1,0 +1,3 @@
+The azure botframework channel now validates the incoming JSON Web Tokens (including signature).
+
+Previously, JWTs were not validated at all.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,7 +16,7 @@ Each file should be named like `<ISSUE>.<TYPE>.md`, where
 
 * `feature`: new user facing features, like new command-line options and new behavior.
 * `improvement`: improvement of existing functionality, usually without requiring user intervention.
-* `bugfix`: fixes a reported bug.
+* `bugfix`: fixes a reported bug or security vulnerability.
 * `doc`: documentation improvement, like rewording an entire section or adding missing docs.
 * `removal`: feature deprecation or feature removal.
 * `misc`: fixing a small typo or internal change, will not be included in the changelog.

--- a/rasa/core/channels/botframework.py
+++ b/rasa/core/channels/botframework.py
@@ -1,13 +1,26 @@
 import datetime
 import json
 import logging
-import requests
-from sanic import Blueprint, response
-from sanic.request import Request
+import re
+from http import HTTPStatus
 from typing import Text, Dict, Any, List, Iterable, Callable, Awaitable, Optional
 
-from rasa.core.channels.channel import UserMessage, OutputChannel, InputChannel
+import jwt
+import requests
+from jwt import InvalidKeyError, PyJWTError
+from jwt.algorithms import RSAAlgorithm
+from requests import HTTPError
+from sanic import Blueprint, response
+from sanic.request import Request
 from sanic.response import HTTPResponse
+
+from rasa.core.channels.channel import UserMessage, OutputChannel, InputChannel
+
+MICROSOFT_OPEN_ID_URI = (
+    "https://login.botframework.com/v1/.well-known/openidconfiguration"
+)
+
+BEARER_REGEX = re.compile(r"Bearer\s+(.*)")
 
 logger = logging.getLogger(__name__)
 
@@ -188,25 +201,93 @@ class BotFrameworkInput(InputChannel):
         self.app_id = app_id
         self.app_password = app_password
 
+        self.jwt_keys: Dict[Text, Any] = {}
+        self.jwt_update_time = datetime.datetime.fromtimestamp(0)
+
+        self._update_cached_jwk_keys()
+
+    def _update_cached_jwk_keys(self) -> None:
+        logger.debug("Updating JWT keys for the Botframework.")
+        response = requests.get(MICROSOFT_OPEN_ID_URI)
+        response.raise_for_status()
+        conf = response.json()
+
+        jwks_uri = conf["jwks_uri"]
+
+        keys_request = requests.get(jwks_uri)
+        keys_request.raise_for_status()
+        keys_list = keys_request.json()
+        self.jwt_keys = {key["kid"]: key for key in keys_list["keys"]}
+        self.jwt_update_time = datetime.datetime.now()
+
+    def _validate_jwt_token(self, jwt_token: Text) -> None:
+        jwt_header = jwt.get_unverified_header(jwt_token)  # type: ignore
+        key_id = jwt_header["kid"]
+        if key_id not in self.jwt_keys:
+            raise InvalidKeyError(f"JWT Key with ID {key_id} not found.")
+
+        key_json = self.jwt_keys[key_id]
+        public_key = RSAAlgorithm.from_jwk(key_json)  # type: ignore
+        jwt.decode(
+            jwt_token,
+            key=public_key,
+            audience=self.app_id,
+            algorithms=jwt_header["alg"],
+        )
+
+    def _validate_auth(self, auth_header: Optional[Text]) -> Optional[HTTPResponse]:
+        if not auth_header:
+            return response.text(
+                "No authorization header provided.", status=HTTPStatus.UNAUTHORIZED
+            )
+
+        # Update the JWT keys daily
+        if datetime.datetime.now() - self.jwt_update_time > datetime.timedelta(days=1):
+            try:
+                self._update_cached_jwk_keys()
+            except HTTPError as error:
+                logger.warning(
+                    f"Could not update JWT keys from {MICROSOFT_OPEN_ID_URI}."
+                )
+                logger.exception(error, exc_info=True)
+
+        auth_match = BEARER_REGEX.match(auth_header)
+        if not auth_match:
+            return response.text(
+                "No Bearer token provided in Authorization header.",
+                status=HTTPStatus.UNAUTHORIZED,
+            )
+
+        (jwt_token,) = auth_match.groups()
+
+        try:
+            self._validate_jwt_token(jwt_token)
+        except PyJWTError as error:
+            logger.error("Bot framework JWT token could not be verified.")
+            logger.exception(error, exc_info=True)
+            return response.text(
+                "Could not validate JWT token.", status=HTTPStatus.UNAUTHORIZED
+            )
+
+        return None
+
     @staticmethod
     def add_attachments_to_metadata(
         postdata: Dict[Text, Any], metadata: Optional[Dict[Text, Any]]
     ) -> Optional[Dict[Text, Any]]:
         """Merge the values of `postdata['attachments']` with `metadata`."""
-
         if postdata.get("attachments"):
             attachments = {"attachments": postdata["attachments"]}
             if metadata:
                 metadata.update(attachments)
             else:
                 metadata = attachments
-
         return metadata
 
     def blueprint(
         self, on_new_message: Callable[[UserMessage], Awaitable[Any]]
     ) -> Blueprint:
-
+        """Defines the Sanic blueprint for the bot framework integration."""
         botframework_webhook = Blueprint("botframework_webhook", __name__)
 
         @botframework_webhook.route("/", methods=["GET"])
@@ -215,6 +296,12 @@ class BotFrameworkInput(InputChannel):
 
         @botframework_webhook.route("/webhook", methods=["POST"])
         async def webhook(request: Request) -> HTTPResponse:
+            validation_response = self._validate_auth(
+                request.headers.get("Authorization")
+            )
+            if validation_response:
+                return validation_response
+
             postdata = request.json
             metadata = self.get_metadata(request)
 

--- a/tests/core/channels/test_botframework.py
+++ b/tests/core/channels/test_botframework.py
@@ -1,0 +1,151 @@
+import json
+import time
+from http import HTTPStatus
+from unittest import mock
+from unittest.mock import Mock
+
+import freezegun
+import jwt
+import pytest
+from _pytest.logging import LogCaptureFixture
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from jwt.algorithms import RSAAlgorithm
+
+from rasa.core.channels import BotFrameworkInput
+
+DAY_IN_SECONDS = 60 * 60 * 24
+
+MS_OPENID_CONFIG_RESPONSE = {
+    "issuer": "https://api.botframework.com",
+    "authorization_endpoint": "https://invalid.botframework.com",
+    "jwks_uri": "https://login.botframework.com/v1/.well-known/keys",
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "token_endpoint_auth_methods_supported": ["private_key_jwt"],
+}
+
+
+@pytest.fixture(scope="function")
+def rsa_private_key() -> RSAPrivateKey:
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+@pytest.fixture(scope="function")
+@mock.patch("requests.get")
+def bot_framework_input(mock_requests: Mock, rsa_private_key: RSAPrivateKey):
+    jwk = json.loads(RSAAlgorithm.to_jwk(rsa_private_key.public_key()))
+    jwk["kid"] = "key_id"
+
+    openid_config_mock_response = mock.Mock()
+    openid_config_mock_response.raise_for_status = mock.Mock()
+    openid_config_mock_response.json.return_value = MS_OPENID_CONFIG_RESPONSE
+
+    openid_keys_mock_response = mock.Mock()
+    openid_keys_mock_response.raise_for_status = mock.Mock()
+    openid_keys_mock_response.json.return_value = {"keys": [jwk]}
+
+    mock_requests.side_effect = [openid_config_mock_response, openid_keys_mock_response]
+
+    return BotFrameworkInput("app_id", "app_password")
+
+
+def test_successful_jwt_signature_verification(
+    bot_framework_input: BotFrameworkInput,
+    rsa_private_key: RSAPrivateKey,
+):
+    encoded = jwt.encode(
+        {
+            "serviceurl": "https://webchat.botframework.com/",
+            "nbf": int(time.time()),
+            "exp": int(time.time()) + DAY_IN_SECONDS,
+            "iss": "https://api.botframework.com",
+            "aud": "app_id",
+        },
+        rsa_private_key,
+        algorithm="RS256",
+        headers={"kid": "key_id", "alg": "RS256"},
+    )
+
+    with pytest.warns(None):
+        resp = bot_framework_input._validate_auth(f"Bearer {encoded}")
+        assert resp is None
+
+
+@mock.patch("requests.get")
+def test_jwk_is_updated_daily(mock_requests: Mock):
+    with freezegun.freeze_time("2012-01-14 08:00:00"):
+        bot_framework_input = BotFrameworkInput("app_id", "app_password")
+        # Two calls at the beginning - on to retrieve open ID metadata,
+        # the second one to actually get the keys.
+        assert mock_requests.call_count == 2
+
+        bot_framework_input._validate_auth("Bearer token_invalid")
+        assert mock_requests.call_count == 2
+
+    with freezegun.freeze_time("2012-01-14 11:00:00"):
+        bot_framework_input._validate_auth("Bearer token_invalid")
+        assert mock_requests.call_count == 2
+
+    with freezegun.freeze_time("2012-01-15 11:00:00"):
+        bot_framework_input._validate_auth("Bearer token_invalid")
+        assert mock_requests.call_count == 4
+
+
+def test_validate_auth_returns_unauthorized_for_invalid_jwt_token(
+    bot_framework_input: BotFrameworkInput,
+    rsa_private_key: RSAPrivateKey,
+    caplog: LogCaptureFixture,
+):
+    encoded = jwt.encode(
+        {
+            "serviceurl": "https://webchat.botframework.com/",
+            "nbf": int(time.time()) + DAY_IN_SECONDS,
+            "exp": int(time.time()) + 2 * DAY_IN_SECONDS,
+            "iss": "https://api.botframework.com",
+            "aud": "app_id",
+        },
+        rsa_private_key,
+        algorithm="RS256",
+        headers={"kid": "key_id", "alg": "RS256"},
+    )
+
+    resp = bot_framework_input._validate_auth(f"Bearer {encoded}")
+
+    assert resp is not None
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+    assert resp.body.decode() == "Could not validate JWT token."
+    assert [msg for msg in caplog.messages] == [
+        "Bot framework JWT token could not be verified.",
+        "The token is not yet valid (nbf)",
+    ]
+
+
+def test_validate_auth_returns_unauthorized_for_absent_header(
+    bot_framework_input: BotFrameworkInput,
+    caplog: LogCaptureFixture,
+):
+    resp = bot_framework_input._validate_auth(None)
+    assert resp is not None
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+    assert resp.body.decode() == "No authorization header provided."
+
+
+def test_validate_auth_returns_unauthorized_for_non_bearer_header(
+    bot_framework_input: BotFrameworkInput,
+):
+    resp = bot_framework_input._validate_auth("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+    assert resp is not None
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+    assert resp.body.decode() == "No Bearer token provided in Authorization header."
+
+
+def test_validate_auth_returns_bad_request_for_invalid_header(
+    bot_framework_input: BotFrameworkInput,
+):
+    resp = bot_framework_input._validate_auth("Bearer invalid")
+    assert resp is not None
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+    assert resp.body.decode() == "Could not validate JWT token."


### PR DESCRIPTION
**Proposed changes**:
This PR enables JSON Web Token validation for the JWTs coming in from the Azure botframework channel. This is achieved by periodically updating the keys that Microsoft uses to sign the tokens, saving those in memory, and then validating the tokens and verifying their signature for incoming requests from the bot framework. 
For details on how the botframework does authentication, see [here](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0#connector-to-bot).

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
