### PR TITLE
ATO 207 run form validation  on form activation

### DIFF
--- a/changelog/11326.bugfix.md
+++ b/changelog/11326.bugfix.md
@@ -1,0 +1,1 @@
+Revert change in #10295 that removed running the form validation action on activation of the form before the loop is active.

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -534,11 +534,8 @@ class FormAction(LoopAction):
            - the form is called after `action_listen`
            - form validation was not cancelled
         """
-        # No active_loop means there are no form filled slots to validate yet
-        if not tracker.active_loop:
-            return []
-
-        needs_validation = (
+        # no active_loop means that it is called during activation
+        needs_validation = not tracker.active_loop or (
             tracker.latest_action_name == ACTION_LISTEN_NAME
             and not tracker.is_active_loop_interrupted
         )

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -336,10 +336,7 @@ class FormAction(LoopAction):
         domain: Domain,
         slot_values: Dict[Text, Any],
     ) -> Dict[Text, Any]:
-        slot_mappings = self.get_mappings_for_slot(event.key, domain)
-
-        for mapping in slot_mappings:
-            slot_values[event.key] = event.value
+        slot_values[event.key] = event.value
 
         return slot_values
 

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -67,6 +67,7 @@ async def test_activate():
         tracker,
         domain,
     )
+    assert isinstance(events[-1], BotUttered)
     assert events[:-1] == [ActiveLoop(form_name), SlotSet(REQUESTED_SLOT, slot_name)]
 
 

--- a/tests/core/actions/test_forms.py
+++ b/tests/core/actions/test_forms.py
@@ -1,7 +1,6 @@
 import textwrap
-from typing import Dict, Text, List, Any, Union, Optional
+from typing import Dict, Text, List, Any, Union
 from unittest.mock import Mock
-from xml import dom
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -73,17 +72,20 @@ async def test_activate(monkeypatch: MonkeyPatch):
 
     async def mocked_action_response(*args, **kwargs):
         return {
-                "events": [
-                    {
-                        "event": "slot",
-                        "timestamp": None,
-                        "name": slot_set_by_remote_custom_extraction_method,
-                        "value": slot_value_set_by_remote_custom_extraction_method
-                    }
-                ],
-                "responses": []
-            }
-    monkeypatch.setattr("rasa.utils.endpoints.EndpointConfig.request", mocked_action_response)
+            "events": [
+                {
+                    "event": "slot",
+                    "timestamp": None,
+                    "name": slot_set_by_remote_custom_extraction_method,
+                    "value": slot_value_set_by_remote_custom_extraction_method,
+                }
+            ],
+            "responses": [],
+        }
+
+    monkeypatch.setattr(
+        "rasa.utils.endpoints.EndpointConfig.request", mocked_action_response
+    )
 
     events = await action.run(
         CollectingOutputChannel(),
@@ -93,8 +95,11 @@ async def test_activate(monkeypatch: MonkeyPatch):
     )
     assert events[:-1] == [
         ActiveLoop(form_name),
-        SlotSet(slot_set_by_remote_custom_extraction_method, slot_value_set_by_remote_custom_extraction_method),
-        SlotSet(REQUESTED_SLOT, domain_required_slot_name)
+        SlotSet(
+            slot_set_by_remote_custom_extraction_method,
+            slot_value_set_by_remote_custom_extraction_method,
+        ),
+        SlotSet(REQUESTED_SLOT, domain_required_slot_name),
     ]
     assert isinstance(events[-1], BotUttered)
 


### PR DESCRIPTION
**Proposed changes**:
- Revert change here https://github.com/RasaHQ/rasa/pull/10295/files#r807244104 that removed running the form validation action on activation of the form (before the loop is active).
- This would make #10913 obsolete since the 2.x mechanism for achieving the same thing would be returned.
- Closes #11199 
- Resolves the issue where any `extract_<slot_name>` method in a FormValidationAction subclass only runs after a required_slot in the form has been set (i.e. after activation).

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
