### PR TITLE
Remove dependabot targeting previous releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - type:dependencies
-      - release:3.2
+      - release:main
     ignore:
       - dependency-name: prompt-toolkit
         versions:
@@ -18,65 +18,7 @@ updates:
       - dependency-name: pytest-asyncio
         versions:
           - "> 0.10.0"
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: "tuesday"
-      time: '13:00'
-    target-branch: "3.1.x"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 10
-    labels:
-      - type:dependencies
-      - release:3.1
-    ignore:
-      - dependency-name: prompt-toolkit
-        versions:
-          - "> 2.0.10"
-      - dependency-name: pytest-asyncio
-        versions:
-          - "> 0.10.0"
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: "tuesday"
-      time: '13:00'
-    target-branch: "3.0.x"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 10
-    labels:
-      - type:dependencies
-      - release:3.0
-    ignore:
-      - dependency-name: prompt-toolkit
-        versions:
-          - "> 2.0.10"
-      - dependency-name: pytest-asyncio
-        versions:
-          - "> 0.10.0"
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: monthly
-      time: '13:00'
-    target-branch: "2.8.x"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 10
-    labels:
-      - type:dependencies
-      - release:2.8
-    ignore:
-      - dependency-name: prompt-toolkit
-        versions:
-          - "> 2.0.10"
-      - dependency-name: pytest-asyncio
-        versions:
-          - "> 0.10.0"
+
   - package-ecosystem: npm
     directory: "/docs"
     schedule:

--- a/.github/workflows/ci-github-actions.yml
+++ b/.github/workflows/ci-github-actions.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    name: Run Actions Tests 
+    name: Run Actions Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Proposed changes**:

We can't configure dependabot for targeting upgrades related to security vulnerabilities only.
As it is, it creates too much noise.
