### PR TITLE
REST metadata

### DIFF
--- a/changelog/11311.bugfix.md
+++ b/changelog/11311.bugfix.md
@@ -1,0 +1,1 @@
+Re-instates the REST channel metadata feature. Metadata can be provided on the `metadata` key.

--- a/changelog/11311.bugfix.md
+++ b/changelog/11311.bugfix.md
@@ -1,1 +1,1 @@
-Re-instates the REST channel metadata feature. Metadata can be provided on the `metadata` key.
+Re-instates the REST channel metadata feature.  Metadata can be provided on the `metadata` key.

--- a/rasa/core/channels/rest.py
+++ b/rasa/core/channels/rest.py
@@ -96,6 +96,7 @@ class RestInput(InputChannel):
         Returns:
             Sanic stream
         """
+
         async def stream(resp: Any) -> None:
             q: Queue = Queue()
             task = asyncio.ensure_future(

--- a/rasa/core/channels/rest.py
+++ b/rasa/core/channels/rest.py
@@ -58,6 +58,21 @@ class RestInput(InputChannel):
     def _extract_input_channel(self, req: Request) -> Text:
         return req.json.get("input_channel") or self.name()
 
+    def get_metadata(self, request: Request) -> Optional[Dict[Text, Any]]:
+        """Extracts additional information from the incoming request.
+
+         Implementing this function is not required. However, it can be used to extract
+         metadata from the request. The return value is passed on to the
+         ``UserMessage`` object and stored in the conversation tracker.
+
+        Args:
+            request: incoming request with the message of the user
+
+        Returns:
+            Metadata which was extracted from the request.
+        """
+        return request.json.get("metadata", None)
+
     def stream_response(
         self,
         on_new_message: Callable[[UserMessage], Awaitable[None]],
@@ -66,6 +81,21 @@ class RestInput(InputChannel):
         input_channel: Text,
         metadata: Optional[Dict[Text, Any]],
     ) -> Callable[[Any], Awaitable[None]]:
+        """Streams response to the client
+
+         If the stream option is enabled, this method will be called to
+         stream the response to the client
+
+        Args:
+            on_new_message: sanic event
+            text: message text
+            sender_id: message sender_id
+            input_channel: input channel name
+            metadata: optional metadata sent with the message
+
+        Returns:
+            Sanic stream
+        """
         async def stream(resp: Any) -> None:
             q: Queue = Queue()
             task = asyncio.ensure_future(

--- a/rasa/core/channels/rest.py
+++ b/rasa/core/channels/rest.py
@@ -81,7 +81,7 @@ class RestInput(InputChannel):
         input_channel: Text,
         metadata: Optional[Dict[Text, Any]],
     ) -> Callable[[Any], Awaitable[None]]:
-        """Streams response to the client
+        """Streams response to the client.
 
          If the stream option is enabled, this method will be called to
          stream the response to the client


### PR DESCRIPTION
Replacement PR for #11311 re-based on `3.2.x`.   I'm targeting `main` for this PR since that's the GitHub default. Am I supposed to target `3.2.x`?

**Proposed changes**:
The REST channel should by default load the `metadata` key.  I thought this worked in the past but can't seem to find when it was dropped.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
