### PR TITLE
fix: allow send domain explictly for actions from multiple files

### DIFF
--- a/changelog/12052.bugfix.md
+++ b/changelog/12052.bugfix.md
@@ -1,0 +1,1 @@
+Fix the error which resulted during merging multiple domain files where at least one of them contains custom actions that explicitly need `send_domain` set as True in the domain.

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -367,7 +367,7 @@ class Domain:
         merge_func_mappings: Dict[Text, Callable[..., Any]] = {
             KEY_INTENTS: rasa.shared.utils.common.merge_lists_of_dicts,
             KEY_ENTITIES: rasa.shared.utils.common.merge_lists_of_dicts,
-            KEY_ACTIONS: rasa.shared.utils.common.merge_lists,
+            KEY_ACTIONS: rasa.shared.utils.common.merge_lists_of_dicts,
             KEY_E2E_ACTIONS: rasa.shared.utils.common.merge_lists,
             KEY_FORMS: rasa.shared.utils.common.merge_dicts,
             KEY_RESPONSES: rasa.shared.utils.common.merge_dicts,

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -2202,15 +2202,20 @@ def test_domain_loads_actions_which_explicitly_need_domain(
 
 
 def test_merge_yaml_domains_loads_actions_which_explicitly_need_domain():
-    test_yaml_1 = textwrap.dedent(f"""
+    test_yaml_1 = textwrap.dedent(
+        """
         actions:
           - action_hello
           - action_bye
-          - action_send_domain: {{send_domain: True}}""")
+          - action_send_domain: {send_domain: True}"""
+    )
 
-    test_yaml_2 = textwrap.dedent(f"""
+    test_yaml_2 = textwrap.dedent(
+        """
         actions:
-          - action_find_restaurants: {{send_domain: True}}""")
+          - action_find_restaurants:
+                send_domain: True"""
+    )
 
     domain_1 = Domain.from_yaml(test_yaml_1)
     domain_2 = Domain.from_yaml(test_yaml_2)

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -924,7 +924,7 @@ def test_domain_from_multiple_files():
 
     assert expected_intents == domain.intents
     assert expected_entities == sorted(domain.entities)
-    assert expected_actions == domain.user_actions
+    assert sorted(expected_actions) == sorted(domain.user_actions)
     assert expected_responses == domain.responses
     assert expected_forms == domain.forms
     assert domain.session_config.session_expiration_time == 360
@@ -2200,44 +2200,55 @@ def test_domain_loads_actions_which_explicitly_need_domain(
         == expected_actions_which_explicitly_need_domain
     )
 
-def test_merge_yaml_domains_loads_actions_which_explicitly_need_domain():
-    test_yaml_1 = f"""config:
-  store_entities_as_slots: true
-entities: []
-intents: []
-slots: {{}}
-responses:
-  utter_greet:
-  - text: hey there!
-actions:
-  - action_hello
-  - action_bye
-  - action_send_domain: {{send_domain: True}}"""
 
-    test_yaml_2 = f"""config:
-  store_entities_as_slots: false
-session_config:
-    session_expiration_time: 20
-    carry_over_slots: true
-entities:
-- cuisine
-intents:
-- greet
-slots:
-  cuisine:
-    type: text
-    mappings:
-    - type: from_text
-actions:
-- action_find_restaurants: {{send_domain: True}}"""
+def test_merge_yaml_domains_loads_actions_which_explicitly_need_domain():
+    test_yaml_1 = """config:
+        store_entities_as_slots: true
+        entities: []
+        intents: []
+        slots: {{}}
+        responses:
+          utter_greet:
+          - text: hey there!
+        actions:
+          - action_hello
+          - action_bye
+          - action_send_domain: {{send_domain: True}}"""
+
+    test_yaml_2 = """config:
+        store_entities_as_slots: false
+        session_config:
+            session_expiration_time: 20
+            carry_over_slots: true
+        entities:
+        - cuisine
+        intents:
+        - greet
+        slots:
+          cuisine:
+            type: text
+            mappings:
+            - type: from_text
+        actions:
+        - action_find_restaurants: {{send_domain: True}}"""
 
     domain_1 = Domain.from_yaml(test_yaml_1)
     domain_2 = Domain.from_yaml(test_yaml_2)
 
     domain = domain_1.merge(domain_2)
-    
+
     # single attribute should be taken from domain_1
-    expected_actions = ["action_hello", "action_bye", "action_send_domain", "action_find_restaurants"]
-    expected_actions_that_need_domain = ["action_send_domain", "action_find_restaurants"]
+    expected_actions = [
+        "action_hello",
+        "action_bye",
+        "action_send_domain",
+        "action_find_restaurants",
+    ]
+    expected_actions_that_need_domain = [
+        "action_send_domain",
+        "action_find_restaurants",
+    ]
     assert sorted(domain._custom_actions) == sorted(expected_actions)
-    assert sorted(domain._actions_which_explicitly_need_domain) == sorted(expected_actions_that_need_domain)
+    assert sorted(domain._actions_which_explicitly_need_domain) == sorted(
+        expected_actions_that_need_domain
+    )

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -2202,35 +2202,15 @@ def test_domain_loads_actions_which_explicitly_need_domain(
 
 
 def test_merge_yaml_domains_loads_actions_which_explicitly_need_domain():
-    test_yaml_1 = """config:
-        store_entities_as_slots: true
-        entities: []
-        intents: []
-        slots: {{}}
-        responses:
-          utter_greet:
-          - text: hey there!
+    test_yaml_1 = textwrap.dedent(f"""
         actions:
           - action_hello
           - action_bye
-          - action_send_domain: {{send_domain: True}}"""
+          - action_send_domain: {{send_domain: True}}""")
 
-    test_yaml_2 = """config:
-        store_entities_as_slots: false
-        session_config:
-            session_expiration_time: 20
-            carry_over_slots: true
-        entities:
-        - cuisine
-        intents:
-        - greet
-        slots:
-          cuisine:
-            type: text
-            mappings:
-            - type: from_text
+    test_yaml_2 = textwrap.dedent(f"""
         actions:
-        - action_find_restaurants: {{send_domain: True}}"""
+          - action_find_restaurants: {{send_domain: True}}""")
 
     domain_1 = Domain.from_yaml(test_yaml_1)
     domain_2 = Domain.from_yaml(test_yaml_2)

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -2237,9 +2237,7 @@ actions:
     domain = domain_1.merge(domain_2)
     
     # single attribute should be taken from domain_1
-    assert domain.store_entities_as_slots
     expected_actions = ["action_hello", "action_bye", "action_send_domain", "action_find_restaurants"]
     expected_actions_that_need_domain = ["action_send_domain", "action_find_restaurants"]
     assert sorted(domain._custom_actions) == sorted(expected_actions)
     assert sorted(domain._actions_which_explicitly_need_domain) == sorted(expected_actions_that_need_domain)
-    

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -2199,3 +2199,47 @@ def test_domain_loads_actions_which_explicitly_need_domain(
         domain._actions_which_explicitly_need_domain
         == expected_actions_which_explicitly_need_domain
     )
+
+def test_merge_yaml_domains_loads_actions_which_explicitly_need_domain():
+    test_yaml_1 = f"""config:
+  store_entities_as_slots: true
+entities: []
+intents: []
+slots: {{}}
+responses:
+  utter_greet:
+  - text: hey there!
+actions:
+  - action_hello
+  - action_bye
+  - action_send_domain: {{send_domain: True}}"""
+
+    test_yaml_2 = f"""config:
+  store_entities_as_slots: false
+session_config:
+    session_expiration_time: 20
+    carry_over_slots: true
+entities:
+- cuisine
+intents:
+- greet
+slots:
+  cuisine:
+    type: text
+    mappings:
+    - type: from_text
+actions:
+- action_find_restaurants: {{send_domain: True}}"""
+
+    domain_1 = Domain.from_yaml(test_yaml_1)
+    domain_2 = Domain.from_yaml(test_yaml_2)
+
+    domain = domain_1.merge(domain_2)
+    
+    # single attribute should be taken from domain_1
+    assert domain.store_entities_as_slots
+    expected_actions = ["action_hello", "action_bye", "action_send_domain", "action_find_restaurants"]
+    expected_actions_that_need_domain = ["action_send_domain", "action_find_restaurants"]
+    assert sorted(domain._custom_actions) == sorted(expected_actions)
+    assert sorted(domain._actions_which_explicitly_need_domain) == sorted(expected_actions_that_need_domain)
+    


### PR DESCRIPTION
**Proposed changes**:
- the changes implemented fixes the bug that for multiple domain files whilst merging would throw an error when trying to explictly send domain for certain custom actions 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
