### PR TITLE
Fix the priority order of slot mappings in which slots are filled

### DIFF
--- a/changelog/11390.bugfix.md
+++ b/changelog/11390.bugfix.md
@@ -1,0 +1,2 @@
+Fixes broken `2.x` regression where the expected priority order in which slot mappings are applicable is from the beginning to the end of the slot mappings list specified in the domain.
+Clarifies this implicit priority order in the docs.

--- a/changelog/11390.bugfix.md
+++ b/changelog/11390.bugfix.md
@@ -1,2 +1,2 @@
-Fixes broken `2.x` regression where the expected priority order in which slot mappings are applicable is from the beginning to the end of the slot mappings list specified in the domain.
+Fixes regression in which slot mappings were prioritized according to reverse order as they were listed in the domain, instead of in order from first to last, as was implicitly expected in `2.x`.
 Clarifies this implicit priority order in the docs.

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -531,10 +531,8 @@ based on the latest user message.
 In addition to the predefined mappings, you can define [custom slot mappings](./domain.mdx#custom-slot-mappings).
 All custom slot mappings should contain a mapping of type `custom`.
 
-Slot mappings are defined as a YAML list of dictionaries mapped to the key `mappings` in the domain file.
-The priority order in which slot mappings fill slots follows the list indexing, where index 0 is top priority.
-Once a slot mapping becomes applicable, the default action [`action_extract_slots`](./default-actions.mdx#action_extract_slots) stops looping through the list of slot mappings and
-sets the slot with the extracted value.
+Slot mappings are specified as a YAML list of dictionaries under the key `mappings` in the domain file.
+Slot mappings are prioritized in the order they are listed in the domain. The first slot mapping found to apply will be used to fill the slot.
 
 The default behavior is for slot mappings to apply after every user message, regardless of the dialogue context.
 To make a slot mapping apply only within the context of a form see [Mapping Conditions](./domain.mdx#mapping-conditions).

--- a/docs/docs/domain.mdx
+++ b/docs/docs/domain.mdx
@@ -531,6 +531,11 @@ based on the latest user message.
 In addition to the predefined mappings, you can define [custom slot mappings](./domain.mdx#custom-slot-mappings).
 All custom slot mappings should contain a mapping of type `custom`.
 
+Slot mappings are defined as a YAML list of dictionaries mapped to the key `mappings` in the domain file.
+The priority order in which slot mappings fill slots follows the list indexing, where index 0 is top priority.
+Once a slot mapping becomes applicable, the default action [`action_extract_slots`](./default-actions.mdx#action_extract_slots) stops looping through the list of slot mappings and
+sets the slot with the extracted value.
+
 The default behavior is for slot mappings to apply after every user message, regardless of the dialogue context.
 To make a slot mapping apply only within the context of a form see [Mapping Conditions](./domain.mdx#mapping-conditions).
 There is one additional default limitation on applying `from_entity` slot mappings in the context of a form;

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1236,6 +1236,7 @@ class ActionExtractSlots(Action):
 
                     if value is not None or tracker.get_slot(slot.name) is not None:
                         slot_events.append(SlotSet(slot.name, value))
+                        break
 
                 should_fill_custom_slot = mapping_type == SlotMappingType.CUSTOM
 

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -2732,3 +2732,76 @@ async def test_action_extract_slots_emits_necessary_slot_set_events(
         assert events[0].value == value_to_set
     else:
         assert len(events) == 0
+
+
+async def test_action_extract_slots_priority_of_slot_mappings():
+    slot_name = "location_slot"
+    entity_name = "location"
+    entity_value = "Berlin"
+
+    domain_yaml = textwrap.dedent(
+        f"""
+        version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
+
+        intents:
+        - greet
+        - goodbye
+        - affirm
+        - deny
+        - mood_great
+        - mood_unhappy
+        - bot_challenge
+        - inform
+
+        entities:
+        - {entity_name}
+
+        slots:
+          {slot_name}:
+            type: text
+            influence_conversation: false
+            mappings:
+            - type: from_entity
+              entity: {entity_name}
+            - type: from_intent
+              value: 42
+              intent: inform
+
+        forms:
+          test_form:
+            required_slots:
+            - {slot_name}
+
+        responses:
+            utter_test:
+                - condition:
+                  - type: slot
+                    name: {slot_name}
+                    value: null
+                  text: "location slot is null"
+                - text: "location slot has value: {{slot_name}}"
+
+            utter_ask_location:
+                - text: "where are you located?"
+        """
+    )
+    domain = Domain.from_yaml(domain_yaml)
+    initial_events = [
+        UserUttered(
+            "I am located in Berlin",
+            intent={"name": "inform"},
+            entities=[{"entity": entity_name, "value": entity_value}],
+        ),
+    ]
+    tracker = DialogueStateTracker.from_events(sender_id="test_id", evts=initial_events)
+
+    action_extract_slots = ActionExtractSlots(None)
+
+    events = await action_extract_slots.run(
+        CollectingOutputChannel(),
+        TemplatedNaturalLanguageGenerator(domain.responses),
+        tracker,
+        domain,
+    )
+    tracker.update_with_events(events, domain=domain)
+    assert tracker.get_slot("location_slot") == entity_value

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -2744,13 +2744,6 @@ async def test_action_extract_slots_priority_of_slot_mappings():
         version: "{LATEST_TRAINING_DATA_FORMAT_VERSION}"
 
         intents:
-        - greet
-        - goodbye
-        - affirm
-        - deny
-        - mood_great
-        - mood_unhappy
-        - bot_challenge
         - inform
 
         entities:
@@ -2767,20 +2760,7 @@ async def test_action_extract_slots_priority_of_slot_mappings():
               value: 42
               intent: inform
 
-        forms:
-          test_form:
-            required_slots:
-            - {slot_name}
-
         responses:
-            utter_test:
-                - condition:
-                  - type: slot
-                    name: {slot_name}
-                    value: null
-                  text: "location slot is null"
-                - text: "location slot has value: {{slot_name}}"
-
             utter_ask_location:
                 - text: "where are you located?"
         """


### PR DESCRIPTION
**Proposed changes**:
- Fixes 2.x regression (broken in `3.x`) where the expected priority order in which slot mappings are applicable is from the beginning to the end of the slot mappings list specified in the domain (more context [here](https://rasahq.atlassian.net/browse/ATO-219))
- Clarifies this implicit priority order in the docs.

**Status (please check what you already did)**:
- [X] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
