### PR TITLE
Caching feature and message fingerprints

### DIFF
--- a/changelog/ATO-264.improvement.md
+++ b/changelog/ATO-264.improvement.md
@@ -1,0 +1,1 @@
+Caching `Message` and `Features` fingerprints unless they are altered, speeding up fingerprinting considerably.

--- a/changelog/ATO-264.improvement.md
+++ b/changelog/ATO-264.improvement.md
@@ -1,1 +1,1 @@
-Caching `Message` and `Features` fingerprints unless they are altered, speeding up fingerprinting considerably.
+Caching `Message` and `Features` fingerprints unless they are altered, saving up to 2/3 of fingerprinting time in our tests.

--- a/rasa/shared/nlu/training_data/features.py
+++ b/rasa/shared/nlu/training_data/features.py
@@ -32,7 +32,7 @@ class Features:
         self.type = feature_type
         self.origin = origin
         self.attribute = attribute
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
         if not self.is_dense() and not self.is_sparse():
             raise ValueError(
                 "Features must either be a numpy array for dense "
@@ -103,7 +103,7 @@ class Features:
         self.features = np.concatenate(  # type: ignore[no-untyped-call]
             (self.features, additional_features.features), axis=-1
         )
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
 
     def _combine_sparse_features(self, additional_features: Features) -> None:
         from scipy.sparse import hstack
@@ -116,7 +116,7 @@ class Features:
             )
 
         self.features = hstack([self.features, additional_features.features])
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
 
     def __key__(
         self,
@@ -151,17 +151,17 @@ class Features:
 
     def fingerprint(self) -> Text:
         """Calculate a stable string fingerprint for the features."""
-        if self.cached_fingerprint is None:
+        if self._cached_fingerprint is None:
             if self.is_dense():
                 f_as_text = self.features.tobytes()
             else:
                 f_as_text = rasa.shared.nlu.training_data.util.sparse_matrix_to_string(
                     self.features
                 )
-            self.cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
+            self._cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
                 [self.type, self.origin, self.attribute, f_as_text]
             )
-        return self.cached_fingerprint
+        return self._cached_fingerprint
 
     @staticmethod
     def filter(

--- a/rasa/shared/nlu/training_data/features.py
+++ b/rasa/shared/nlu/training_data/features.py
@@ -151,7 +151,7 @@ class Features:
 
     def fingerprint(self) -> Text:
         """Calculate a stable string fingerprint for the features."""
-        if self._cached_fingerprint is None:
+        if not isinstance(self._cached_fingerprint, str):
             if self.is_dense():
                 f_as_text = self.features.tobytes()
             else:

--- a/rasa/shared/nlu/training_data/features.py
+++ b/rasa/shared/nlu/training_data/features.py
@@ -32,6 +32,7 @@ class Features:
         self.type = feature_type
         self.origin = origin
         self.attribute = attribute
+        self.cached_fingerprint = None
         if not self.is_dense() and not self.is_sparse():
             raise ValueError(
                 "Features must either be a numpy array for dense "
@@ -102,6 +103,7 @@ class Features:
         self.features = np.concatenate(  # type: ignore[no-untyped-call]
             (self.features, additional_features.features), axis=-1
         )
+        self.cached_fingerprint = None
 
     def _combine_sparse_features(self, additional_features: Features) -> None:
         from scipy.sparse import hstack
@@ -114,6 +116,7 @@ class Features:
             )
 
         self.features = hstack([self.features, additional_features.features])
+        self.cached_fingerprint = None
 
     def __key__(
         self,
@@ -148,16 +151,17 @@ class Features:
 
     def fingerprint(self) -> Text:
         """Calculate a stable string fingerprint for the features."""
-        if self.is_dense():
-            f_as_text = self.features.tobytes()
-        else:
-            f_as_text = rasa.shared.nlu.training_data.util.sparse_matrix_to_string(
-                self.features
+        if self.cached_fingerprint is None:
+            if self.is_dense():
+                f_as_text = self.features.tobytes()
+            else:
+                f_as_text = rasa.shared.nlu.training_data.util.sparse_matrix_to_string(
+                    self.features
+                )
+            self.cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
+                [self.type, self.origin, self.attribute, f_as_text]
             )
-
-        return rasa.shared.utils.io.deep_container_fingerprint(
-            [self.type, self.origin, self.attribute, f_as_text]
-        )
+        return self.cached_fingerprint
 
     @staticmethod
     def filter(

--- a/rasa/shared/nlu/training_data/features.py
+++ b/rasa/shared/nlu/training_data/features.py
@@ -32,7 +32,7 @@ class Features:
         self.type = feature_type
         self.origin = origin
         self.attribute = attribute
-        self._cached_fingerprint = None
+        self._cached_fingerprint: Optional[Text] = None
         if not self.is_dense() and not self.is_sparse():
             raise ValueError(
                 "Features must either be a numpy array for dense "
@@ -151,7 +151,7 @@ class Features:
 
     def fingerprint(self) -> Text:
         """Calculate a stable string fingerprint for the features."""
-        if not isinstance(self._cached_fingerprint, str):
+        if self._cached_fingerprint is None:
             if self.is_dense():
                 f_as_text = self.features.tobytes()
             else:

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -54,6 +54,7 @@ class Message:
         self.features = features if features else []
 
         self.data.update(**kwargs)
+        self.cached_fingerprint = None
 
         if output_properties:
             self.output_properties = output_properties
@@ -64,6 +65,7 @@ class Message:
     def add_features(self, features: Optional["Features"]) -> None:
         if features is not None:
             self.features.append(features)
+        self.cached_fingerprint = None
 
     def add_diagnostic_data(self, origin: Text, data: Dict[Text, Any]) -> None:
         """Adds diagnostic data from the `origin` component.
@@ -80,6 +82,7 @@ class Message:
             )
         self.data.setdefault(DIAGNOSTIC_DATA, {})
         self.data[DIAGNOSTIC_DATA][origin] = data
+        self.cached_fingerprint = None
 
     def set(self, prop: Text, info: Any, add_to_output: bool = False) -> None:
         """Sets the message's property to the given value.
@@ -92,6 +95,7 @@ class Message:
         self.data[prop] = info
         if add_to_output:
             self.output_properties.add(prop)
+        self.cached_fingerprint = None
 
     def get(self, prop: Text, default: Optional[Any] = None) -> Any:
         return self.data.get(prop, default)
@@ -143,9 +147,11 @@ class Message:
         Returns:
             Fingerprint of the message.
         """
-        return rasa.shared.utils.io.deep_container_fingerprint(
-            [self.data, self.features]
-        )
+        if self.cached_fingerprint is None:
+            self.cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
+                [self.data, self.features]
+            )
+        return self.cached_fingerprint
 
     @classmethod
     def build(

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -63,6 +63,7 @@ class Message:
         self.output_properties.add(TEXT)
 
     def add_features(self, features: Optional["Features"]) -> None:
+        """Add more vectorized features to the message."""
         if features is not None:
             self.features.append(features)
         self.cached_fingerprint = None
@@ -98,6 +99,7 @@ class Message:
         self.cached_fingerprint = None
 
     def get(self, prop: Text, default: Optional[Any] = None) -> Any:
+        """Retrieve message property."""
         return self.data.get(prop, default)
 
     def as_dict_nlu(self) -> dict:

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -149,7 +149,7 @@ class Message:
         Returns:
             Fingerprint of the message.
         """
-        if self._cached_fingerprint is None:
+        if not isinstance(self._cached_fingerprint, str):
             self._cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
                 [self.data, self.features]
             )

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -54,7 +54,7 @@ class Message:
         self.features = features if features else []
 
         self.data.update(**kwargs)
-        self._cached_fingerprint = None
+        self._cached_fingerprint: Optional[Text] = None
 
         if output_properties:
             self.output_properties = output_properties
@@ -149,7 +149,7 @@ class Message:
         Returns:
             Fingerprint of the message.
         """
-        if not isinstance(self._cached_fingerprint, str):
+        if self._cached_fingerprint is None:
             self._cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
                 [self.data, self.features]
             )

--- a/rasa/shared/nlu/training_data/message.py
+++ b/rasa/shared/nlu/training_data/message.py
@@ -54,7 +54,7 @@ class Message:
         self.features = features if features else []
 
         self.data.update(**kwargs)
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
 
         if output_properties:
             self.output_properties = output_properties
@@ -66,7 +66,7 @@ class Message:
         """Add more vectorized features to the message."""
         if features is not None:
             self.features.append(features)
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
 
     def add_diagnostic_data(self, origin: Text, data: Dict[Text, Any]) -> None:
         """Adds diagnostic data from the `origin` component.
@@ -83,7 +83,7 @@ class Message:
             )
         self.data.setdefault(DIAGNOSTIC_DATA, {})
         self.data[DIAGNOSTIC_DATA][origin] = data
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
 
     def set(self, prop: Text, info: Any, add_to_output: bool = False) -> None:
         """Sets the message's property to the given value.
@@ -96,7 +96,7 @@ class Message:
         self.data[prop] = info
         if add_to_output:
             self.output_properties.add(prop)
-        self.cached_fingerprint = None
+        self._cached_fingerprint = None
 
     def get(self, prop: Text, default: Optional[Any] = None) -> Any:
         """Retrieve message property."""
@@ -149,11 +149,11 @@ class Message:
         Returns:
             Fingerprint of the message.
         """
-        if self.cached_fingerprint is None:
-            self.cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
+        if self._cached_fingerprint is None:
+            self._cached_fingerprint = rasa.shared.utils.io.deep_container_fingerprint(
                 [self.data, self.features]
             )
-        return self.cached_fingerprint
+        return self._cached_fingerprint
 
     @classmethod
     def build(

--- a/tests/shared/nlu/training_data/test_features.py
+++ b/tests/shared/nlu/training_data/test_features.py
@@ -33,38 +33,11 @@ def test_print(type: Text, is_sparse: bool):
     assert str(feat)
 
 
-def test_fingerprint_changes_after_combining_dense():
-    existing_features = Features(
-        np.array([[1, 0, 2, 3], [2, 0, 0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "test"
-    )
-    original_fingerprint = existing_features.fingerprint()
-    new_features = Features(
-        np.array([[1, 0], [0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "origin"
-    )
-
-    existing_features.combine_with_features(new_features)
-    after_combining_fingerprint = existing_features.fingerprint()
-    assert original_fingerprint != after_combining_fingerprint
-
-
-def test_fingerprint_changes_after_combining_sparse():
-    existing_features = Features(
-        np.array([[1, 0, 2, 3], [2, 0, 0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "test"
-    )
-    original_fingerprint = existing_features.fingerprint()
-    new_features = Features(
-        scipy.sparse.csr_matrix([[1, 0], [0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "origin"
-    )
-
-    existing_features.combine_with_features(new_features)
-    after_combining_fingerprint = existing_features.fingerprint()
-    assert original_fingerprint != after_combining_fingerprint
-
-
 def test_combine_with_existing_dense_features():
     existing_features = Features(
         np.array([[1, 0, 2, 3], [2, 0, 0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "test"
     )
+    fingerprint = existing_features.fingerprint()
     new_features = Features(
         np.array([[1, 0], [0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "origin"
     )
@@ -73,6 +46,8 @@ def test_combine_with_existing_dense_features():
     existing_features.combine_with_features(new_features)
 
     assert np.all(expected_features == existing_features.features)
+    # check that combining features changes fingerprint
+    assert fingerprint != existing_features.fingerprint()
 
 
 def test_combine_with_existing_dense_features_shape_mismatch():
@@ -92,6 +67,7 @@ def test_combine_with_existing_sparse_features():
         TEXT,
         "test",
     )
+    fingerprint = existing_features.fingerprint()
     new_features = Features(
         scipy.sparse.csr_matrix([[1, 0], [0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "origin"
     )
@@ -101,6 +77,8 @@ def test_combine_with_existing_sparse_features():
     actual_features = existing_features.features.toarray()
 
     assert np.all(expected_features == actual_features)
+    # check that combining features changes fingerprint
+    assert fingerprint != existing_features.fingerprint()
 
 
 def test_combine_with_existing_sparse_features_shape_mismatch():

--- a/tests/shared/nlu/training_data/test_features.py
+++ b/tests/shared/nlu/training_data/test_features.py
@@ -33,6 +33,34 @@ def test_print(type: Text, is_sparse: bool):
     assert str(feat)
 
 
+def test_fingerprint_changes_after_combining_dense():
+    existing_features = Features(
+        np.array([[1, 0, 2, 3], [2, 0, 0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "test"
+    )
+    original_fingerprint = existing_features.fingerprint()
+    new_features = Features(
+        np.array([[1, 0], [0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "origin"
+    )
+
+    existing_features.combine_with_features(new_features)
+    after_combining_fingerprint = existing_features.fingerprint()
+    assert original_fingerprint != after_combining_fingerprint
+
+
+def test_fingerprint_changes_after_combining_sparse():
+    existing_features = Features(
+        np.array([[1, 0, 2, 3], [2, 0, 0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "test"
+    )
+    original_fingerprint = existing_features.fingerprint()
+    new_features = Features(
+        scipy.sparse.csr_matrix([[1, 0], [0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "origin"
+    )
+
+    existing_features.combine_with_features(new_features)
+    after_combining_fingerprint = existing_features.fingerprint()
+    assert original_fingerprint != after_combining_fingerprint
+
+
 def test_combine_with_existing_dense_features():
     existing_features = Features(
         np.array([[1, 0, 2, 3], [2, 0, 0, 1]]), FEATURE_TYPE_SEQUENCE, TEXT, "test"

--- a/tests/shared/nlu/training_data/test_message.py
+++ b/tests/shared/nlu/training_data/test_message.py
@@ -408,3 +408,19 @@ def test_message_fingerprint_includes_data_and_features(
     assert fp3 != fp4
 
     assert len({fp1, fp2, fp3, fp4}) == 4
+
+
+def test_message_fingerprint_is_recalculated_after_setting_data():
+    message = Message(data={TEXT: "This is a test sentence."})
+    fp1 = message.fingerprint()
+    message.set(INTENT, "test")
+    fp2 = message.fingerprint()
+    assert fp1 != fp2
+
+
+def test_message_fingerprint_is_recalculated_after_adding_diagnostics_data():
+    message = Message(data={TEXT: "This is a test sentence."})
+    fp1 = message.fingerprint()
+    message.add_diagnostic_data("origin", "test")
+    fp2 = message.fingerprint()
+    assert fp1 != fp2


### PR DESCRIPTION
**Proposed changes**:
- Caching fingerprints of messages until message is manipulated
- Caching fingerprints of features until they are manipulated

In my test on the oos dataset (roughly 15k nlu examples) the changes shaved off around 25 seconds of around 40 seconds in total for the fingerprinting. So roughly a 2/3 reduction in pure fingerprinting time.

I also looked at more general options to speed up caching, but our caching methods are just very generic and work on a very diverse set of inputs, especially arbitrarily nested dicts and lists. I found that my attempts to improve caching there, for example trying to employ frozendicts to cache some of the dictionaries, lead to longer fingerprinting times.

I also considered adding additional safeguards such as a test that checks whether all the classes methods were wrapped with either `invalidates_cached_fingerprint` or `does_not_invalidate_cached_fingerprint`. This would prevent developers from accidentally adding a new method that changes `Message` or `Feature` state and not invalidate the cached fingerprint. However, it seemed somewhat heavy handed given that it is also not a perfect protection. So I dropped it again.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
