### PR TITLE
refer to official poetry installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,7 @@ also be asked to sign a
 ### Installing Poetry
 
 Rasa uses Poetry for packaging and dependency management. If you want to build it from source,
-you have to install Poetry first. This is how it can be done:
-
-```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-```
-
-There are several other ways to install Poetry. Please, follow
+you have to install Poetry first. Please follow
 [the official guide](https://python-poetry.org/docs/#installation) to see all possible options.
 
 ### Managing environments

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -259,11 +259,13 @@ Next step: Use the Rasa Playground to prototype your first assistant in the brow
 If you want to use the development version of Rasa Open Source, you can get it from GitHub:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+curl -sSL https://install.python-poetry.org | python3 -
 git clone https://github.com/RasaHQ/rasa.git
 cd rasa
 poetry install
 ```
+
+Please refer to the [official Poetry installation guide ](https://python-poetry.org/docs/#installation) for more information.
 
 ## Additional Dependencies
 


### PR DESCRIPTION
**Proposed changes**:
- poetry installation instructions on the README were deprecated. Since there's a variety of ways to install poetry I simply referred to the official installation instructions in the readme and updated the existing linux/mac section in docs

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
