### PR TITLE
Run default `action_extract_slots` after a `UserUttered` event returned by a custom action

### DIFF
--- a/changelog/11362.bugfix.md
+++ b/changelog/11362.bugfix.md
@@ -1,0 +1,1 @@
+Run default action `action_extract_slots` after a custom action returns a `UserUttered` event to fill any applicable slots.

--- a/data/test_custom_action_triggers_action_extract_slots/config.yml
+++ b/data/test_custom_action_triggers_action_extract_slots/config.yml
@@ -10,7 +10,7 @@ pipeline:
     min_ngram: 1
     max_ngram: 4
   - name: DIETClassifier
-    epochs: 100
+    epochs: 15
     constrain_similarities: true
   - name: EntitySynonymMapper
 

--- a/data/test_custom_action_triggers_action_extract_slots/config.yml
+++ b/data/test_custom_action_triggers_action_extract_slots/config.yml
@@ -1,0 +1,24 @@
+version: "3.1"
+
+pipeline:
+  - name: WhitespaceTokenizer
+  - name: RegexFeaturizer
+  - name: LexicalSyntacticFeaturizer
+  - name: CountVectorsFeaturizer
+  - name: CountVectorsFeaturizer
+    analyzer: char_wb
+    min_ngram: 1
+    max_ngram: 4
+  - name: DIETClassifier
+    epochs: 100
+    constrain_similarities: true
+  - name: EntitySynonymMapper
+
+policies:
+  - name: AugmentedMemoizationPolicy
+    max_history: 6
+  - name: RulePolicy
+    core_fallback_threshold: 0.4
+    core_fallback_action_name: "action_fallback_universal_search"
+    enable_fallback_prediction: True
+    check_for_contradictions: True

--- a/data/test_custom_action_triggers_action_extract_slots/domain.yml
+++ b/data/test_custom_action_triggers_action_extract_slots/domain.yml
@@ -1,0 +1,24 @@
+version: "3.1"
+
+intents:
+  - activate_flow
+  - mood_great
+
+entities:
+  - mood
+
+slots:
+  mood_slot:
+    type: text
+    influence_conversation: true
+    mappings:
+      - type: from_entity
+        entity: mood
+
+responses:
+  utter_happy:
+    - text: Great, carry on!
+
+actions:
+  - action_force_next_utter
+  - action_fallback_universal_search

--- a/data/test_custom_action_triggers_action_extract_slots/nlu.yml
+++ b/data/test_custom_action_triggers_action_extract_slots/nlu.yml
@@ -1,0 +1,12 @@
+version: "3.1"
+
+nlu:
+- intent: activate_flow
+  examples: |
+    - Trigger custom action.
+    - Activate custom action.
+
+- intent: mood_great
+  examples: |
+    - I am so [happy](mood).
+    - Feeling [sad](mood).

--- a/data/test_custom_action_triggers_action_extract_slots/stories.yml
+++ b/data/test_custom_action_triggers_action_extract_slots/stories.yml
@@ -1,0 +1,15 @@
+version: "3.1"
+
+stories:
+
+- story: happy path
+  steps:
+  - intent: activate_flow
+  - action: action_force_next_utter
+
+- story: test next action
+  steps:
+  - intent: mood_great
+    entities:
+    - mood: happy
+  - action: utter_happy

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -887,6 +887,15 @@ class MessageProcessor:
             events = []
 
         self._log_action_on_tracker(tracker, action, events, prediction)
+
+        if any(isinstance(e, UserUttered) for e in events):
+            logger.debug(
+                f"A `UserUttered` event was returned by executing "
+                f"action '{action.name()}'. This will run the default action "
+                f"'{ACTION_EXTRACT_SLOTS}'."
+            )
+            tracker = await self.run_action_extract_slots(output_channel, tracker)
+
         if action.name() != ACTION_LISTEN_NAME and not action.name().startswith(
             UTTER_PREFIX
         ):

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -65,6 +65,7 @@ from rasa.shared.nlu.constants import INTENT_NAME_KEY, METADATA_MODEL_ID
 from rasa.shared.nlu.training_data.message import Message
 from rasa.utils.endpoints import EndpointConfig
 from rasa.shared.core.constants import (
+    ACTION_EXTRACT_SLOTS,
     ACTION_RESTART_NAME,
     ACTION_UNLIKELY_INTENT_NAME,
     DEFAULT_INTENTS,
@@ -1520,3 +1521,78 @@ async def test_loads_correct_model_from_path(
 
     assert core_processor.model_filename == trained_core_model_name
     assert nlu_processor.model_filename == trained_nlu_model_name
+
+
+async def test_custom_action_triggers_action_extract_slots(
+    trained_async: Callable,
+    caplog: LogCaptureFixture,
+):
+    parent_folder = "data/test_custom_action_triggers_action_extract_slots"
+    domain_path = f"{parent_folder}/domain.yml"
+    config_path = f"{parent_folder}/config.yml"
+    stories_path = f"{parent_folder}/stories.yml"
+    nlu_path = f"{parent_folder}/nlu.yml"
+
+    model_path = await trained_async(domain_path, config_path, [stories_path, nlu_path])
+    agent = Agent.load(model_path)
+    processor = agent.processor
+
+    action_server_url = "http://some-url"
+    endpoint = EndpointConfig(action_server_url)
+    processor.action_endpoint = endpoint
+
+    entity_name = "mood"
+    slot_name = "mood_slot"
+    slot_value = "happy"
+    custom_action = "action_force_next_utter"
+
+    sender_id = uuid.uuid4().hex
+    message = UserMessage(
+        text="Activate custom action.",
+        output_channel=CollectingOutputChannel(),
+        sender_id=sender_id,
+        parse_data={
+            "intent": {"name": "activate_flow", "confidence": 1},
+            "entities": [],
+        },
+    )
+
+    with aioresponses() as mocked:
+        mocked.post(
+            action_server_url,
+            payload={
+                "events": [
+                    {"event": "action", "name": "action_listen"},
+                    {
+                        "event": "user",
+                        "text": "Feeling so happy",
+                        "parse_data": {
+                            "intent": {"name": "mood_great", "confidence": 1.0},
+                            "entities": [{"entity": entity_name, "value": slot_value}],
+                        },
+                    },
+                ]
+            },
+        )
+        with caplog.at_level(logging.DEBUG):
+            await processor.handle_message(message)
+
+        caplog_records = [rec.message for rec in caplog.records]
+
+        assert (
+            f"A `UserUttered` event was returned by executing "
+            f"action '{custom_action}'. This will run the default action "
+            f"'{ACTION_EXTRACT_SLOTS}'." in caplog_records
+        )
+
+    tracker = processor.get_tracker(sender_id)
+    assert any(
+        isinstance(e, UserUttered) and e.text == "Feeling so happy"
+        for e in tracker.events
+    )
+    assert SlotSet(slot_name, slot_value) in tracker.events
+    assert tracker.get_slot(slot_name) == slot_value
+    assert any(
+        isinstance(e, BotUttered) and e.text == "Great, carry on!"
+        for e in tracker.events
+    )

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1523,6 +1523,7 @@ async def test_loads_correct_model_from_path(
     assert nlu_processor.model_filename == trained_nlu_model_name
 
 
+@pytest.mark.timeout(120, func_only=True)
 async def test_custom_action_triggers_action_extract_slots(
     trained_async: Callable,
     caplog: LogCaptureFixture,


### PR DESCRIPTION
**Proposed changes**:
- Fixes https://rasahq.atlassian.net/browse/ATO-244

**Status (please check what you already did)**:
- [X] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
