### PR TITLE
update plugin for program output in docs

### DIFF
--- a/docs/plugins/program_output.js
+++ b/docs/plugins/program_output.js
@@ -32,7 +32,7 @@ const { readFile, writeFile } = fs.promises;
 
 const PROGRAM_OUTPUT_RE = /```[a-z]+ \[([^\]]+)\]\n```/;
 
-const VERSIONED_DOCS_PATH_RE = /(\/versioned_docs\/version-\d+\.\d+\.x)\//;
+const VERSIONED_DOCS_PATH_RE = /(\/versioned_docs\/version-\d+\.x)\//;
 
 const defaultOptions = {
     docsDir: './docs',


### PR DESCRIPTION
**Proposed changes**:
- Change regex for docusaurus plugin that looks for versioned docs to look for `X.x` folders not `X.x.x`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
