### PR TITLE
Restore documentation building parameters compatible with node 12

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -68,7 +68,7 @@
     "sass-loader": "^9.0.3",
     "styled-components": "^4.2.0",
     "tinycolor2": "^1.4.2",
-    "unist-util-visit-children": "^1.1.3",
+    "unist-util-visit-children": "^2.0.0",
     "utility-opentype": "^0.1.4"
   },
   "browserslist": {

--- a/docs/plugins/program_output.js
+++ b/docs/plugins/program_output.js
@@ -23,7 +23,7 @@
 */
 const fs = require('fs');
 const globby = require('globby');
-const visitChildren = require('unist-util-visit-children');
+const {visitChildren} = import('unist-util-visit-children');
 const { promisify } = require('util');
 
 const exec = promisify(require('child_process').exec);

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -16794,10 +16794,17 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
-unist-util-visit-children@^1.1.3, unist-util-visit-children@^1.1.4:
+unist-util-visit-children@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz#e8a087e58a33a2815f76ea1901c15dec2cb4b432"
   integrity sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==
+
+unist-util-visit-children@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-2.0.0.tgz#c853e309863d764e4aaf69795f999c4e1c94b44a"
+  integrity sha512-n8CvdoeexGn6EkAa865Wp9SFFuS1IKf1j0vMoEwHHfA5f48gJPK6rwS/s/P+ouRDfAklQaiBQtlloX3KadUrww==
+  dependencies:
+    "@types/unist" "^2.0.0"
 
 unist-util-visit-parents@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This PR reverts commit 6a263937b61eaa1bb7a8480e3632fe7d2ced80ce.

**Proposed changes**:
- Currently the documention website requires node.js <= 12.22.x, this PR reverts an accidental change

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
