### PR TITLE
Temporarily revert "Update docs rasa x" in 3.1.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -18,6 +18,11 @@ body:
     attributes:
       label: Rasa SDK version
       description: What's the rasa SDK version you used (if relevant)
+  - type: input
+    id: version-rasa-x
+    attributes:
+      label: Rasa X version
+      description: What's the Rasa X version you used (if relevant)
   - type: dropdown
     id: version-python
     attributes:

--- a/changelog/11156.misc.md
+++ b/changelog/11156.misc.md
@@ -1,1 +1,0 @@
-`rasa --version` does not print "Rasa X Version" anymore.

--- a/docs/docs/chitchat-faqs.mdx
+++ b/docs/docs/chitchat-faqs.mdx
@@ -16,8 +16,8 @@ with the answer being independent of anything the user has said previously.
 <ChatBotText>My name is Sara!</ChatBotText>
 <ChatUserText>Which languages can I build assistants in?</ChatUserText>
 <ChatBotText>You can use Rasa to build assistants in any language you want!</ChatBotText>
-<ChatUserText>What’s Rasa Enterprise?</ChatUserText>
-<ChatBotText>Rasa Enterprise is a tool to learn from real conversations and improve your assistant.</ChatBotText>
+<ChatUserText>What’s Rasa X?</ChatUserText>
+<ChatBotText>Rasa X is a tool to learn from real conversations and improve your assistant.</ChatBotText>
 </Chat>
 
 

--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -25,6 +25,7 @@ abstract: The command line interface (CLI) gives you easy-to-remember commands f
 |`rasa data validate`    |Checks the domain, NLU and conversation data for inconsistencies.                                                                         |
 |`rasa export`           |Exports conversations from a tracker store to an event broker.                                                                            |
 |`rasa evaluate markers` |Extracts markers from an existing tracker store.                                                                                                |
+|`rasa x`                |Launches Rasa X in local mode.                                                                                                            |
 |`rasa -h`               |Shows all available commands.                                                                                                             |
 
 ## Log Level
@@ -163,7 +164,11 @@ from scratch.
 
 ## rasa interactive
 
-You can start an interactive learning session by running:
+You can [use Rasa X in local mode](https://rasa.com/docs/rasa-enterprise) to do interactive learning in a UI,
+check out the [docs](https://rasa.com/docs/rasa-enterprise/user-guide/test-assistant#talk-to-your-bot)
+for more details.
+
+If you'd rather use the command line, you can start an interactive learning session by running:
 
 ```bash
 rasa interactive
@@ -204,7 +209,11 @@ The following arguments can be used to configure the interactive learning sessio
 
 ## rasa shell
 
-You can start a chat session by running:
+You can [use Rasa X in local mode](https://rasa.com/docs/rasa-enterprise) to talk to your assistant in a UI.
+Check out the [Rasa X docs](https://rasa.com/docs/rasa-enterprise/user-guide/test-assistant#talk-to-your-bot)
+for more details.
+
+If you'd rather use the command line, you can start a chat session by running:
 
 ```bash
 rasa shell
@@ -478,9 +487,9 @@ should be published:
 ```text [rasa export --help]
 ```
 
-:::tip Import conversations into Rasa Enterprise
-This command is most commonly used to import old conversations into Rasa Enterprise to annotate
-them. Read more about [importing conversations into Rasa Enterprise](https://rasa.com/docs/rasa-enterprise/installation-and-setup/deploy#1-import-existing-conversations-from-rasa-open-source).
+:::tip Import conversations into Rasa X
+This command is most commonly used to import old conversations into Rasa X to annotate
+them. Read more about [importing conversations into Rasa X](https://rasa.com/docs/rasa-enterprise/installation-and-setup/deploy#1-import-existing-conversations-from-rasa-open-source).
 :::
 
 ## rasa evaluate markers
@@ -529,4 +538,22 @@ Python Logging Options:
   -v, --verbose         Be verbose. Sets logging level to INFO. (default: None)
   -vv, --debug          Print lots of debugging statements. Sets logging level to DEBUG. (default: None)
   --quiet               Be quiet! Sets logging level to WARNING. (default: None)
+```
+
+## rasa x
+
+Rasa X is a tool for practicing Conversation-Driven Development.
+You can find more information about it <a className="reference external" href="https://rasa.com/docs/rasa-enterprise/" target="_blank">here</a>.You can start Rasa X in local mode by executing
+
+```bash
+rasa x
+```
+
+To be able to start Rasa X you need to have Rasa X local mode [installed](https://rasa.com/docs/rasa-enterprise/installation-and-setup/install/local-mode)
+and you need to be in a Rasa project directory.
+
+
+The following arguments are available for `rasa x`:
+
+```text [rasa x --help]
 ```

--- a/docs/docs/connectors/cisco-webex-teams.mdx
+++ b/docs/docs/connectors/cisco-webex-teams.mdx
@@ -29,7 +29,7 @@ Please follow this link below to find the room ID
 In the OAuth & Permissions section, add the URL of the Rasa Open Source endpoint
 that Webex should forward the messages to. The endpoint for receiving Cisco Webex Teams messages
 is `http://<host>:<port>/webhooks/webexteams/webhook`, replacing
-the host and port with the appropriate values from your running Rasa Open Source server.
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 ## Running on Cisco Webex Teams
 
@@ -42,7 +42,7 @@ webexteams:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Cisco Webex Teams to send messages to.
 
 :::note

--- a/docs/docs/connectors/custom-connectors.mdx
+++ b/docs/docs/connectors/custom-connectors.mdx
@@ -42,7 +42,7 @@ responses:
 
 The webhook you give to the custom channel to call would be
 `http://<host>:<port>/webhooks/myio/webhook`, replacing 
-the host and port with the appropriate values from your running Rasa Open Source server.
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 
 ## The `blueprint` method

--- a/docs/docs/connectors/facebook-messenger.mdx
+++ b/docs/docs/connectors/facebook-messenger.mdx
@@ -39,7 +39,7 @@ You need to set up a Facebook app and a page.
 6. Set up a **Webhook** and select at least the **messaging** and
    **messaging_postback** subscriptions. Insert your callback URL, which will
    look like `https://<host>:<port>/webhooks/facebook/webhook`, replacing
-   the host and port with the appropriate values from your running Rasa Open Source server.
+   the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
    
    Insert the **Verify Token** which has to match the `verify`
    entry in your `credentials.yml`.
@@ -65,7 +65,7 @@ facebook:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Facebook Messenger to send messages to.
 
 

--- a/docs/docs/connectors/hangouts.mdx
+++ b/docs/docs/connectors/hangouts.mdx
@@ -14,7 +14,7 @@ more information, see the Cards section).
 In order to connect your Rasa bot to Google Hangouts Chat, you first need to create a project in
 Google Developer Console that includes the Hangouts API. There you can specify your bot's endpoint.
 This endpoint should look like look like `https://<host>:<port>/webhooks/hangouts/webhook`, replacing
-the host and port with the appropriate values from your running Rasa Open Source server.
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 :::note configure https
 Hangouts Chat only forwards
@@ -47,7 +47,7 @@ hangouts:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Google Hangouts to send messages to.
 
 ### Cards and Interactive Cards

--- a/docs/docs/connectors/mattermost.mdx
+++ b/docs/docs/connectors/mattermost.mdx
@@ -38,7 +38,7 @@ For information on converting existing user account into bot account please see
 
 6. Add the Callback URL, which will
    look like `http://<host>:<port>/webhooks/mattermost/webhook`, replacing
-   the host and port with the appropriate values from your running Rasa Open Source server.
+   the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 For more detailed steps, visit the
 [Mattermost docs](https://docs.mattermost.com/guides/developer.html).
@@ -55,5 +55,5 @@ mattermost:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Mattermost to send messages to.

--- a/docs/docs/connectors/microsoft-bot-framework.mdx
+++ b/docs/docs/connectors/microsoft-bot-framework.mdx
@@ -10,7 +10,7 @@ Once you have them you can add these to your `credentials.yml`.
 
 The endpoint URL that Microsoft Bot Framework should send messages to will
 look like `http://<host>:<port>/webhooks/botframework/webhook`, replacing
-the host and port with the appropriate values from your running Rasa Open Source server.
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 
 ## Running on Microsoft Bot Framework
@@ -24,5 +24,5 @@ botframework:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Microsoft Bot Framework to send messages to.

--- a/docs/docs/connectors/rocketchat.mdx
+++ b/docs/docs/connectors/rocketchat.mdx
@@ -27,7 +27,7 @@ description: Build a Rasa Chat Bot on Rocketchat
 
 6. In the **URLs** section, set the URL to 
    `http://<host>:<port>/webhooks/rocketchat/webhook`, replacing
-   the host and port with the appropriate values from your running Rasa Open Source server.
+   the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 For more information on the Rocket.Chat Webhooks, see the
 [Rocket.Chat Guide](https://docs.rocket.chat/guides/administrator-guides/integrations).
@@ -44,5 +44,5 @@ rocketchat:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for RocketChat to send messages to.

--- a/docs/docs/connectors/slack.mdx
+++ b/docs/docs/connectors/slack.mdx
@@ -182,5 +182,5 @@ slack:
   conversation_granularity: "sender" # sender allows 1 conversation per user (across channels), channel allows 1 conversation per user per channel, thread allows 1 conversation per user per thread. This configuration is optional and set to sender by default.
 ```
 
-Make sure to restart your Rasa Open Source server after changing the
+Make sure to restart your Rasa X or Rasa Open Source server after changing the
 `credentials.yml` for the changes to take effect.

--- a/docs/docs/connectors/telegram.mdx
+++ b/docs/docs/connectors/telegram.mdx
@@ -16,7 +16,7 @@ You need to set up a Telegram bot.
 1. To create the bot, go to [Bot Father](https://web.telegram.org/#/im?p=@BotFather),
    enter `/newbot` and follow the instructions. The URL that Telegram should send messages to will look like
    `http://<host>:<port>/webhooks/telegram/webhook`, replacing
-   the host and port with the appropriate values from your running Rasa Open Source server.
+   the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 2. At the end you should get your `access_token` and the username you
    set will be your `verify`.
@@ -39,7 +39,7 @@ telegram:
 ```
 
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Telegram to send messages to.
 
 

--- a/docs/docs/connectors/twilio.mdx
+++ b/docs/docs/connectors/twilio.mdx
@@ -30,7 +30,7 @@ You need to set up a Twilio account.
    [Phone Numbers](https://www.twilio.com/console/phone-numbers/incoming) in the Twilio
    dashboard and selecting your phone number. Find the `Messaging` section and add
    your webhook URL (e.g. `https://<host>:<port>/webhooks/twilio/webhook`,
-   replacing the host and port with the appropriate values from your running Rasa Open Source server)
+   replacing the host and port with the appropriate values from your running Rasa X or Rasa Open Source server)
    to the `A MESSAGE COMES IN` setting.
 
 For more information, see the [Twilio REST API](https://www.twilio.com/docs/iam/api).
@@ -57,5 +57,5 @@ twilio:
   twilio_number: "+440123456789"  # if using WhatsApp: "whatsapp:+440123456789"
 ```
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available for Twilio to send messages to.

--- a/docs/docs/connectors/your-own-website.mdx
+++ b/docs/docs/connectors/your-own-website.mdx
@@ -5,6 +5,10 @@ title: Your Own Website
 description: Deploy and Run a Rasa Chat Bot on a Website
 ---
 
+If you just want an easy way for users to test your bot, the best option
+is usually the chat interface that ships with Rasa X, where you can [invite users
+to test your bot](https://rasa.com/docs/rasa-enterprise/user-guide/share-assistant/#share-your-bot).
+
 If you already have an existing website and want to add a Rasa assistant to it,
 you can use the [Rasa Chat Widget](#chat-widget) a widget which you can incorporate into your existing webpage by adding a HTML snippet.
 
@@ -29,10 +33,10 @@ rest:
   # require any credentials
 ```
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the REST channel available to receive messages. You can then send messages to 
 `http://<host>:<port>/webhooks/rest/webhook`, replacing
-the host and port with the appropriate values from your running Rasa Open Source server.
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 #### Request and Response Format
 
@@ -69,10 +73,10 @@ callback:
   url: "http://localhost:5034/bot"
 ```
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available to receive messages. 
 You can then send messages to `http://<host>:<port>/webhooks/callback/webhook`, replacing
-the host and port with the appropriate values from your running Rasa Open Source server.
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server.
 
 #### Request and Response Format
 
@@ -112,10 +116,10 @@ socketio:
 The first two configuration values define the event names used by Rasa Open Source
 when sending or receiving messages over socket.io.
 
-Restart your Rasa Open Source server
+Restart your Rasa X or Rasa Open Source server
 to make the new channel endpoint available to receive messages. 
 You can then send messages to `http://<host>:<port>/socket.io`, replacing
-the host and port with the appropriate values from your running Rasa Open Source server. 
+the host and port with the appropriate values from your running Rasa X or Rasa Open Source server. 
 
 :::note session persistence
 By default, the SocketIO channel uses the socket id as `sender_id`, which causes

--- a/docs/docs/contextual-conversations.mdx
+++ b/docs/docs/contextual-conversations.mdx
@@ -100,7 +100,7 @@ always have a higher [policy priority](./policies.mdx#policy-priority) and will 
 
 The [TEDPolicy](https://blog.rasa.com/unpacking-the-ted-policy-in-rasa-open-source/) is made to handle
 unexpected user behaviors. For example,
-in the conversation below (extracted from a conversation on [Rasa Enterprise](https://rasa.com/docs/rasa-enterprise/user-guide/review-conversations/)):
+in the conversation below (extracted from a conversation on [Rasa X](https://rasa.com/docs/rasa-enterprise/user-guide/review-conversations/)):
 
 ```yaml-rasa
 stories:
@@ -119,10 +119,10 @@ stories:
   - action: action_chitchat
   - intent: how_to_get_started
     entities:
-    - product: enterprise
+    - product: x
   - slot_was_set:
-    - product: enterprise
-  - action: utter_explain_enterprise
+    - product: x
+  - action: utter_explain_x
   - action: utter_also_explain_nlucore
   - intent: affirm
   - action: utter_explain_nlu
@@ -131,13 +131,13 @@ stories:
 ```
 
 Here we can see the user has completed a few chitchat tasks first, and then ultimately
-asks how they can get started with Rasa Enterprise. The TEDPolicy correctly predicts that
-Rasa Enterprise should be explained to the user, and then also takes them down the getting started
+asks how they can get started with Rasa X. The TEDPolicy correctly predicts that
+Rasa X should be explained to the user, and then also takes them down the getting started
 path, without asking all the qualifying questions first.
 
 Since the machine-learning policy has generalized to this situation, you should add this story
 to your training data to continuously improve your bot and help the model generalize
-better in future. [Rasa Enterprise](https://rasa.com/docs/rasa-enterprise/) is a tool that can help
+better in future. [Rasa X](https://rasa.com/docs/rasa-enterprise/) is a tool that can help
 you improve your bot and make it more contextual.
 
 

--- a/docs/docs/conversation-driven-development.mdx
+++ b/docs/docs/conversation-driven-development.mdx
@@ -24,7 +24,7 @@ CDD is not a linear process; you'll circle back to the same actions over and ove
 
 Read more about these actions and the concept of CDD on the [Rasa Blog](https://blog.rasa.com/conversation-driven-development-a-better-approach-to-building-ai-assistants/).
 
-You can also check out [Rasa Enterprise](https://rasa.com/docs/rasa-enterprise/), a purpose-built tool for CDD.
+You can also check out [Rasa X](https://rasa.com/docs/rasa-enterprise/), a purpose-built tool for CDD.
 
 ## CDD in early stages of development
 
@@ -42,10 +42,13 @@ If you're at the earliest stage of bot development, it might seem like CDD has n
     CDD leads to frequent, smaller updates to your bot as you gather insights from bot conversations. [Setting up a CI/CD pipeline](setting-up-ci-cd.mdx) early on in development will enable you to act quickly on what you see in conversations.
 
 
+At this stage, you can [install Rasa X in local mode](https://rasa.com/docs/rasa-enterprise/installation-and-setup/installation-guide/#local-mode) to make it easier to share your bot with test users, collect conversations, and apply NLU and Story best practices based on the conversations you collect.
+
+
 ## CDD with a bot in production
 
 Once your bot is in production, you'll have more conversations to gain insights from. Then you can fully apply CDD actions.
-At this stage, you can [install Rasa Enterprise on a server](https://rasa.com/docs/rasa-enterprise/installation-and-setup/installation-guide/#helm-chart)
+At this stage, you can [install Rasa X on a server](https://rasa.com/docs/rasa-enterprise/installation-and-setup/installation-guide/#helm-chart)
 to both deploy your bot and enable CDD with a bot in production.
 
 ### Review

--- a/docs/docs/deploy/deploy-rasa-x.mdx
+++ b/docs/docs/deploy/deploy-rasa-x.mdx
@@ -1,0 +1,18 @@
+---
+id: deploy-rasa-x
+sidebar_label: "Deploy Rasa X"
+title: "Deploy Rasa X"
+description: "Deploying Rasa X to improve your Rasa assistant"
+abstract: This page shows you where to find out how to deploy Rasa X and forward events to it from your Rasa Open Source deployment.
+---
+<!-- this file is version specific, do not use `@site/...` syntax -->
+import variables from './../variables.json';
+
+## a. Deploy Rasa X
+
+Visit the [Installation Guide for Rasa X](https://rasa.com/docs/rasa-enterprise/installation-and-setup/installation-guide) where you can learn about available installation methods and
+how to deploy Rasa X by following one of them.
+
+## b. Connect Rasa Open Source deployment to Rasa X
+
+Visit the [Connect Rasa Open Source deployment](https://rasa.com/docs/rasa-enterprise/installation-and-setup/deploy#2-connect-rasa-open-source-deployment-the-rasa-helm-chart) section to learn how to connect your Rasa Assistant to Rasa X deployment.

--- a/docs/docs/deploy/deploy-rasa.mdx
+++ b/docs/docs/deploy/deploy-rasa.mdx
@@ -285,3 +285,4 @@ Visit [the Rasa helm chart README](https://github.com/RasaHQ/helm-charts/tree/ma
 ## Next Steps
 
 - Visit [the Rasa helm chart repository](https://github.com/RasaHQ/helm-charts/tree/main/charts/rasa) where you can find examples of configuration
+- Visit [the Rasa X docs](https://rasa.com/docs/rasa-enterprise/) and learn how to [integrate your Rasa Open Source deployment with Rasa X](https://rasa.com/docs/rasa-enterprise/installation-and-setup/deploy#2-connect-rasa-open-source-deployment-the-rasa-helm-chart).

--- a/docs/docs/deploy/introduction.mdx
+++ b/docs/docs/deploy/introduction.mdx
@@ -19,6 +19,13 @@ The best time to deploy your assistant and make it available to test users is on
 important happy paths or is what we call a [minimum viable assistant](../glossary.mdx). Then you can use incoming
 conversations to inform further development of your assistant.
 
+Connecting your deployed assistant to Rasa X makes it easy to share your assistant
+with test users via the [share your assistant feature in
+Rasa X](https://rasa.com/docs/rasa-enterprise/user-guide/share-assistant#share-your-bot).
+Then, when you're ready to make your assistant available via one or more [Messaging and Voice Channels](../messaging-and-voice-channels.mdx),
+you can add them to your existing deployment set up.
+See the [Rasa X Installation Guide](https://rasa.com/docs/rasa-enterprise/installation-and-setup/installation-guide/) to learn how to deploy Rasa X and connect it to your Rasa Open Source deployment.
+
 
 ## Recommended Deployment Method
 The [Rasa Helm chart](https://github.com/RasaHQ/helm-charts/tree/main/charts/rasa) is the production ready method to deploy

--- a/docs/docs/event-brokers.mdx
+++ b/docs/docs/event-brokers.mdx
@@ -6,7 +6,10 @@ description: Find out how open source chatbot framework Rasa allows you to strea
 ---
 
 An event broker allows you to connect your running assistant to other services that process the data coming
-in from conversations. The event broker publishes messages to a message streaming service,
+in from conversations. For example, you could [connect your live assistant to
+Rasa X](https://rasa.com/docs/rasa-enterprise/installation-and-setup/deploy#connect-an-existing-deployment)
+to review and annotate conversations or forward messages to an external analytics
+service. The event broker publishes messages to a message streaming service,
 also known as a message broker, to forward Rasa [Events](https://rasa.com/docs/action-server/events) from the Rasa server to other services.
 
 ## Format

--- a/docs/docs/glossary.mdx
+++ b/docs/docs/glossary.mdx
@@ -97,7 +97,7 @@ Dual Intent and Entity Transformer. The default NLU architecture used by Rasa Op
 
 ## [Interactive Learning](./writing-stories.mdx#using-interactive-learning)
 
-  In the Rasa CLI, a training mode where the developer corrects and validates the assistant’s predictions at every step of the conversation. The conversation can be saved to the story format and added to the assistant’s training data.
+  In Rasa X or the Rasa CLI, a training mode where the developer corrects and validates the assistant’s predictions at every step of the conversation. The conversation can be saved to the story format and added to the assistant’s training data.
   
 ## [Knowledge Base / Knowledge Graph](https://rasa.com/docs/action-server/knowledge-bases)
 
@@ -125,6 +125,10 @@ Dual Intent and Entity Transformer. The default NLU architecture used by Rasa Op
 
   Natural Language Understanding (NLU) deals with parsing and understanding human language into a structured format.  
 
+## [NLU Inbox](https://rasa.com/docs/rasa-enterprise/user-guide/annotate-nlu-examples)
+
+  The area within Rasa X where new user messages are collected for review and annotation. Only messages not already represented in the training data will appear in the NLU Inbox.
+
 ## [Pipeline](./tuning-your-model.mdx)
 
   The list of NLU components (see [NLU Component](#nlu-component)) that defines a Rasa assistant’s NLU system. A user message is processed by each component one by one, before returning the final structured output.
@@ -149,9 +153,9 @@ Dual Intent and Entity Transformer. The default NLU architecture used by Rasa Op
 
   An element in the Rasa NLU pipeline (see [Pipeline](#pipeline)) that processes incoming messages. Components perform tasks ranging from entity extraction to intent classification to pre-processing.
   
-## [Rasa Enterprise](https://rasa.com/docs/rasa-enterprise/)
+## [Rasa X](https://rasa.com/docs/rasa-enterprise/)
 
-  A tool for [conversation-driven development](./conversation-driven-development.mdx). Rasa Enterprise helps teams share and test an assistant built with Rasa Open Source, annotate user messages, and view conversations.
+  A tool for [conversation-driven development](./conversation-driven-development.mdx). Rasa X helps teams share and test an assistant built with Rasa Open Source, annotate user messages, and view conversations.
   
 ## [Retrieval Intent](./chitchat-faqs.mdx)
 
@@ -171,6 +175,9 @@ Dual Intent and Entity Transformer. The default NLU architecture used by Rasa Op
   answering FAQs, filling [Forms](./forms.mdx), or handling
   [Fallbacks](./fallback-handoff.mdx#fallbacks).
 
+## [Share Your Bot](https://rasa.com/docs/rasa-enterprise/user-guide/share-assistant)
+  Rasa X feature that generates a link to a chat UI for test users. **Share your bot** allows test users to talk to an assistant while it’s still in development. 
+
 ## [Slot](./domain.mdx#slots)
 
   A key-value store that Rasa uses to track information over the course of a conversation.
@@ -179,6 +186,10 @@ Dual Intent and Entity Transformer. The default NLU architecture used by Rasa Op
 
   Training data format for the dialogue model, consisting of a conversation between a user and a bot. The user's messages are represented as annotated intents and entities, and the bot’s responses are represented as a sequence of actions. 
   
+## [Talk to Your Bot](https://rasa.com/docs/rasa-enterprise/user-guide/share-assistant#talk-to-your-bot)
+
+  Chat interface within Rasa X that allows bot developers to talk to, test, and correct their assistant. Can be enabled in strict Interactive Learning mode, which requires each prediction to be confirmed before the conversation can proceed.
+
 ## [TED Policy](./policies.mdx#ted-policy)
 
   Transformer Embedding Dialogue Policy. TED is the default machine learning-based dialogue policy used by Rasa Open Source. TED complements rule-based policies by handling previously unseen situations, where no rule exists to determine the next action. 

--- a/docs/docs/messaging-and-voice-channels.mdx
+++ b/docs/docs/messaging-and-voice-channels.mdx
@@ -36,7 +36,7 @@ Learn how to make your assistant available on:
 
 ## Testing Channels on Your Local Machine
 
-If you're running a Rasa Open Source server on `localhost`, 
+If you're running Rasa X Local mode or a Rasa Open Source server on `localhost`, 
 most external channels won't be able to find your server URL, since `localhost` is not open to the internet. 
 
 To make a port on your local machine publicly available on the internet, 

--- a/docs/docs/reaching-out-to-user.mdx
+++ b/docs/docs/reaching-out-to-user.mdx
@@ -152,7 +152,8 @@ The response will use the value from the slot `plant` to warn about the specific
 
 ### Try it out
 
-To try out the dry plant notification example, you'll need to start a [CallbackChannel](./connectors/your-own-website.mdx#callbackinput).
+To try out the dry plant notification example, you'll need to start either [Rasa X](https://rasa.com/docs/rasa-enterprise/)
+or a [CallbackChannel](./connectors/your-own-website.mdx#callbackinput).
 
 :::caution
 External Events and Reminders don't work in request-response channels like the `rest` channel or `rasa shell`.
@@ -431,7 +432,8 @@ intents:
 
 ### Try it Out
 
-To try out reminders you'll need to start a [CallbackChannel](./connectors/your-own-website.mdx#callbackinput).
+To try out reminders you'll need to start either [Rasa X](https://rasa.com/docs/rasa-enterprise/)
+or a [CallbackChannel](./connectors/your-own-website.mdx#callbackinput).
 You'll also need to start the action server to schedule, react to, and cancel your reminders.
 See the [reminderbot README](https://github.com/RasaHQ/rasa/blob/main/examples/reminderbot) for details.
 

--- a/docs/docs/rei/deploy.mdx
+++ b/docs/docs/rei/deploy.mdx
@@ -171,4 +171,6 @@ For the rest channel, no credentials are required. To learn more see: https://ra
 
 ## Next steps
 
+- [Learn how to deploy Rasa X / Enterprise](https://rasa.com/docs/rasa-enterprise/installation-and-setup/installation-guide)
+- [Learn how to connect Rasa OSS to Rasa X / Enterprise](https://rasa.com/docs/rasa-enterprise/installation-and-setup/deploy#2-connect-rasa-open-source-deployment-the-rasa-helm-chart)
 - Visit [Rasa OSS Helm chart](https://github.com/RasaHQ/helm-charts/tree/main/charts/rasa)

--- a/docs/docs/setting-up-ci-cd.mdx
+++ b/docs/docs/setting-up-ci-cd.mdx
@@ -110,13 +110,13 @@ succeeded.
 
 If you ran [test stories](./testing-your-assistant.mdx) in your CI pipeline,
 you'll already have a trained model. You can set up your CD pipeline to upload the trained model to your
-Rasa server if the CI results are satisfactory. For example, to upload a model to Rasa Enterprise:
+Rasa server if the CI results are satisfactory. For example, to upload a model to Rasa X:
 
 ```bash
 curl -k -F "model=@models/my_model.tar.gz" "https://example.rasa.com/api/projects/default/models?api_token={your_api_token}"
 ```
 
-If you are using Rasa Enterprise, you can also [tag the uploaded model](https://rasa.com/docs/rasa-enterprise/pages/http-api/#tag/Models/paths/~1projects~1{project_id}~1models~1{model}~1tags~1{tag}/put)
+If you are using Rasa X, you can also [tag the uploaded model](https://rasa.com/docs/rasa-enterprise/pages/http-api/#tag/Models/paths/~1projects~1{project_id}~1models~1{model}~1tags~1{tag}/put)
 as production (or whichever deployment you want to tag if using multiple [deployment environments](https://rasa.com/docs/rasa-enterprise/enterprise/deployment-environments/#)):
 
 ```bash

--- a/docs/docs/testing-your-assistant.mdx
+++ b/docs/docs/testing-your-assistant.mdx
@@ -185,6 +185,7 @@ Conversation testing is only as thorough and accurate as the test
 cases you include, so you should continue to grow your set of test stories
 as you make improvements to your assistant. A good rule of thumb to follow is that you should aim for your test stories
 to be representative of the true distribution of real conversations.
+Rasa X makes it easy to [add test conversations based on real conversations](https://rasa.com/docs/rasa-enterprise/user-guide/test-assistant/#how-to-create-tests).
 
 See the [CLI documentation on `rasa test`](./command-line-interface.mdx#rasa-test) for
 more configuration options.

--- a/docs/docs/writing-stories.mdx
+++ b/docs/docs/writing-stories.mdx
@@ -497,6 +497,10 @@ your bot doesn't know how to do something yet, you can just teach it!
 
 In Rasa Open Source, you can run interactive learning in the command line with
 [`rasa interactive`](./command-line-interface.mdx#rasa-interactive).
+[Rasa X](http://rasa.com/docs/rasa-enterprise) provides a UI for interactive learning,
+and you can use any user conversation as a starting point.
+See [Talk to Your Bot](https://rasa.com/docs/rasa-enterprise/user-guide/share-assistant/#talk-to-your-bot)
+in the Rasa X docs.
 
 ### Command-line Interactive Learning
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -51,6 +51,7 @@ module.exports = {
         'deploy/introduction',
         'deploy/deploy-rasa',
         'deploy/deploy-action-server',
+        'deploy/deploy-rasa-x',
         {
             type: 'category',
             label: 'Deployment Tools',

--- a/examples/reminderbot/README.md
+++ b/examples/reminderbot/README.md
@@ -30,7 +30,12 @@ To train and chat with `reminderbot`, execute the following steps:
     rasa run actions
     ```
 
-3. To test this example, run a
+3. (Option 1) Run Rasa X to talk to your bot. In a separate console window from where you ran the step 2 command:
+    ```
+    rasa x
+    ```
+
+3. (Option 2) To test this example without Rasa X, run a
    [callback channel](https://rasa.com/docs/rasa/connectors/your-own-website#callbackinput).
    In a separate console window from where you ran the step 2 command:
     ```

--- a/rasa/__main__.py
+++ b/rasa/__main__.py
@@ -77,9 +77,18 @@ def create_argument_parser() -> argparse.ArgumentParser:
 
 def print_version() -> None:
     """Prints version information of rasa tooling and python."""
+
+    try:
+        from rasax.community.version import __version__
+
+        rasa_x_info = __version__
+    except ModuleNotFoundError:
+        rasa_x_info = None
+
     print(f"Rasa Version      :         {version.__version__}")
     print(f"Minimum Compatible Version: {MINIMUM_COMPATIBLE_VERSION}")
     print(f"Rasa SDK Version  :         {rasa_sdk_version}")
+    print(f"Rasa X Version    :         {rasa_x_info}")
     print(f"Python Version    :         {platform.python_version()}")
     print(f"Operating System  :         {platform.platform()}")
     print(f"Python Path       :         {sys.executable}")

--- a/rasa/cli/initial_project/credentials.yml
+++ b/rasa/cli/initial_project/credentials.yml
@@ -27,7 +27,7 @@ rest:
 #  token: "<bot token>"
 #  webhook_url: "<callback URL>"
 
-# This entry is needed if you are using Rasa Enterprise. The entry represents credentials
-# for the Rasa Enterprise "channel", i.e. Talk to your bot and Share with guest testers.
+# This entry is needed if you are using Rasa X. The entry represents credentials
+# for the Rasa X "channel", i.e. Talk to your bot and Share with guest testers.
 rasa:
   url: "http://localhost:5002/api"

--- a/rasa/core/channels/rasa_chat.py
+++ b/rasa/core/channels/rasa_chat.py
@@ -21,11 +21,10 @@ INTERACTIVE_LEARNING_PERMISSION = "clientEvents:create"
 
 
 class RasaChatInput(RestInput):
-    """Chat input channel for Rasa Enterprise."""
+    """Chat input channel for Rasa X"""
 
     @classmethod
     def name(cls) -> Text:
-        """Name of the channel."""
         return "rasa"
 
     @classmethod
@@ -68,7 +67,7 @@ class RasaChatInput(RestInput):
                     logger.error(
                         "Retrieved json response from URL '{}' but could not find "
                         "'{}' field containing the JWT public key. Please make sure "
-                        "you use an up-to-date version of Rasa Enterprise (>= 0.20.2). "
+                        "you use an up-to-date version of Rasa X (>= 0.20.2). "
                         "Response was: {}"
                         "".format(public_key_url, public_key_field, json.dumps(rjs))
                     )
@@ -89,7 +88,7 @@ class RasaChatInput(RestInput):
             )
 
     async def _extract_sender(self, req: Request) -> Optional[Text]:
-        """Fetch user from the Rasa Enterprise Admin API."""
+        """Fetch user from the Rasa X Admin API."""
         jwt_payload = None
         if req.headers.get("Authorization"):
             jwt_payload = await self._decode_bearer_token(req.headers["Authorization"])


### PR DESCRIPTION
Reverts RasaHQ/rasa#11156

⚠️ this needs to be merged before the next 3.1.x micro release, and re-applied after it's done. I'll also take care of the merge back into `main`