### PR TITLE
Disabling transformer layers in DIET for unit test

### DIFF
--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -38,7 +38,8 @@ from rasa.utils.tensorflow.constants import (
     ENTITY_RECOGNITION,
     INTENT_CLASSIFICATION,
     MODEL_CONFIDENCE,
-    HIDDEN_LAYERS_SIZES, NUM_TRANSFORMER_LAYERS,
+    HIDDEN_LAYERS_SIZES,
+    NUM_TRANSFORMER_LAYERS,
 )
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -38,7 +38,7 @@ from rasa.utils.tensorflow.constants import (
     ENTITY_RECOGNITION,
     INTENT_CLASSIFICATION,
     MODEL_CONFIDENCE,
-    HIDDEN_LAYERS_SIZES, EMBEDDING_DIMENSION, NUM_TRANSFORMER_LAYERS,
+    HIDDEN_LAYERS_SIZES, NUM_TRANSFORMER_LAYERS,
 )
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -38,7 +38,7 @@ from rasa.utils.tensorflow.constants import (
     ENTITY_RECOGNITION,
     INTENT_CLASSIFICATION,
     MODEL_CONFIDENCE,
-    HIDDEN_LAYERS_SIZES,
+    HIDDEN_LAYERS_SIZES, EMBEDDING_DIMENSION, NUM_TRANSFORMER_LAYERS,
 )
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier
@@ -614,8 +614,8 @@ async def test_doesnt_checkpoint_with_zero_eval_num_examples(
 @pytest.mark.parametrize(
     "classifier_params",
     [
-        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: False},
-        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: True},
+        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: False, NUM_TRANSFORMER_LAYERS: 0},
+        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: True, NUM_TRANSFORMER_LAYERS: 0},
     ],
 )
 @pytest.mark.timeout(300, func_only=True)


### PR DESCRIPTION
**Proposed changes**:
- Disabling the transformer layers during this test of diet which currently takes a median test time of 3 min per parametrization

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
