### PR TITLE
update release tag evaluation in docs workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -72,61 +72,20 @@ jobs:
 
     - name: Check if tag version is equal or higher than the latest tagged Rasa version
       id: rasa_get_version
+      if: env.IS_TAG_BUILD == 'true' || env.IS_MAIN_BRANCH == 'true'
       run: |
         # Get latest tagged Rasa version
         git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
         # Fetch branch history
         git fetch --prune --unshallow
-        LATEST_TAGGED_NON_ALPHA_RASA_VERSION=$(git tag | sort -r -V | grep -E "^[0-9.]+$" | head -n1)
+        python scripts/evaluate_release_tag.py $TAG_NAME
+        exit_status=$?
 
-        echo "LATEST_TAGGED_NON_ALPHA_RASA_VERSION=${LATEST_TAGGED_NON_ALPHA_RASA_VERSION}" >> $GITHUB_ENV
-
-        # Return 'true' if tag version is equal or higher than the latest tagged Rasa version
-        IS_LATEST_VERSION=$((printf '%s\n%s\n' "${LATEST_TAGGED_NON_ALPHA_RASA_VERSION}" "$TAG_NAME" \
-          | sort -V -C && echo true || echo false) || true)
-
-
-        if [[ "${IS_LATEST_VERSION}" == "true" && "$TAG_NAME" =~ ^[0-9.]+$ ]]; then
-          echo "::set-output name=is_latest_version::true"
+        if [[ "${exit_status}" == "0" ]]; then
+          echo "::set-output name=build_docs::true"
         else
-          echo "::set-output name=is_latest_version::false"
+          echo "::set-output name=build_docs::false"
         fi
-
-
-    # MAJOR.MINOR.MICRO(PATCH)
-    # docs are built on every minor tag for the latest major (when 3.0 is out, the latest major is 3.0)
-    # (technically it'll be always the latest version)
-    #
-    # docs are built on every micro tag for the latest minor of
-    # - the latest major (when 3.0 is out, the latest major is 3.0)
-    # - the previous major (when 3.0 is out, the previous major is 2.0, the latest minor on this version being 2.8)
-    - name: Check if it's a micro tag for the latest minor
-      if: env.IS_TAG_BUILD == 'true' || env.IS_MAIN_BRANCH == 'true'
-      id: check_tag
-      run: |
-        IS_LATEST_VERSION=${{ steps.rasa_get_version.outputs.is_latest_version }}
-
-        # the latest major (when 3.0 is out, the latest major is 3.0)
-        # build docs on push to the main branch
-        if [[ "${IS_LATEST_VERSION}" == "true" || "${IS_MAIN_BRANCH}" == "true" ]]; then
-          echo "::set-output name=build_docs::true"
-          exit 0
-        fi
-
-        # the previous major (when 3.0 is out, the previous major is 2.0, the latest minor on this version being 2.8)
-        CURRENT_MAJOR_VERSION=$(echo ${LATEST_TAGGED_NON_ALPHA_RASA_VERSION} | awk -F\. '{print $1}')
-        PREVIOUS_MAJOR_LATEST_VERSION=$(git tag | sort -r -V | grep -E "^[0-9.]+$" | grep -vE "^${CURRENT_MAJOR_VERSION}" | head -n1)
-
-        # Return 'true' if tag version is equal or higher than the latest previous major version
-        IS_PREVIOUS_MAJOR_LATEST_VERSION=$((printf '%s\n%s\n' "${PREVIOUS_MAJOR_LATEST_VERSION}" "$TAG_NAME" \
-          | sort -V -C && echo true || echo false) || true)
-
-        if [[ "${IS_PREVIOUS_MAJOR_LATEST_VERSION}" == "true" ]]; then
-          echo "::set-output name=build_docs::true"
-          exit 0
-        fi
-
-        echo "::set-output name=build_docs::false"
 
   prebuild_docs:
     name: Prebuild Docs

--- a/scripts/evaluate_release_tag.py
+++ b/scripts/evaluate_release_tag.py
@@ -1,0 +1,74 @@
+"""Evaluate release tag for whether docs should be built or not.
+
+"""
+import os
+import argparse
+from pathlib import Path
+from subprocess import check_output
+from typing import List, Text, Set
+
+from pep440_version_utils import Version, is_valid_version
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Parse all the command line arguments for the release script."""
+
+    parser = argparse.ArgumentParser(description="Evaluate whether docs should be built for release tag.")
+    parser.add_argument(
+        "tag",
+        type=str,
+        help="The tag currently being released.",
+    )
+
+    return parser
+
+def is_plain_version(version: Version) -> bool:
+    """Check whether a version is a X.x.x release with no alpha or rc markers"""
+    return version.base_version == str(version)
+
+
+def git_existing_tag_versions() -> Set[Text]:
+    """Return all existing tags in the local git repo."""
+
+    stdout = check_output(["git", "tag"])
+    tags = set(stdout.decode().split("\n"))
+    versions = [Version(tag) for tag in tags if is_valid_version(tag)]
+    return versions
+
+def git_plain_tag_versions(versions: List[Version]) -> Set[Text]:
+    """Return non-alpha/rc existing tags"""
+    return [version for version in versions if is_plain_version(version)]
+
+
+def main(args: argparse.Namespace) -> None:
+    tag = Version(args.tag)
+
+    existing_tags = git_existing_tag_versions()
+    existing_tags.sort()
+    latest_version = existing_tags[-1]
+    print(f"The latest non-alpha/rc/nightly tag is {latest_version}.")
+
+    previous_major = latest_version.major - 1
+    previous_major_versions = [tag for tag in existing_tags if tag.major == previous_major]
+    previous_major_latest_version = previous_major_versions[-1]
+    print(f"The latest tag on the previous major is {previous_major_latest_version}.")
+
+    build_docs = False
+
+    if not is_plain_version(tag):
+        print(f"Tag {tag} is an alpha, rc, nightly, or otherwise non-standard version.")
+    elif tag > latest_version:
+        print(f"Tag {tag} is higher than the latest version. Docs should be built.")
+        build_docs = True
+    elif tag.major == previous_major and tag > previous_major_latest_version:
+        print(f"Tag {tag} is higher than the latest version for the previous major. Docs should be built.")
+        build_docs = True
+
+    if not build_docs:
+        raise SystemExit(f"Docs should not be built for tag {tag}.")
+
+
+
+if __name__ == "__main__":
+    arg_parser = create_argument_parser()
+    cmdline_args = arg_parser.parse_args()
+    main(cmdline_args)

--- a/scripts/evaluate_release_tag.py
+++ b/scripts/evaluate_release_tag.py
@@ -72,3 +72,4 @@ if __name__ == "__main__":
     arg_parser = create_argument_parser()
     cmdline_args = arg_parser.parse_args()
     main(cmdline_args)
+ 


### PR DESCRIPTION
**Proposed changes**:
- Fix release tag evaluation in docs workflow so that docs are not built for previous minors on the latest major, which were overwriting the latest version of the docs


**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
