### PR TITLE
Slack channel fixes

### DIFF
--- a/changelog/11305.bugfix.md
+++ b/changelog/11305.bugfix.md
@@ -1,1 +1,2 @@
-Fixed a problem that caused Slack to go in timeout if the action took more than 3 seconds.
+- Fixed error in creating response when slack sends retry messages. Assigning `None` to `response.text` caused `TypeError: Bad body type. Expected str, got NoneType`.
+- Fixed Slack triggering timeout after 3 seconds if the action execution is too slow. Running `on_new_message` as an asyncio background task instead of a blocking await fixes this by immediately returning a response with code 200.

--- a/changelog/11305.bugfix.md
+++ b/changelog/11305.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a problem that caused Slack to go in timeout if the action took more than 3 seconds.

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import hmac
 from http import HTTPStatus
@@ -385,7 +386,7 @@ class SlackInput(InputChannel):
                 metadata=metadata,
             )
 
-            await on_new_message(user_msg)
+            asyncio.create_task(on_new_message(user_msg))
         except Exception as e:
             logger.error(f"Exception when trying to handle message.{e}")
             logger.error(str(e), exc_info=True)

--- a/rasa/core/channels/slack.py
+++ b/rasa/core/channels/slack.py
@@ -364,7 +364,7 @@ class SlackInput(InputChannel):
             )
 
             return response.text(
-                None, status=HTTPStatus.CREATED, headers={"X-Slack-No-Retry": "1"}
+                "", status=HTTPStatus.CREATED, headers={"X-Slack-No-Retry": "1"}
             )
 
         if metadata is not None:

--- a/tests/core/channels/test_slack.py
+++ b/tests/core/channels/test_slack.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 import json
 import logging
 import time
@@ -11,6 +12,7 @@ from sanic.compat import Header
 from sanic.request import Request
 
 from rasa.core.channels import SlackInput
+from rasa.core.channels.channel import UserMessage
 from rasa.shared.exceptions import InvalidConfigException
 from tests.utilities import json_of_latest_request, latest_request
 
@@ -913,3 +915,64 @@ def test_slack_verify_signature_missing_headers():
     slack = SlackInput("mytoken", slack_signing_secret="foobar")
 
     assert slack.is_request_from_slack_authentic(request) is False
+
+
+async def fake_on_new_message(message: UserMessage):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_slack_process_message_retry():
+    input_channel = SlackInput(
+        slack_token="YOUR_SLACK_TOKEN",
+        slack_channel="YOUR_SLACK_CHANNEL",
+        slack_signing_secret="foobar",
+    )
+
+    request = Mock()
+    request.headers = {
+        input_channel.retry_num_header: 1,
+        input_channel.retry_reason_header: input_channel.errors_ignore_retry[0],
+    }
+
+    response = await input_channel.process_message(
+        request=request,
+        on_new_message=fake_on_new_message,
+        text="",
+        sender_id=None,
+        metadata=None,
+    )
+
+    assert response.status == HTTPStatus.CREATED
+    assert response.headers == {"X-Slack-No-Retry": "1"}
+
+
+async def fake_on_new_message_sleep(message: UserMessage):
+    time.sleep(3)
+
+
+@pytest.mark.asyncio
+async def test_slack_process_message_timeout():
+    input_channel = SlackInput(
+        slack_token="YOUR_SLACK_TOKEN",
+        slack_channel="YOUR_SLACK_CHANNEL",
+        slack_signing_secret="foobar",
+    )
+
+    request = Mock()
+    request.headers = {}
+
+    start = time.time()
+    response = await input_channel.process_message(
+        request=request,
+        on_new_message=fake_on_new_message_sleep,
+        text="",
+        sender_id=None,
+        metadata=None,
+    )
+    end = time.time()
+
+    duration = end - start
+
+    assert duration < 3
+    assert response.status == HTTPStatus.OK

--- a/tests/core/channels/test_slack.py
+++ b/tests/core/channels/test_slack.py
@@ -454,6 +454,7 @@ def test_slackbot_init_three_parameter():
 
 # Use monkeypatch for sending attachments, images and plain text.
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_attachment_only():
     from rasa.core.channels.slack import SlackBot
 
@@ -482,6 +483,7 @@ async def test_slackbot_send_attachment_only():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_attachment_only_threaded():
     from rasa.core.channels.slack import SlackBot
 
@@ -511,6 +513,7 @@ async def test_slackbot_send_attachment_only_threaded():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_attachment_with_text():
     from rasa.core.channels.slack import SlackBot
 
@@ -540,6 +543,7 @@ async def test_slackbot_send_attachment_with_text():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_attachment_with_text_threaded():
     from rasa.core.channels.slack import SlackBot
 
@@ -570,6 +574,7 @@ async def test_slackbot_send_attachment_with_text_threaded():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_image_url():
     from rasa.core.channels.slack import SlackBot
 
@@ -598,6 +603,7 @@ async def test_slackbot_send_image_url():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_image_url_threaded():
     from rasa.core.channels.slack import SlackBot
 
@@ -627,6 +633,7 @@ async def test_slackbot_send_image_url_threaded():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_text():
     from rasa.core.channels.slack import SlackBot
 
@@ -654,6 +661,7 @@ async def test_slackbot_send_text():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_text_threaded():
     from rasa.core.channels.slack import SlackBot
 
@@ -682,6 +690,7 @@ async def test_slackbot_send_text_threaded():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_text_with_buttons():
     from rasa.core.channels.slack import SlackBot
 
@@ -725,6 +734,7 @@ async def test_slackbot_send_text_with_buttons():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_text_with_buttons_threaded():
     from rasa.core.channels.slack import SlackBot
 
@@ -769,6 +779,7 @@ async def test_slackbot_send_text_with_buttons_threaded():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_custom_json():
     from rasa.core.channels.slack import SlackBot
 
@@ -795,6 +806,7 @@ async def test_slackbot_send_custom_json():
 
 
 @pytest.mark.filterwarnings("ignore:unclosed.*:ResourceWarning")
+@pytest.mark.asyncio
 async def test_slackbot_send_custom_json_threaded():
     from rasa.core.channels.slack import SlackBot
 


### PR DESCRIPTION
**Proposed changes**:
- Fixed response when slack sends retries (None was giving error)
- Running on_new_message as an asyncio background task instead of a blocking await (so that we immediately return 200 to Slack and we don't reach the 3 seconds timeout if the action execution is slow)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
