### PR TITLE
Remove linear-norm

### DIFF
--- a/docs/docs/policies.mdx
+++ b/docs/docs/policies.mdx
@@ -206,11 +206,8 @@ If you want to fine-tune your model, start by modifying the following parameters
   This should help in better generalization of the model to real world test sets.
 
 * `model_confidence`:
-  This parameter allows the user to configure how confidences are computed during inference. It can take two values:
+  This parameter allows the user to configure how confidences are computed during inference. Currently, only one value is supported:
   * `softmax`: Confidences are in the range `[0, 1]` (old behavior and current default). Computed similarities are normalized with the `softmax` activation function.
-  * `linear_norm`: Confidences are in the range `[0, 1]`. Computed dot product similarities are normalized with a linear function.
-
-  Please try using `linear_norm` as the value for `model_confidence`. This should make it easier to [handle actions predicted with low confidence](./fallback-handoff.mdx#handling-low-action-confidence).
 
 * `use_gpu`:
   This parameter defines whether a GPU (if available) will be used training. By default, `TEDPolicy` will be trained on GPU 


### PR DESCRIPTION
Co-authored-by: Antonio <netocaastro10@gmail.com>

**Proposed changes**:
- Removed model_confidence's linear-norm setting from the policies.mdx. Linear-norm was [removed](https://github.com/RasaHQ/rasa/blob/main/CHANGELOG.mdx#300---2021-11-23) in 3.0.0.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
