### PR TITLE
Scripts/ato 573 3.3.x doc release should omit alpha releases

### DIFF
--- a/changelog/11926.bugfix.md
+++ b/changelog/11926.bugfix.md
@@ -1,0 +1,1 @@
+Decision to publish docs should not consider next major and minor alpha release versions.

--- a/scripts/evaluate_release_tag.py
+++ b/scripts/evaluate_release_tag.py
@@ -1,10 +1,7 @@
 """Evaluate release tag for whether docs should be built or not.
 
 """
-from ensurepip import version
-import os
 import argparse
-from pathlib import Path
 from subprocess import check_output
 from typing import List, Text, Set
 

--- a/scripts/evaluate_release_tag.py
+++ b/scripts/evaluate_release_tag.py
@@ -3,9 +3,10 @@
 """
 import argparse
 from subprocess import check_output
-from typing import List, Text, Set
+from typing import List
 
 from pep440_version_utils import Version, is_valid_version
+
 
 def create_argument_parser() -> argparse.ArgumentParser:
     """Parse all the command line arguments for the release script."""
@@ -19,12 +20,13 @@ def create_argument_parser() -> argparse.ArgumentParser:
 
     return parser
 
+
 def is_plain_version(version: Version) -> bool:
     """Check whether a version is a X.x.x release with no alpha or rc markers"""
     return version.base_version == str(version)
 
 
-def git_existing_tag_versions() -> Set[Text]:
+def git_existing_tag_versions() -> List[Version]:
     """Return all existing tags in the local git repo."""
 
     stdout = check_output(["git", "tag"])
@@ -32,36 +34,52 @@ def git_existing_tag_versions() -> Set[Text]:
     versions = [Version(tag) for tag in tags if is_valid_version(tag)]
     return versions
 
-def git_plain_tag_versions(versions: List[Version]) -> Set[Text]:
+
+def git_plain_tag_versions(versions: List[Version]) -> List[Version]:
     """Return non-alpha/rc existing tags"""
     return [version for version in versions if is_plain_version(version)]
 
 
-def main(args: argparse.Namespace) -> None:
-    tag = Version(args.tag)
+def filter_non_alpha_releases(tags: List[Version]) -> List[Version]:
+    return [tag for tag in tags if tag.is_alpha is False]
 
-    existing_tags = git_existing_tag_versions()
-    existing_tags.sort()
-    latest_version = existing_tags[-1]
+
+def get_existing_tag_versions() -> List[Version]:
+    stdout = check_output(["git", "tag"])
+    tags = set(stdout.decode().split("\n"))
+    versions = [Version(tag) for tag in tags if is_valid_version(tag)]
+    return versions
+
+
+def should_build_docs(tag: Version) -> bool:
+    existing_tags = get_existing_tag_versions()
+    non_alpha_releases = filter_non_alpha_releases(existing_tags)
+    non_alpha_releases.sort()
+    latest_version = non_alpha_releases[-1]
     print(f"The latest non-alpha/rc/nightly tag is {latest_version}.")
 
     previous_major = latest_version.major - 1
-    previous_major_versions = [tag for tag in existing_tags if tag.major == previous_major]
+    previous_major_versions = [tag for tag in non_alpha_releases if tag.major == previous_major]
     previous_major_latest_version = previous_major_versions[-1]
     print(f"The latest tag on the previous major is {previous_major_latest_version}.")
 
-    build_docs = False
+    need_to_build_docs = False
 
     if not is_plain_version(tag):
         print(f"Tag {tag} is an alpha, rc, nightly, or otherwise non-standard version.")
     elif tag >= latest_version:
         print(f"Tag {tag} is the latest version. Docs should be built.")
-        build_docs = True
+        need_to_build_docs = True
     elif tag.major == previous_major and tag > previous_major_latest_version:
         print(f"Tag {tag} is higher than the latest version for the previous major. Docs should be built.")
-        build_docs = True
+        need_to_build_docs = True
 
-    if not build_docs:
+    return need_to_build_docs
+
+
+def main(args: argparse.Namespace) -> None:
+    tag = Version(args.tag)
+    if not should_build_docs(tag):
         raise SystemExit(f"Docs should not be built for tag {tag}.")
 
 

--- a/tests/scripts/test_evaluate_release_tag.py
+++ b/tests/scripts/test_evaluate_release_tag.py
@@ -1,0 +1,60 @@
+from scripts.evaluate_release_tag import filter_non_alpha_releases, should_build_docs
+import pytest
+from pep440_version_utils import Version
+from typing import List
+from unittest.mock import patch
+
+
+@pytest.mark.parametrize("releases, expected",
+    [
+        (
+            [Version("1.1.0"), Version("2.2.0")],
+            [Version("1.1.0"), Version("2.2.0")],
+        ),
+        (
+            [Version("1.1.0"), Version("2.2.0"), Version("1.1.1a")],
+            [Version("1.1.0"), Version("2.2.0")],
+        ),
+(
+            [Version("1.1.0"), Version("2.2.0"), Version("1.1.1a1")],
+            [Version("1.1.0"), Version("2.2.0")],
+        )
+    ],
+)
+def test_filter_non_alpha_releases(releases: List[Version], expected: List[Version]):
+    result = filter_non_alpha_releases(releases)
+    assert result == expected
+
+
+@pytest.mark.parametrize("releases, tag, expected",
+     [
+         (
+            [Version("1.1.0"), Version("2.2.0")], Version("2.3.0"), True,
+         ),
+         (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0a1")], Version("2.2.1"), True,
+         ),
+         (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")], Version("1.2.0"), True,
+         ),
+         (
+            [Version("1.1.0"), Version("1.2.0a1"), Version("2.3.0")], Version("1.1.2"), True,
+         ),
+         (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")], Version("2.2.1"), False,
+         ),
+         (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")], Version("2.2.1a1"), False,
+         ),
+     ],
+)
+@patch("scripts.evaluate_release_tag.get_existing_tag_versions")
+def test_should_build_docs(
+    mock_get_existing_tag_versions,
+    releases: List[Version],
+    tag: Version,
+    expected: bool,
+) -> None:
+    mock_get_existing_tag_versions.return_value = releases
+    result = should_build_docs(tag)
+    assert result == expected

--- a/tests/scripts/test_evaluate_release_tag.py
+++ b/tests/scripts/test_evaluate_release_tag.py
@@ -5,7 +5,8 @@ from typing import List
 from unittest.mock import patch
 
 
-@pytest.mark.parametrize("releases, expected",
+@pytest.mark.parametrize(
+    "releases, expected",
     [
         (
             [Version("1.1.0"), Version("2.2.0")],
@@ -15,10 +16,10 @@ from unittest.mock import patch
             [Version("1.1.0"), Version("2.2.0"), Version("1.1.1a")],
             [Version("1.1.0"), Version("2.2.0")],
         ),
-(
+        (
             [Version("1.1.0"), Version("2.2.0"), Version("1.1.1a1")],
             [Version("1.1.0"), Version("2.2.0")],
-        )
+        ),
     ],
 )
 def test_filter_non_alpha_releases(releases: List[Version], expected: List[Version]):
@@ -26,27 +27,40 @@ def test_filter_non_alpha_releases(releases: List[Version], expected: List[Versi
     assert result == expected
 
 
-@pytest.mark.parametrize("releases, tag, expected",
-     [
-         (
-            [Version("1.1.0"), Version("2.2.0")], Version("2.3.0"), True,
-         ),
-         (
-            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0a1")], Version("2.2.1"), True,
-         ),
-         (
-            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")], Version("1.2.0"), True,
-         ),
-         (
-            [Version("1.1.0"), Version("1.2.0a1"), Version("2.3.0")], Version("1.1.2"), True,
-         ),
-         (
-            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")], Version("2.2.1"), False,
-         ),
-         (
-            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")], Version("2.2.1a1"), False,
-         ),
-     ],
+@pytest.mark.parametrize(
+    "releases, tag, expected",
+    [
+        (
+            [Version("1.1.0"), Version("2.2.0")],
+            Version("2.3.0"),
+            True,
+        ),
+        (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0a1")],
+            Version("2.2.1"),
+            True,
+        ),
+        (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")],
+            Version("1.2.0"),
+            True,
+        ),
+        (
+            [Version("1.1.0"), Version("1.2.0a1"), Version("2.3.0")],
+            Version("1.1.2"),
+            True,
+        ),
+        (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")],
+            Version("2.2.1"),
+            False,
+        ),
+        (
+            [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")],
+            Version("2.2.1a1"),
+            False,
+        ),
+    ],
 )
 @patch("scripts.evaluate_release_tag.get_existing_tag_versions")
 def test_should_build_docs(


### PR DESCRIPTION
**Proposed changes**:
- port ATO-573 to 3.3.x

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
