### PR TITLE
Do not merge 3.0/3.1 back to main

### DIFF
--- a/.github/workflows/automatic-release-to-main-merger.yml
+++ b/.github/workflows/automatic-release-to-main-merger.yml
@@ -7,6 +7,9 @@ on:
     - '[0-9]+.[0-9]+.x'
     # Don't merge 2.8.x into main
     - '!2.8.x'
+    # Don't merge 3.0 and 3.1 into main
+    - '!3.0.x'
+    - '!3.1.x'
 
     types:
     # means that the PR is closed, we still have to check if it was merged


### PR DESCRIPTION
We do not want to merge back these releases to the main branch.

Ex:
* https://github.com/RasaHQ/rasa/pull/11250
* https://github.com/RasaHQ/rasa/pull/11202