### PR TITLE
disabled last of the slow e2e agent tests for now

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -574,6 +574,7 @@ def e2e_bot_test_stories_with_unknown_bot_utterances() -> Path:
     return Path("data/test_e2ebot/tests/test_stories_with_unknown_bot_utterances.yml")
 
 
+# FIXME: This fixture is very slow, do not use it without fixing that first
 @pytest.fixture(scope="session")
 async def e2e_bot(
     trained_async: Callable,

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -106,6 +106,8 @@ def _custom_prediction_states_for_rules(
     return _prediction_states
 
 
+# FIXME: these tests take too long to run in the CI, disabling them for now
+@pytest.mark.skip_on_ci
 async def test_testing_warns_if_action_unknown(
     capsys: CaptureFixture,
     e2e_bot_agent: Agent,


### PR DESCRIPTION
**Proposed changes**:
- Disabling the last of the 3 e2e agent tests. The other two had been disabled previously. This one was missed and takes on average 6 min in the unit testing according to our data.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
