### PR TITLE
Support for Weights & Biases training experiment tracker

### DIFF
--- a/rasa/core/policies/unexpected_intent_policy.py
+++ b/rasa/core/policies/unexpected_intent_policy.py
@@ -83,6 +83,7 @@ from rasa.utils.tensorflow.constants import (
     BALANCED,
     TENSORBOARD_LOG_DIR,
     TENSORBOARD_LOG_LEVEL,
+    WANDB_PROJECT_NAME,
     CHECKPOINT_MODEL,
     FEATURIZERS,
     ENTITY_RECOGNITION,
@@ -244,6 +245,8 @@ class UnexpecTEDIntentPolicy(TEDPolicy):
             # Either after every epoch or for every training step.
             # Valid values: 'epoch' and 'batch'
             TENSORBOARD_LOG_LEVEL: "epoch",
+            # Weights and Biases project name to trace training experiments
+            WANDB_PROJECT_NAME: None,
             # Perform model checkpointing
             CHECKPOINT_MODEL: False,
             # Specify what features to use as sequence and sentence features.

--- a/rasa/nlu/selectors/response_selector.py
+++ b/rasa/nlu/selectors/response_selector.py
@@ -74,6 +74,7 @@ from rasa.utils.tensorflow.constants import (
     BALANCED,
     TENSORBOARD_LOG_DIR,
     TENSORBOARD_LOG_LEVEL,
+    WANDB_PROJECT_NAME,
     CONCAT_DIMENSION,
     FEATURIZERS,
     CHECKPOINT_MODEL,
@@ -251,6 +252,8 @@ class ResponseSelector(DIETClassifier):
             # Either after every epoch or for every training step.
             # Valid values: 'epoch' and 'batch'
             TENSORBOARD_LOG_LEVEL: "epoch",
+            # Weights and Biases project name to trace training experiments
+            WANDB_PROJECT_NAME: None,
             # Specify what features to use as sequence and sentence features
             # By default all features in the pipeline are used.
             FEATURIZERS: [],

--- a/rasa/utils/tensorflow/constants.py
+++ b/rasa/utils/tensorflow/constants.py
@@ -85,6 +85,8 @@ MEAN_POOLING = "mean"
 TENSORBOARD_LOG_DIR = "tensorboard_log_directory"
 TENSORBOARD_LOG_LEVEL = "tensorboard_log_level"
 
+WANDB_PROJECT_NAME = "wandb_project_name"
+
 SEQUENCE_FEATURES = "sequence_features"
 SENTENCE_FEATURES = "sentence_features"
 

--- a/rasa/utils/train_utils.py
+++ b/rasa/utils/train_utils.py
@@ -348,6 +348,7 @@ def create_common_callbacks(
     epochs: int,
     tensorboard_log_dir: Optional[Text] = None,
     tensorboard_log_level: Optional[Text] = None,
+    wandb_project_name: Optional[Text] = None,
     checkpoint_dir: Optional[Path] = None,
 ) -> List["Callback"]:
     """Create common callbacks.
@@ -355,6 +356,7 @@ def create_common_callbacks(
     The following callbacks are created:
     - RasaTrainingLogger callback
     - Optional TensorBoard callback
+    - Optional Wand callback
     - Optional RasaModelCheckpoint callback
 
     Args:
@@ -362,6 +364,7 @@ def create_common_callbacks(
         tensorboard_log_dir: optional directory that should be used for tensorboard
         tensorboard_log_level: defines when training metrics for tensorboard should be
                                logged. Valid values: 'epoch' and 'batch'.
+        wandb_project_name: optional WAND project name 
         checkpoint_dir: optional directory that should be used for model checkpointing
 
     Returns:
@@ -382,6 +385,11 @@ def create_common_callbacks(
             )
         )
 
+    if wandb_project_name:
+        import wandb
+        callbacks.append(
+            wandb.keras.WandbCallback()
+        )
     if checkpoint_dir:
         callbacks.append(RasaModelCheckpoint(checkpoint_dir))
 


### PR DESCRIPTION
**Proposed changes**:
- Support for Weights and Biases training experiments tracker [wandb.ai](https://wandb.ai/)
  - In order to use the service you need sign up (free tier is available) and expose the key into the environment: 
    - export **WANDB_API_KEY**= key-value

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
