### PR TITLE
Allow `EndpointConfig` as parameter type given to `AwaitableTrackerStore.create()` method

### DIFF
--- a/changelog/11368.bugfix.md
+++ b/changelog/11368.bugfix.md
@@ -1,0 +1,1 @@
+Handle the case when an `EndpointConfig` object is given as parameter to the `AwaitableTrackerStore.create()` method.

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1398,10 +1398,13 @@ class AwaitableTrackerStore(TrackerStore):
         """Wrapper to call `create` method of primary tracker store."""
         if isinstance(obj, TrackerStore):
             return AwaitableTrackerStore(obj)
+        elif isinstance(obj, EndpointConfig):
+            return AwaitableTrackerStore(_create_from_endpoint_config(obj))
         else:
             raise ValueError(
                 f"{type(obj).__name__} supplied "
-                f"but expected object of type {TrackerStore.__name__}."
+                f"but expected object of type {TrackerStore.__name__} or "
+                f"of type {EndpointConfig.__name__}."
             )
 
     async def retrieve(self, sender_id: Text) -> Optional[DialogueStateTracker]:

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -966,3 +966,13 @@ def test_create_non_async_tracker_store(domain: Domain):
         tracker_store = TrackerStore.create(endpoint_config)
     assert isinstance(tracker_store, AwaitableTrackerStore)
     assert isinstance(tracker_store._tracker_store, NonAsyncTrackerStore)
+
+
+def test_create_awaitable_tracker_store_with_endpoint_config():
+    endpoint_config = EndpointConfig(
+        type="tests.core.test_tracker_stores.NonAsyncTrackerStore"
+    )
+    tracker_store = AwaitableTrackerStore.create(endpoint_config)
+
+    assert isinstance(tracker_store, AwaitableTrackerStore)
+    assert isinstance(tracker_store._tracker_store, NonAsyncTrackerStore)


### PR DESCRIPTION
**Proposed changes**:
- Fixes https://rasahq.atlassian.net/browse/ATO-222

**Status (please check what you already did)**:
- [X] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
