### PR TITLE
Remove hard pin on tensorflow-macos requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ version = "~2.8.4"
 markers = "sys_platform != 'darwin' or platform_machine != 'arm64'"
 
 [tool.poetry.dependencies.tensorflow-macos]
-version = "2.8.0"
+version = "^2.8.0"
 markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"
 
 [tool.poetry.dependencies.PyJWT]


### PR DESCRIPTION
**Upd.**
Ok, I'm not gonna bother signing CLA which requires providing my phone number and address over just one character change. 

Do not accept my contribution, just fix it please.

Hard pin to 2.8.0 prevents installation on Python 3.10:

```
ERROR: Could not find a version that satisfies the requirement tensorflow-macos==2.8.0; sys_platform == "darwin" and platform_machine == "arm64" (from rasa) (from versions: 2.9.0, 2.9.1, 2.9.2, 2.10.0, 2.11.0)

ERROR: Cannot install rasa==3.4.0 and tensorflow-macos>=2.11.0 because these package versions have conflicting dependencies.
```


**Status: didn't do any of the things below as I don't find them necessarily applicable to this PR**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
