### PR TITLE
Updated LATEST_TRAINING_DATA_FORMAT_VERSION to 3.2

### DIFF
--- a/rasa/shared/constants.py
+++ b/rasa/shared/constants.py
@@ -44,7 +44,7 @@ MODEL_CONFIG_SCHEMA_FILE = "shared/utils/schemas/model_config.yml"
 CONFIG_SCHEMA_FILE = "shared/utils/schemas/config.yml"
 RESPONSES_SCHEMA_FILE = "shared/nlu/training_data/schemas/responses.yml"
 SCHEMA_EXTENSIONS_FILE = "shared/utils/pykwalify_extensions.py"
-LATEST_TRAINING_DATA_FORMAT_VERSION = "3.1"
+LATEST_TRAINING_DATA_FORMAT_VERSION = "3.2"
 
 DOMAIN_SCHEMA_FILE = "shared/utils/schemas/domain.yml"
 


### PR DESCRIPTION
Without this, training data with version 3.2 couldn't be used with Rasa 3.2.x

**Proposed changes**:
- Set LATEST_TRAINING_DATA_FORMAT_VERSION  to "3.2"

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
