### PR TITLE
Add the hook to get extra non-custom actions from plugins

### DIFF
--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -177,18 +177,19 @@ def action_for_name_or_text(
 
     defaults = {a.name(): a for a in default_actions(action_endpoint)}
 
-    extra_defaults = plugin_manager().hook.extra_default_actions(domain=domain)
-    defaults = reduce(
-        lambda acc, actions: {**acc, **{a.name(): a for a in actions}},
-        extra_defaults,
-        defaults,
-    )
-
     if (
         action_name_or_text in defaults
         and action_name_or_text not in domain.user_actions_and_forms
     ):
         return defaults[action_name_or_text]
+
+    extra_defaults = reduce(
+        lambda acc, actions: {**acc, **{a.name(): a for a in actions}},
+        plugin_manager().hook.extra_default_actions(domain=domain),
+        {},
+    )
+    if action_name_or_text in extra_defaults:
+        return extra_defaults[action_name_or_text]
 
     if action_name_or_text.startswith(UTTER_PREFIX) and is_retrieval_action(
         action_name_or_text, domain.retrieval_intents
@@ -1267,7 +1268,6 @@ class ActionExtractSlots(Action):
         validated_events = await self._execute_validation_action(
             slot_events, output_channel, nlg, tracker, domain
         )
-
         return validated_events
 
 

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -183,13 +183,13 @@ def action_for_name_or_text(
     ):
         return defaults[action_name_or_text]
 
-    extra_defaults: Dict[str, "Action"] = reduce(
+    space_activation_actions: Dict[str, "Action"] = reduce(
         lambda acc, actions: {**acc, **{a.name(): a for a in actions}},
-        plugin_manager().hook.extra_default_actions(domain=domain),
+        plugin_manager().hook.generate_space_activation_actions(domain=domain),
         {},
     )
-    if action_name_or_text in extra_defaults:
-        return extra_defaults[action_name_or_text]
+    if action_name_or_text in space_activation_actions:
+        return space_activation_actions[action_name_or_text]
 
     if action_name_or_text.startswith(UTTER_PREFIX) and is_retrieval_action(
         action_name_or_text, domain.retrieval_intents

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -183,7 +183,7 @@ def action_for_name_or_text(
     ):
         return defaults[action_name_or_text]
 
-    extra_defaults = reduce(
+    extra_defaults: Dict[str, "Action"] = reduce(
         lambda acc, actions: {**acc, **{a.name(): a for a in actions}},
         plugin_manager().hook.extra_default_actions(domain=domain),
         {},

--- a/rasa/plugin.py
+++ b/rasa/plugin.py
@@ -13,6 +13,8 @@ from rasa.shared.nlu.training_data.message import Message
 
 if typing.TYPE_CHECKING:
     from rasa.rasa.engine.graph import SchemaNode
+    from rasa.shared.core.domain import Domain
+    from rasa.core.actions.action import Action
 
 hookspec = pluggy.HookspecMarker("rasa")
 
@@ -93,3 +95,8 @@ def clean_entity_targets_for_evaluation(
     merged_targets: List[str], extractor: str
 ) -> List[str]:
     """Remove entity targets for space-based entity extractors."""
+
+
+@hookspec  # type: ignore[misc]
+def extra_default_actions(domain: "Domain") -> List["Action"]:
+    """Hook specification for getting a plugin's list of default actions."""

--- a/rasa/plugin.py
+++ b/rasa/plugin.py
@@ -98,5 +98,5 @@ def clean_entity_targets_for_evaluation(
 
 
 @hookspec  # type: ignore[misc]
-def extra_default_actions(domain: "Domain") -> List["Action"]:
-    """Hook specification for getting a plugin's list of default actions."""
+def generate_space_activation_actions(domain: "Domain") -> List["Action"]:
+    """Hook specification for getting a plugin's list of space activation actions."""


### PR DESCRIPTION
**Proposed changes**:
Add hookspec to collect default actions from plugins and merge them to the `default_actions` list.

One of the ways how a user can activate space is by triggering intent that calls activation action. To make activation action non-custom action here, we add a mechanism to extend `default_actions`.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
