### PR TITLE
Restore documentation building parameters compatible with node 12

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -108,10 +108,10 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Set up Node 16.x 🦙
+      - name: Set up Node 12.x 🦙
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: "16.x"
+          node-version: "12.x"
 
       - name: Read Poetry Version 🔢
         run: |
@@ -146,8 +146,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: docs/node_modules
-          key: ${{ runner.os }}-yarn-16.x-${{ hashFiles('docs/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-16.x
+          key: ${{ runner.os }}-yarn-12.x-${{ hashFiles('docs/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-12.x
 
       - name: Install Dependencies 📦
         run: make install install-docs
@@ -199,11 +199,11 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Set up Node 16.x 🦙
+      - name: Set up Node 12.x 🦙
         if: needs.changes.outputs.docs == 'true'
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: "16.x"
+          node-version: "12.x"
 
       - name: Read Poetry Version 🔢
         if: needs.changes.outputs.docs == 'true'
@@ -243,8 +243,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: docs/node_modules
-          key: ${{ runner.os }}-yarn-16.x-${{ hashFiles('docs/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-16.x
+          key: ${{ runner.os }}-yarn-12.x-${{ hashFiles('docs/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-12.x
 
       - name: Install Dependencies 📦
         if: needs.changes.outputs.docs == 'true'
@@ -287,17 +287,17 @@ jobs:
       - name: Checkout git repository 🕝
         uses: actions/checkout@v3
 
-      - name: Set up Node 16.x 🦙
+      - name: Set up Node 12.x 🦙
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: "16.x"
+          node-version: "12.x"
 
       - name: Load Yarn Cached Packages ⬇
         uses: actions/cache@v3
         with:
           path: docs/node_modules
-          key: ${{ runner.os }}-yarn-16.x-${{ hashFiles('docs/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-16.x
+          key: ${{ runner.os }}-yarn-12.x-${{ hashFiles('docs/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-12.x
 
       - name: Install Dependencies 📦
         run: make install-docs


### PR DESCRIPTION
This PR reverts commit https://github.com/RasaHQ/rasa/commit/b775964bc57eaf3ffef1ecdd6075efb6aac0ea3b.

**Proposed changes**:
- Currently the documention website requires node.js <= 12.22.x, this PR reverts an accidental change

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
