### PR TITLE
rasa init handling '~'

### DIFF
--- a/rasa/cli/scaffold.py
+++ b/rasa/cli/scaffold.py
@@ -220,6 +220,9 @@ def run(args: argparse.Namespace) -> None:
         # Can't use `if not path` either, as `None` will be handled differently (abort)
         if path == "":
             path = "."
+        if path[0] == "~":
+            homePath = os.path.expanduser('~')
+            path = homePath + path[1:]
 
     if args.no_prompt and not os.path.isdir(path):
         print_error_and_exit(f"Project init path '{path}' not found.")


### PR DESCRIPTION
Adding project path reading to ```rasa init``` handling '~'

**Proposed changes**:
- Adding if statement to check if project path starts with '~', and if so, creating the project based on the home path.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
