### PR TITLE
Bugfix splitting of multiline messages containing buttons

### DIFF
--- a/rasa/core/channels/channel.py
+++ b/rasa/core/channels/channel.py
@@ -393,9 +393,17 @@ class CollectingOutputChannel(OutputChannel):
         buttons: List[Dict[Text, Any]],
         **kwargs: Any,
     ) -> None:
-        await self._persist_message(
-            self._message(recipient_id, text=text, buttons=buttons)
-        )
+        message_parts: List[Text] = text.strip().split("\n\n")
+        last_message_id: int = len(message_parts)
+
+        for i, message_part in enumerate(message_parts, start=1):
+            await self._persist_message(
+                self._message(
+                    recipient_id,
+                    text=message_part,
+                    buttons=buttons if i == last_message_id else None,
+                )
+            )
 
     async def send_custom_json(
         self, recipient_id: Text, json_message: Dict[Text, Any], **kwargs: Any

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -42,6 +42,13 @@ async def test_send_response(default_channel, default_tracker):
         "text": "This message should come first:  \n\n"
         "This is message two  \nThis as well\n\n"
     }
+    multiline_text_message_with_buttons = {
+        **multiline_text_message,
+        "buttons": [
+            {"title": "some title 1", "payload": '/some_payload1'}, 
+            {"title": "some title 2", "payload": '/some_payload2'}
+        ]
+    }
     image_only_message = {"image": "https://i.imgur.com/nGF1K8f.jpg"}
     text_and_image_message = {
         "text": "look at this",
@@ -56,6 +63,9 @@ async def test_send_response(default_channel, default_tracker):
     await default_channel.send_response(
         default_tracker.sender_id, multiline_text_message
     )
+    await default_channel.send_response(
+        default_tracker.sender_id, multiline_text_message_with_buttons
+    )
     await default_channel.send_response(default_tracker.sender_id, image_only_message)
     await default_channel.send_response(
         default_tracker.sender_id, text_and_image_message
@@ -63,7 +73,7 @@ async def test_send_response(default_channel, default_tracker):
     await default_channel.send_response(default_tracker.sender_id, custom_json_message)
     collected = default_channel.messages
 
-    assert len(collected) == 8
+    assert len(collected) == 10
 
     # text only message
     assert collected[0] == {"recipient_id": "my-sender", "text": "hey"}
@@ -78,20 +88,34 @@ async def test_send_response(default_channel, default_tracker):
         "text": "This is message two  \nThis as well",
     }
 
-    # image only message
+    # multiline text message with buttons, should split on '\n\n'
     assert collected[3] == {
+        "recipient_id": "my-sender",
+        "text": "This message should come first:  ",
+    }
+    assert collected[4] == {
+        "recipient_id": "my-sender",
+        "text": "This is message two  \nThis as well",
+        "buttons": [
+            {"title": "some title 1", "payload": '/some_payload1'}, 
+            {"title": "some title 2", "payload": '/some_payload2'}
+        ]
+    }
+
+    # image only message
+    assert collected[5] == {
         "recipient_id": "my-sender",
         "image": "https://i.imgur.com/nGF1K8f.jpg",
     }
 
     # text & image combined - will result in two messages
-    assert collected[4] == {"recipient_id": "my-sender", "text": "look at this"}
-    assert collected[5] == {
+    assert collected[6] == {"recipient_id": "my-sender", "text": "look at this"}
+    assert collected[7] == {
         "recipient_id": "my-sender",
         "image": "https://i.imgur.com/T5xVo.jpg",
     }
-    assert collected[6] == {"recipient_id": "my-sender", "text": "look at this"}
-    assert collected[7] == {
+    assert collected[8] == {"recipient_id": "my-sender", "text": "look at this"}
+    assert collected[9] == {
         "recipient_id": "my-sender",
         "custom": {"some_random_arg": "value", "another_arg": "value2"},
     }


### PR DESCRIPTION
**Proposed changes**:
Currently multiline messages don't get split into separate messages on two newlines if they contain buttons. And this seems to be a bug.
The change proposed is to split a message on separate messages on two newlines and include buttons with the last of them.

Some discussion on this problem I found here: https://github.com/RasaHQ/rasa/issues/4895

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
