### PR TITLE
Add workflow step to install pep440

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -70,6 +70,10 @@ jobs:
     - name: Checkout git repository 🕝
       uses: actions/checkout@v3
 
+    - name: Install version library
+      run: |
+        python3 -m pip install pep440_version_utils
+
     - name: Check if tag version is equal or higher than the latest tagged Rasa version
       id: rasa_get_version
       if: env.IS_TAG_BUILD == 'true' || env.IS_MAIN_BRANCH == 'true'


### PR DESCRIPTION
Proposed changes:

The documentation workflow has been failing with ModuleNotFoundError: No module named 'pep440_version_utils', in the branch 3.1.x this additional step was [added](https://github.com/RasaHQ/rasa/pull/11444/files#diff-d7ecc9db1d2f1f75440ba2c3e433aec8c252e9c86a6260732400737857c71d3bR73) to fix this but its missing from main.
