### PR TITLE
Fix unawaited method issue in Telegram channel interface

### DIFF
--- a/changelog/11818.bugfix.md
+++ b/changelog/11818.bugfix.md
@@ -1,0 +1,2 @@
+Fixes `RuntimeWarning: coroutine 'Bot.set_webhook' was never awaited` issue encountered when starting the rasa server, 
+which caused the Telegram bot to be unresponsive.

--- a/docs/docs/connectors/telegram.mdx
+++ b/docs/docs/connectors/telegram.mdx
@@ -46,7 +46,8 @@ to make the new channel endpoint available for Telegram to send messages to.
 
 At the beginning of a conversation, the user will press the 'Start' button in Telegram.
 This will trigger a message with the content */start* to be sent.
-Make sure your bot can handle this intro message by designing a specific intent which can then be used in stories.
+Make sure your bot can handle this intro message by designing a specific intent in the nlu training data file.
+Then add this `start` intent to the domain alongside a story or rule to handle it.
 
 :::
 

--- a/docs/docs/connectors/telegram.mdx
+++ b/docs/docs/connectors/telegram.mdx
@@ -42,6 +42,14 @@ telegram:
 Restart your Rasa server
 to make the new channel endpoint available for Telegram to send messages to.
 
+:::note Handling `/start` message
+
+At the beginning of a conversation, the user will press the 'Start' button in Telegram.
+This will trigger a message with the content */start* to be sent.
+Make sure your bot can handle this intro message by designing a specific intent which can then be used in stories.
+
+:::
+
 
 ## Supported Response Attachments
 

--- a/docs/docs/messaging-and-voice-channels.mdx
+++ b/docs/docs/messaging-and-voice-channels.mdx
@@ -40,7 +40,8 @@ If you're running a Rasa server on `localhost`,
 most external channels won't be able to find your server URL, since `localhost` is not open to the internet. 
 
 To make a port on your local machine publicly available on the internet, 
-you can use [ngrok](https://ngrok.com/).
+you can use [ngrok](https://ngrok.com/). Alternatively, see this [list](https://github.com/anderspitman/awesome-tunneling)
+tracking and comparing other tunneling solutions.
 
 After installing ngrok, run:
 

--- a/rasa/core/channels/telegram.py
+++ b/rasa/core/channels/telegram.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from copy import deepcopy
@@ -288,7 +289,7 @@ class TelegramInput(InputChannel):
         channel = TelegramOutput(self.access_token)
 
         try:
-            channel.set_webhook(url=self.webhook_url)
+            asyncio.run(channel.set_webhook(url=self.webhook_url))
         except TelegramAPIError as error:
             raise RasaException(
                 "Failed to set channel webhook: " + str(error)

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -33,7 +33,7 @@ from tests.utilities import json_of_latest_request, latest_request
 logger = logging.getLogger(__name__)
 
 
-def noop(*args, **kwargs):
+async def noop(*args, **kwargs):
     """Just do nothing."""
     pass
 


### PR DESCRIPTION
**Proposed changes**:
- Fixes `RuntimeWarning: coroutine 'Bot.set_webhook' was never awaited` issued when starting the rasa server, that causes Telegram bot to be unresponsive.
- Tested manually with moodbot in Telegram and only locally by using ngrok, bot was responsive after the fix.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
