### PR TITLE
fix SADeprecationWarning

### DIFF
--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -995,7 +995,7 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
             port = parsed.port or port
             host = parsed.hostname or host
 
-        return sa.engine.url.URL(
+        return sa.engine.url.URL.create(
             dialect,
             username,
             password,
@@ -1017,7 +1017,7 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
 
         self._create_database(self.engine, db)
         self.engine.dispose()
-        engine_url = sa.engine.url.URL(
+        engine_url = sa.engine.url.URL.create(
             drivername=engine_url.drivername,
             username=engine_url.username,
             password=engine_url.password,


### PR DESCRIPTION
QLAlchemy URL() is now deprecated in favor of URL.create()

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
