### PR TITLE
Do not assign a reviewer to dependabot PRs for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     pull-request-branch-name:
       separator: "-"
     open-pull-requests-limit: 10
-    reviewers:
-      - RasaHQ/atom-squad
     labels:
       - type:dependencies
     ignore:


### PR DESCRIPTION
**Proposed changes**:
- Remove automatic reviewer in dependabot PRs for python

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
