### PR TITLE
LocalModelStorage bypasses windows path name length restriction upon saving archive

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -318,6 +318,17 @@ jobs:
         # (tests will still run in other envs, they will just not create annotations)
         run: pip install pytest-github-actions-annotate-failures
 
+      - name: Disable "LongPathsEnabled" option on Windows
+        if: matrix.os == 'windows-2019'
+        # On Windows laptops, a default preset prevents path names from being longer than
+        # 260 characters. Some of our users can't enable this setting due to company policies.
+        # We implemented a fix for model storage. The Windows container in GitHub
+        # comes with the setting enabled, so we disable it here in order to ensure our tests
+        # are running in an environment where long path names are prevented.
+        run: |
+          (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
+          Set-ItemProperty 'HKLM:\System\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -value 0
+
       - name: Install ddtrace
         if: needs.changes.outputs.backend == 'true'
         run: poetry run pip install -U ddtrace

--- a/changelog/11792.bugfix.md
+++ b/changelog/11792.bugfix.md
@@ -1,0 +1,1 @@
+Bypass Windows path length restrictions upon saving and reading a model archive in `rasa.engine.storage.LocalModelStorage`.

--- a/rasa/engine/storage/local_model_storage.py
+++ b/rasa/engine/storage/local_model_storage.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from tarsafe import TarSafe
-from typing import Text, Generator, Tuple, Union
+from typing import Generator, Optional, Text, Tuple, Union
 
 import rasa.utils.common
 import rasa.shared.utils.io
@@ -25,6 +25,32 @@ logger = logging.getLogger(__name__)
 # Paths within model archive
 MODEL_ARCHIVE_COMPONENTS_DIR = "components"
 MODEL_ARCHIVE_METADATA_FILE = "metadata.json"
+
+
+@contextmanager
+def windows_safe_temporary_directory(
+    suffix: Optional[Text] = None,
+    prefix: Optional[Text] = None,
+    dir: Optional[Text] = None,
+) -> Generator[Text, None, None]:
+    """Like `tempfile.TemporaryDirectory`, but works with Windows and long file names.
+
+    On Windows by default there is a restriction on long path names.
+    Using the prefix below allows to bypass this restriction in environments
+    where it's not possible to override this behavior, mostly for internal
+    policy reasons.
+
+    Reference: https://stackoverflow.com/a/49102229
+    """
+    if sys.platform == "win32":
+        directory = tempfile.mkdtemp(suffix, prefix, dir)
+        try:
+            yield directory
+        finally:
+            shutil.rmtree(f"\\\\?\\{directory}")
+    else:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            yield temporary_directory
 
 
 class LocalModelStorage(ModelStorage):
@@ -51,7 +77,7 @@ class LocalModelStorage(ModelStorage):
                 f"empty model storage."
             )
 
-        with tempfile.TemporaryDirectory() as temporary_directory:
+        with windows_safe_temporary_directory() as temporary_directory:
             temporary_directory_path = Path(temporary_directory)
 
             cls._extract_archive_to_directory(
@@ -72,7 +98,7 @@ class LocalModelStorage(ModelStorage):
         cls, model_archive_path: Union[Text, Path]
     ) -> ModelMetadata:
         """Retrieves metadata from archive (see parent class for full docstring)."""
-        with tempfile.TemporaryDirectory() as temporary_directory:
+        with windows_safe_temporary_directory() as temporary_directory:
             temporary_directory_path = Path(temporary_directory)
 
             cls._extract_archive_to_directory(
@@ -88,9 +114,9 @@ class LocalModelStorage(ModelStorage):
     ) -> None:
         with TarSafe.open(model_archive_path, mode="r:gz") as tar:
             if sys.platform == "win32":
-                # on windows by default there is a restriction on long
+                # on Windows by default there is a restriction on long
                 # path names; using the prefix below allows to bypass
-                # this restriction in environment where it's not possible
+                # this restriction in environments where it's not possible
                 # to override this behavior, mostly for internal policy reasons
                 # reference: https://stackoverflow.com/a/49102229
                 tar.extractall(f"\\\\?\\{temporary_directory}")
@@ -167,7 +193,7 @@ class LocalModelStorage(ModelStorage):
         """Creates model package (see parent class for full docstring)."""
         logger.debug(f"Start to created model package for path '{model_archive_path}'.")
 
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with windows_safe_temporary_directory() as temp_dir:
             temporary_directory = Path(temp_dir)
 
             shutil.copytree(

--- a/rasa/engine/storage/local_model_storage.py
+++ b/rasa/engine/storage/local_model_storage.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import logging
 import shutil
-from tarsafe import TarSafe
+import sys
 import tempfile
 import uuid
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from tarsafe import TarSafe
 from typing import Text, Generator, Tuple, Union
 
 import rasa.utils.common
@@ -86,7 +87,15 @@ class LocalModelStorage(ModelStorage):
         model_archive_path: Union[Text, Path], temporary_directory: Path
     ) -> None:
         with TarSafe.open(model_archive_path, mode="r:gz") as tar:
-            tar.extractall(temporary_directory)
+            if sys.platform == "win32":
+                # on windows by default there is a restriction on long
+                # path names; using the prefix below allows to bypass
+                # this restriction in environment where it's not possible
+                # to override this behavior, mostly for internal policy reasons
+                # reference: https://stackoverflow.com/a/49102229
+                tar.extractall(f"\\\\?\\{temporary_directory}")
+            else:
+                tar.extractall(temporary_directory)
         LocalModelStorage._assert_not_rasa2_archive(temporary_directory)
 
     @staticmethod


### PR DESCRIPTION
**Proposed changes**:
- LocalModelStorage bypasses windows path name length restriction upon saving archive
- Made sure the test was failing using TDD (see [build logs](https://github.com/RasaHQ/rasa/actions/runs/3564189533/jobs/5987876826))

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
