### PR TITLE
Use strings for Python versions in the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -23,12 +23,12 @@ body:
     attributes:
       label: Python version
       options:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10
-        - Other
+        - "3.6"
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "Other"
     validations:
       required: true
   - type: dropdown

--- a/changelog/11634.misc.md
+++ b/changelog/11634.misc.md
@@ -1,0 +1,1 @@
+Fixed the Python version dropdown in the bug report issue template to show "3.10" instead of "3.1"


### PR DESCRIPTION
**Proposed changes**:
- Change the data type for Python versions in the bug report issue template from numbers to strings. Treating versions as numbers means that Python 3.10 is displayed as "3.1". Changing to data type to strings makes 3.10 display correctly as "3.10".

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

This shouldn't need tests or documentation, and doesn't change any Python files.

Fixes #11634