### PR TITLE
Slots in rules are not validated against declared slots - [ENG 151]

### DIFF
--- a/changelog/12059.bugfix.md
+++ b/changelog/12059.bugfix.md
@@ -1,0 +1,1 @@
+Check unresolved slots before initiating model training.

--- a/rasa/model_training.py
+++ b/rasa/model_training.py
@@ -28,9 +28,6 @@ import rasa.model
 
 CODE_NEEDS_TO_BE_RETRAINED = 0b0001
 CODE_FORCED_TRAINING = 0b1000
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 class TrainingResult(NamedTuple):

--- a/rasa/model_training.py
+++ b/rasa/model_training.py
@@ -76,7 +76,7 @@ def _dry_run_result(
     return TrainingResult(dry_run_results=fingerprint_results)
 
 
-def _get_unresolved_slots(domain: Domain, stories: StoryGraph) -> List[Text]:
+def get_unresolved_slots(domain: Domain, stories: StoryGraph) -> List[Text]:
     """Returns a list of unresolved slots.
 
     Args:
@@ -97,7 +97,7 @@ def _get_unresolved_slots(domain: Domain, stories: StoryGraph) -> List[Text]:
     )
 
 
-def check_unresolved_slots(domain: Domain, stories: StoryGraph) -> None:
+def _check_unresolved_slots(domain: Domain, stories: StoryGraph) -> None:
     """Checks if there are any unresolved slots.
 
     Args:
@@ -110,7 +110,7 @@ def check_unresolved_slots(domain: Domain, stories: StoryGraph) -> None:
     Returns:
         `None` if there are no unresolved slots.
     """
-    unresolved_slots = _get_unresolved_slots(domain, stories)
+    unresolved_slots = get_unresolved_slots(domain, stories)
     if unresolved_slots:
         rasa.shared.utils.cli.print_error_and_exit(
             f"Unresolved slots found in stories/rules🚨 \n"
@@ -201,7 +201,7 @@ def train(
         )
         training_type = TrainingType.CORE
 
-    check_unresolved_slots(domain_object, stories)
+    _check_unresolved_slots(domain_object, stories)
 
     with telemetry.track_model_training(file_importer, model_type="rasa"):
         return _train_graph(
@@ -385,7 +385,7 @@ def train_core(
         )
         return None
 
-    check_unresolved_slots(domain, stories_data)
+    _check_unresolved_slots(domain, stories_data)
 
     return _train_graph(
         file_importer,

--- a/tests/test_model_training.py
+++ b/tests/test_model_training.py
@@ -30,8 +30,8 @@ from rasa.engine.recipes.default_recipe import DefaultV1Recipe
 from rasa.engine.graph import GraphModelConfiguration
 from rasa.engine.training.graph_trainer import GraphTrainer
 from rasa.shared.data import TrainingType
-
-
+from rasa.shared.core.events import ActionExecuted, SlotSet
+from rasa.shared.core.training_data.structures import RuleStep, StoryGraph, StoryStep
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier
 from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 import rasa.shared.utils.io
@@ -1049,3 +1049,40 @@ def test_fingerprint_changes_if_module_changes(
 
     assert result.code == rasa.model_training.CODE_NEEDS_TO_BE_RETRAINED
     assert not result.dry_run_results[f"train_{module_name}.{new_class_name}1"].is_hit
+
+
+def test_get_unresolved_slots(capsys: CaptureFixture):
+    stories = StoryGraph(
+        [
+            StoryStep(
+                "greet",
+                events=[SlotSet("temp1"), ActionExecuted("temp3"), SlotSet("cuisine")],
+            ),
+            RuleStep("bye", events=[SlotSet("temp4")]),
+        ]
+    )
+    domain_path = "data/test_domains/default_with_mapping.yml"
+    domain = Domain.load(domain_path)
+    with pytest.raises(SystemExit):
+        rasa.model_training._check_unresolved_slots(domain, stories)
+
+    error_output = capsys.readouterr().out
+    assert (
+        "temp1" in error_output
+        and "temp4" in error_output
+        and "cuisine" not in error_output
+    )
+
+    stories = StoryGraph(
+        [
+            StoryStep(
+                "greet",
+                events=[
+                    SlotSet("location"),
+                    ActionExecuted("temp"),
+                    SlotSet("cuisine"),
+                ],
+            )
+        ]
+    )
+    assert rasa.model_training._check_unresolved_slots(domain, stories) is None

--- a/tests/test_model_training.py
+++ b/tests/test_model_training.py
@@ -1064,7 +1064,7 @@ def test_check_unresolved_slots(capsys: CaptureFixture):
     domain_path = "data/test_domains/default_with_mapping.yml"
     domain = Domain.load(domain_path)
     with pytest.raises(SystemExit):
-        rasa.model_training.check_unresolved_slots(domain, stories)
+        rasa.model_training._check_unresolved_slots(domain, stories)
 
     error_output = capsys.readouterr().out
     assert (
@@ -1085,4 +1085,4 @@ def test_check_unresolved_slots(capsys: CaptureFixture):
             )
         ]
     )
-    assert rasa.model_training.check_unresolved_slots(domain, stories) is None
+    assert rasa.model_training._check_unresolved_slots(domain, stories) is None

--- a/tests/test_model_training.py
+++ b/tests/test_model_training.py
@@ -1051,7 +1051,7 @@ def test_fingerprint_changes_if_module_changes(
     assert not result.dry_run_results[f"train_{module_name}.{new_class_name}1"].is_hit
 
 
-def test_get_unresolved_slots(capsys: CaptureFixture):
+def test_check_unresolved_slots(capsys: CaptureFixture):
     stories = StoryGraph(
         [
             StoryStep(
@@ -1064,7 +1064,7 @@ def test_get_unresolved_slots(capsys: CaptureFixture):
     domain_path = "data/test_domains/default_with_mapping.yml"
     domain = Domain.load(domain_path)
     with pytest.raises(SystemExit):
-        rasa.model_training._check_unresolved_slots(domain, stories)
+        rasa.model_training.check_unresolved_slots(domain, stories)
 
     error_output = capsys.readouterr().out
     assert (
@@ -1085,4 +1085,4 @@ def test_get_unresolved_slots(capsys: CaptureFixture):
             )
         ]
     )
-    assert rasa.model_training._check_unresolved_slots(domain, stories) is None
+    assert rasa.model_training.check_unresolved_slots(domain, stories) is None


### PR DESCRIPTION
**Proposed changes**:
- Check unresolved slots before initiating model training.
- Collects all the unresolved slots and throws an error mentioning the same. Hence, allows user to know all the slot mismatches at the first try itself.
- Fixes: https://rasahq.atlassian.net/browse/ENG-151

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
