### PR TITLE
fix: wrong python version is issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -23,11 +23,11 @@ body:
     attributes:
       label: Python version
       options:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
         - Other
     validations:
       required: true


### PR DESCRIPTION
**Proposed changes**:
- Python version option items are specified as numbers which cause s 3.10 to be displayed as 3.1. Just quoted options to treat them as strings. Fixes https://github.com/RasaHQ/rasa/issues/11634

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
