### PR TITLE
refine from_trigger mapping check

### DIFF
--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1280,9 +1280,21 @@ def extract_slot_value_from_predefined_mapping(
         active_loop.get(ACTIVE_LOOP)
         for active_loop in mapping.get(MAPPING_CONDITIONS, [])
     ]
+
+    trigger_mapping_condition_met = True
+
+    if active_loops_in_mapping_conditions and tracker.active_loop_name is None:
+        trigger_mapping_condition_met = False
+    elif (
+        active_loops_in_mapping_conditions
+        and tracker.active_loop_name is not None
+        and (tracker.active_loop_name not in active_loops_in_mapping_conditions)
+    ):
+        trigger_mapping_condition_met = False
+
     should_fill_trigger_slot = (
         mapping_type == SlotMappingType.FROM_TRIGGER_INTENT
-        and tracker.active_loop_name not in active_loops_in_mapping_conditions
+        and trigger_mapping_condition_met
     )
 
     value: List[Any] = []

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -605,7 +605,7 @@ class FormAction(LoopAction):
 
         if not prefilled_slots:
             logger.debug("No pre-filled required slots to validate.")
-            return []
+            return [e for e in extraction_events if isinstance(e, SlotSet)]
 
         logger.debug(f"Validating pre-filled required slots: {prefilled_slots}")
 


### PR DESCRIPTION
**Proposed changes**:
- Fix for [ATO-334](https://rasahq.atlassian.net/browse/ATO-334), reported issue that slot with a `from_trigger_intent` mapping with an active_loop condition was being filled, despite that particular form not being activated.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
