### PR TITLE
Ato 266 docs update 

### DIFF
--- a/changelog/11768.doc.md
+++ b/changelog/11768.doc.md
@@ -1,0 +1,2 @@
+The documentation was updated for Buttons using messages that start with '/'. 
+Previously, it wrongly stated that messages with '/' bypass NLU, which is not the case.

--- a/docs/docs/responses.mdx
+++ b/docs/docs/responses.mdx
@@ -311,13 +311,13 @@ Passing multiple entities is also possible with:
 '/intent_name{{"entity_type_1":"entity_value_1", "entity_type_2": "entity_value_2"}}'
 ```
 
-:::note bypass nlu with buttons
-You can use buttons to bypass NLU prediction and trigger a specific intent and entities.
+:::note overwrite nlu with buttons
+You can use buttons to overwrite the NLU prediction and trigger a specific intent and entities.
 
-Messages starting with `/` are sent straight to the
+Messages starting with `/` are sent handled by the
 `RegexInterpreter`, which expects NLU input in a shortened `/intent{entities}` format.
 In the example above, if the user clicks a button, the user input
-will be directly classified as either the `mood_great` or `mood_sad` intent.
+will be classified as either the `mood_great` or `mood_sad` intent.
 
 You can include entities with the intent to be passed to the `RegexInterpreter` using the following format:
 


### PR DESCRIPTION
**Proposed changes**:
Update the documentation for Buttons using messages with '/'. It wrongly stated that messages with '/' bypass NLU, which is not the case.

**Status (please check what you already did)**:
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)