### PR TITLE
Fix rule policy training for slots with initial values

### DIFF
--- a/rasa/shared/core/generator.py
+++ b/rasa/shared/core/generator.py
@@ -182,6 +182,9 @@ class TrackerWithCachedStates(DialogueStateTracker):
             tracker.update(event, skip_states=True)
 
         tracker._states_for_hashing = copy.copy(self._states_for_hashing)
+        tracker._omit_unset_slots = (
+            tracker._omit_unset_slots if hasattr(self, "_omit_unset_slots") else None
+        )
 
         return tracker
 

--- a/rasa/shared/core/generator.py
+++ b/rasa/shared/core/generator.py
@@ -109,6 +109,7 @@ class TrackerWithCachedStates(DialogueStateTracker):
             or omit_unset_slots != self._omit_unset_slots
         ):
             states = super().past_states(domain, omit_unset_slots=omit_unset_slots)
+            self._omit_unset_slots = omit_unset_slots
             self._states_for_hashing = deque(
                 self.freeze_current_state(s) for s in states
             )

--- a/rasa/shared/core/generator.py
+++ b/rasa/shared/core/generator.py
@@ -103,7 +103,11 @@ class TrackerWithCachedStates(DialogueStateTracker):
 
         # if don't have it cached, we use the domain to calculate the states
         # from the events
-        if self._states_for_hashing is None:
+        if (
+            self._states_for_hashing is None
+            or not hasattr(self, "_omit_unset_slots")
+            or omit_unset_slots != self._omit_unset_slots
+        ):
             states = super().past_states(domain, omit_unset_slots=omit_unset_slots)
             self._states_for_hashing = deque(
                 self.freeze_current_state(s) for s in states


### PR DESCRIPTION
**Rule policy was thrown off if slots have initial values defined**:
- addresses #11395 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
