### PR TITLE
Docs should publish for all supported minor versions

### DIFF
--- a/scripts/evaluate_release_tag.py
+++ b/scripts/evaluate_release_tag.py
@@ -63,6 +63,9 @@ def should_build_docs(tag: Version) -> bool:
     elif tag >= latest_version:
         print(f"Tag {tag} is the latest version. Docs should be built.")
         need_to_build_docs = True
+    elif tag < latest_version:
+        print(f"Tag {tag} is an old minor. Docs should be built.")
+        need_to_build_docs = True
     elif tag.major == previous_major and tag > previous_major_latest_version:
         print(f"Tag {tag} is higher than the latest version for the previous major. Docs should be built.")
         need_to_build_docs = True

--- a/tests/scripts/test_evaluate_release_tag.py
+++ b/tests/scripts/test_evaluate_release_tag.py
@@ -1,8 +1,10 @@
-from scripts.evaluate_release_tag import filter_non_alpha_releases, should_build_docs
-import pytest
-from pep440_version_utils import Version
 from typing import List
 from unittest.mock import patch
+
+import pytest
+from pep440_version_utils import Version
+
+from scripts.evaluate_release_tag import filter_non_alpha_releases, should_build_docs
 
 
 @pytest.mark.parametrize(
@@ -39,7 +41,13 @@ def test_filter_non_alpha_releases(releases: List[Version], expected: List[Versi
             True,
         ),
         (
-            [Version("3.2.5"), Version("3.3.4a1"), Version("3.3.3"), Version("3.4.3"), Version("2.2.3")],
+            [
+                Version("3.2.5"),
+                Version("3.3.4a1"),
+                Version("3.3.3"),
+                Version("3.4.3"),
+                Version("2.2.3"),
+            ],
             Version("3.2.6"),
             True,
         ),

--- a/tests/scripts/test_evaluate_release_tag.py
+++ b/tests/scripts/test_evaluate_release_tag.py
@@ -39,14 +39,14 @@ def test_filter_non_alpha_releases(releases: List[Version], expected: List[Versi
             True,
         ),
         (
-            [Version("1.1.0"), Version("1.2.0a1"), Version("2.3.0")],
-            Version("1.1.2"),
+            [Version("3.2.5"), Version("3.3.4a1"), Version("3.3.3"), Version("3.4.3"), Version("2.2.3")],
+            Version("3.2.6"),
             True,
         ),
         (
             [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")],
             Version("2.2.1"),
-            False,
+            True,
         ),
         (
             [Version("1.1.0"), Version("2.2.0"), Version("2.3.0")],


### PR DESCRIPTION
**Proposed changes**:
- Docs were not being published for older minor versions. This will publish docs for all tags except alpha tags.
