### PR TITLE
Draft: Removed omit_unset_slot feature and changed logic to always omit unset slots

### DIFF
--- a/rasa/core/featurizers/tracker_featurizers.py
+++ b/rasa/core/featurizers/tracker_featurizers.py
@@ -77,7 +77,6 @@ class TrackerFeaturizer:
     def _create_states(
         tracker: DialogueStateTracker,
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_rule_only_turns: bool = False,
         rule_only_data: Optional[Dict[Text, Any]] = None,
     ) -> List[State]:
@@ -86,7 +85,6 @@ class TrackerFeaturizer:
         Args:
             tracker: The tracker to transform to states.
             domain: The domain of the tracker.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_rule_only_turns: If `True` ignore dialogue turns that are present
                 only in rules.
             rule_only_data: Slots and loops,
@@ -97,7 +95,6 @@ class TrackerFeaturizer:
         """
         return tracker.past_states(
             domain,
-            omit_unset_slots=omit_unset_slots,
             ignore_rule_only_turns=ignore_rule_only_turns,
             rule_only_data=rule_only_data,
         )
@@ -221,15 +218,13 @@ class TrackerFeaturizer:
         self,
         trackers: List[DialogueStateTracker],
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Tuple[List[List[State]], List[List[Text]]]:
-        """Transforms trackers to states and labels.
+        self.labels__ = """Transforms trackers to states and labels.
 
         Args:
             trackers: The trackers to transform.
             domain: The domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
@@ -243,7 +238,6 @@ class TrackerFeaturizer:
         ) = self.training_states_labels_and_entities(
             trackers,
             domain,
-            omit_unset_slots=omit_unset_slots,
             ignore_action_unlikely_intent=ignore_action_unlikely_intent,
         )
         return trackers_as_states, trackers_as_labels
@@ -253,7 +247,6 @@ class TrackerFeaturizer:
         self,
         trackers: List[DialogueStateTracker],
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Tuple[List[List[State]], List[List[Text]], List[List[Dict[Text, Any]]]]:
         """Transforms trackers to states, labels, and entity data.
@@ -261,7 +254,6 @@ class TrackerFeaturizer:
         Args:
             trackers: The trackers to transform.
             domain: The domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
@@ -518,7 +510,6 @@ class FullDialogueTrackerFeaturizer(TrackerFeaturizer):
         self,
         trackers: List[DialogueStateTracker],
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Tuple[List[List[State]], List[List[Text]], List[List[Dict[Text, Any]]]]:
         """Transforms trackers to states, action labels, and entity data.
@@ -526,7 +517,6 @@ class FullDialogueTrackerFeaturizer(TrackerFeaturizer):
         Args:
             trackers: The trackers to transform.
             domain: The domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
@@ -548,9 +538,7 @@ class FullDialogueTrackerFeaturizer(TrackerFeaturizer):
             disable=rasa.shared.utils.io.is_logging_disabled(),
         )
         for tracker in pbar:
-            states = self._create_states(
-                tracker, domain, omit_unset_slots=omit_unset_slots
-            )
+            states = self._create_states(tracker, domain)
             events = tracker.applied_events()
 
             if ignore_action_unlikely_intent:
@@ -719,7 +707,6 @@ class MaxHistoryTrackerFeaturizer(TrackerFeaturizer):
         self,
         trackers: List[DialogueStateTracker],
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Tuple[List[List[State]], List[List[Text]], List[List[Dict[Text, Any]]]]:
         """Transforms trackers to states, action labels, and entity data.
@@ -727,7 +714,6 @@ class MaxHistoryTrackerFeaturizer(TrackerFeaturizer):
         Args:
             trackers: The trackers to transform.
             domain: The domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
@@ -756,7 +742,6 @@ class MaxHistoryTrackerFeaturizer(TrackerFeaturizer):
             for states, label, entities in self._extract_examples(
                 tracker,
                 domain,
-                omit_unset_slots=omit_unset_slots,
                 ignore_action_unlikely_intent=ignore_action_unlikely_intent,
             ):
 
@@ -782,7 +767,6 @@ class MaxHistoryTrackerFeaturizer(TrackerFeaturizer):
         self,
         tracker: DialogueStateTracker,
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Iterator[Tuple[List[State], List[Text], List[Dict[Text, Any]]]]:
         """Creates an iterator over training examples from a tracker.
@@ -790,16 +774,13 @@ class MaxHistoryTrackerFeaturizer(TrackerFeaturizer):
         Args:
             trackers: The tracker from which to extract training examples.
             domain: The domain of the training data.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
         Returns:
             An iterator over example states, labels, and entity data.
         """
-        tracker_states = self._create_states(
-            tracker, domain, omit_unset_slots=omit_unset_slots
-        )
+        tracker_states = self._create_states(tracker, domain)
         events = tracker.applied_events()
 
         if ignore_action_unlikely_intent:
@@ -955,7 +936,6 @@ class IntentMaxHistoryTrackerFeaturizer(MaxHistoryTrackerFeaturizer):
         self,
         trackers: List[DialogueStateTracker],
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Tuple[List[List[State]], List[List[Text]], List[List[Dict[Text, Any]]]]:
         """Transforms trackers to states, intent labels, and entity data.
@@ -963,7 +943,6 @@ class IntentMaxHistoryTrackerFeaturizer(MaxHistoryTrackerFeaturizer):
         Args:
             trackers: The trackers to transform.
             domain: The domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
@@ -995,7 +974,6 @@ class IntentMaxHistoryTrackerFeaturizer(MaxHistoryTrackerFeaturizer):
             for states, label, entities in self._extract_examples(
                 tracker,
                 domain,
-                omit_unset_slots=omit_unset_slots,
                 ignore_action_unlikely_intent=ignore_action_unlikely_intent,
             ):
 
@@ -1036,7 +1014,6 @@ class IntentMaxHistoryTrackerFeaturizer(MaxHistoryTrackerFeaturizer):
         self,
         tracker: DialogueStateTracker,
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_action_unlikely_intent: bool = False,
     ) -> Iterator[Tuple[List[State], List[Text], List[Dict[Text, Any]]]]:
         """Creates an iterator over training examples from a tracker.
@@ -1044,16 +1021,13 @@ class IntentMaxHistoryTrackerFeaturizer(MaxHistoryTrackerFeaturizer):
         Args:
             tracker: The tracker from which to extract training examples.
             domain: The domain of the training data.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_action_unlikely_intent: Whether to remove `action_unlikely_intent`
                 from training states.
 
         Returns:
             An iterator over example states, labels, and entity data.
         """
-        tracker_states = self._create_states(
-            tracker, domain, omit_unset_slots=omit_unset_slots
-        )
+        tracker_states = self._create_states(tracker, domain)
         events = tracker.applied_events()
 
         if ignore_action_unlikely_intent:

--- a/rasa/core/policies/rule_policy.py
+++ b/rasa/core/policies/rule_policy.py
@@ -747,7 +747,7 @@ class RulePolicy(MemoizationPolicy):
             rule_trackers_as_states,
             rule_trackers_as_actions,
         ) = self.featurizer.training_states_and_labels(
-            rule_trackers, domain, omit_unset_slots=True
+            rule_trackers, domain
         )
 
         rules_lookup = self._create_lookup_from_states(

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1179,14 +1179,12 @@ class Domain:
 
     @staticmethod
     def _get_slots_sub_state(
-        tracker: "DialogueStateTracker", omit_unset_slots: bool = False
+        tracker: "DialogueStateTracker"
     ) -> SubState:
         """Sets all set slots with the featurization of the stored value.
 
         Args:
             tracker: dialog state tracker containing the dialog so far
-            omit_unset_slots: If `True` do not include the initial values of slots.
-
         Returns:
             a mapping of slot names to their featurization
         """
@@ -1197,9 +1195,7 @@ class Domain:
             # included in featurised sub-states.
             # Note that this condition checks if the slot itself is None. An unset slot
             # will be a Slot object and its `value` attribute will be None.
-            if slot is not None and slot.as_feature():
-                if omit_unset_slots and not slot.has_been_set:
-                    continue
+            if slot is not None and slot.as_feature() and slot.has_been_set:
                 if slot.value == rasa.shared.core.constants.SHOULD_NOT_BE_SET:
                     slots[slot_name] = rasa.shared.core.constants.SHOULD_NOT_BE_SET
                 elif any(slot.as_feature()):
@@ -1249,22 +1245,17 @@ class Domain:
         }
 
     def get_active_state(
-        self, tracker: "DialogueStateTracker", omit_unset_slots: bool = False
-    ) -> State:
+        self, tracker: "DialogueStateTracker") -> State:
         """Given a dialogue tracker, makes a representation of current dialogue state.
 
         Args:
             tracker: dialog state tracker containing the dialog so far
-            omit_unset_slots: If `True` do not include the initial values of slots.
-
         Returns:
             A representation of the dialogue's current state.
         """
         state = {
             rasa.shared.core.constants.USER: self._get_user_sub_state(tracker),
-            rasa.shared.core.constants.SLOTS: self._get_slots_sub_state(
-                tracker, omit_unset_slots=omit_unset_slots
-            ),
+            rasa.shared.core.constants.SLOTS: self._get_slots_sub_state(tracker),
             rasa.shared.core.constants.PREVIOUS_ACTION: self._get_prev_action_sub_state(
                 tracker
             ),
@@ -1317,7 +1308,6 @@ class Domain:
     def states_for_tracker_history(
         self,
         tracker: "DialogueStateTracker",
-        omit_unset_slots: bool = False,
         ignore_rule_only_turns: bool = False,
         rule_only_data: Optional[Dict[Text, Any]] = None,
     ) -> List[State]:
@@ -1325,7 +1315,6 @@ class Domain:
 
         Args:
             tracker: Dialogue state tracker containing the dialogue so far.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_rule_only_turns: If True ignore dialogue turns that are present
                 only in rules.
             rule_only_data: Slots and loops,
@@ -1355,7 +1344,7 @@ class Domain:
                 if turn_was_hidden:
                     continue
 
-            state = self.get_active_state(tr, omit_unset_slots=omit_unset_slots)
+            state = self.get_active_state(tr)
 
             if ignore_rule_only_turns:
                 # clean state from only rule features

--- a/rasa/shared/core/generator.py
+++ b/rasa/shared/core/generator.py
@@ -101,13 +101,12 @@ class TrackerWithCachedStates(DialogueStateTracker):
         return tracker
 
     def past_states_for_hashing(
-        self, domain: Domain, omit_unset_slots: bool = False
+        self, domain: Domain
     ) -> Deque[FrozenState]:
-        """Generates and caches the past states of this tracker based on the history.
+        self.states_ = """Generates and caches the past states of this tracker based on the history.
 
         Args:
             domain: a :class:`rasa.shared.core.domain.Domain`
-            omit_unset_slots: If `True` do not include the initial values of slots.
 
         Returns:
             A list of states
@@ -121,7 +120,7 @@ class TrackerWithCachedStates(DialogueStateTracker):
         # from the events
         states_for_hashing = self._states_for_hashing
         if not states_for_hashing:
-            states = super().past_states(domain, omit_unset_slots=omit_unset_slots)
+            states = super().past_states(domain)
             states_for_hashing = deque(self.freeze_current_state(s) for s in states)
 
         self._states_for_hashing = states_for_hashing
@@ -138,7 +137,6 @@ class TrackerWithCachedStates(DialogueStateTracker):
     def past_states(
         self,
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_rule_only_turns: bool = False,
         rule_only_data: Optional[Dict[Text, Any]] = None,
     ) -> List[State]:
@@ -146,7 +144,6 @@ class TrackerWithCachedStates(DialogueStateTracker):
 
         Args:
             domain: The Domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_rule_only_turns: If True ignore dialogue turns that are present
                 only in rules.
             rule_only_data: Slots and loops,
@@ -156,7 +153,7 @@ class TrackerWithCachedStates(DialogueStateTracker):
             a list of states
         """
         states_for_hashing = self.past_states_for_hashing(
-            domain, omit_unset_slots=omit_unset_slots
+            domain
         )
         return self._unfreeze_states(states_for_hashing)
 

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -297,7 +297,6 @@ class DialogueStateTracker:
     def past_states(
         self,
         domain: Domain,
-        omit_unset_slots: bool = False,
         ignore_rule_only_turns: bool = False,
         rule_only_data: Optional[Dict[Text, Any]] = None,
     ) -> List[State]:
@@ -305,7 +304,6 @@ class DialogueStateTracker:
 
         Args:
             domain: The Domain.
-            omit_unset_slots: If `True` do not include the initial values of slots.
             ignore_rule_only_turns: If True ignore dialogue turns that are present
                 only in rules.
             rule_only_data: Slots and loops,
@@ -316,7 +314,6 @@ class DialogueStateTracker:
         """
         return domain.states_for_tracker_history(
             self,
-            omit_unset_slots=omit_unset_slots,
             ignore_rule_only_turns=ignore_rule_only_turns,
             rule_only_data=rule_only_data,
         )


### PR DESCRIPTION
Seems to me that initial slot values do not have predictive value by default in policy action prediction. If they do, they need to be incorporated explicitly. Incorporating them implicitly silently breaks Rule policy (see fixed issue below), Memoization policy probably too, and forces the ML policy to learn to ignore the slot.

**Proposed changes**:
- Removed `omit_unset_slot` feature and changed logic to always omit unset slots
- fixes #11395 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
