### PR TITLE
Add intent's prefix splitting step before intent tokenization

### DIFF
--- a/rasa/nlu/tokenizers/jieba_tokenizer.py
+++ b/rasa/nlu/tokenizers/jieba_tokenizer.py
@@ -41,6 +41,8 @@ class JiebaTokenizer(Tokenizer):
             "intent_split_symbol": "_",
             # Regular expression to detect tokens
             "token_pattern": None,
+            # Symbol on which prefix should be split
+            "prefix_separator_symbol": None,
         }
 
     def __init__(

--- a/rasa/nlu/tokenizers/mitie_tokenizer.py
+++ b/rasa/nlu/tokenizers/mitie_tokenizer.py
@@ -27,6 +27,8 @@ class MitieTokenizer(Tokenizer):
             "intent_split_symbol": "_",
             # Regular expression to detect tokens
             "token_pattern": None,
+            # Symbol on which prefix should be split
+            "prefix_separator_symbol": None,
         }
 
     @staticmethod

--- a/rasa/nlu/tokenizers/spacy_tokenizer.py
+++ b/rasa/nlu/tokenizers/spacy_tokenizer.py
@@ -34,6 +34,8 @@ class SpacyTokenizer(Tokenizer):
             "intent_split_symbol": "_",
             # Regular expression to detect tokens
             "token_pattern": None,
+            # Symbol on which prefix should be split
+            "prefix_separator_symbol": None,
         }
 
     @staticmethod

--- a/rasa/nlu/tokenizers/tokenizer.py
+++ b/rasa/nlu/tokenizers/tokenizer.py
@@ -102,6 +102,8 @@ class Tokenizer(GraphComponent, abc.ABC):
         self.token_pattern_regex = None
         if token_pattern:
             self.token_pattern_regex = re.compile(token_pattern)
+        # split intent to prefix and suffix greedily, None means don't split
+        self.prefix_separator_symbol = config.get("prefix_separator_symbol")
 
     @classmethod
     def create(
@@ -161,7 +163,15 @@ class Tokenizer(GraphComponent, abc.ABC):
         return words
 
     def _split_name(self, message: Message, attribute: Text = INTENT) -> List[Token]:
-        text = message.get(attribute)
+        orig_text = message.get(attribute)
+
+        if (
+            self.prefix_separator_symbol is not None
+            and self.prefix_separator_symbol in orig_text
+        ):
+            prefix, text = orig_text.split(self.prefix_separator_symbol, maxsplit=1)
+        else:
+            prefix, text = None, orig_text
 
         # for INTENT_RESPONSE_KEY attribute,
         # first split by RESPONSE_IDENTIFIER_DELIMITER
@@ -174,7 +184,10 @@ class Tokenizer(GraphComponent, abc.ABC):
         else:
             words = self._tokenize_on_split_symbol(text)
 
-        return self._convert_words_to_tokens(words, text)
+        if prefix is not None:
+            words = [prefix] + words
+
+        return self._convert_words_to_tokens(words, orig_text)
 
     def _apply_token_pattern(self, tokens: List[Token]) -> List[Token]:
         """Apply the token pattern to the given tokens.

--- a/rasa/nlu/tokenizers/tokenizer.py
+++ b/rasa/nlu/tokenizers/tokenizer.py
@@ -185,7 +185,7 @@ class Tokenizer(GraphComponent, abc.ABC):
             words = self._tokenize_on_split_symbol(text)
 
         if prefix is not None:
-            words = [prefix] + words
+            words = self._tokenize_on_split_symbol(prefix) + words
 
         return self._convert_words_to_tokens(words, orig_text)
 

--- a/rasa/nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa/nlu/tokenizers/whitespace_tokenizer.py
@@ -36,6 +36,8 @@ class WhitespaceTokenizer(Tokenizer):
             "intent_split_symbol": "_",
             # Regular expression to detect tokens
             "token_pattern": None,
+            # Symbol on which prefix should be split
+            "prefix_separator_symbol": None,
         }
 
     def __init__(self, config: Dict[Text, Any]) -> None:

--- a/tests/nlu/tokenizers/test_tokenizer.py
+++ b/tests/nlu/tokenizers/test_tokenizer.py
@@ -314,6 +314,16 @@ def test_token_fingerprints_are_unique():
             ["prefix", "faq", "ask", "language"],
         ),
         ("prefix_forecast_for_LUNCH", INTENT, ["prefix_forecast_for_LUNCH"]),
+        (
+            "main+other!Forecast+for+LUNCH",
+            INTENT,
+            ["main", "other", "Forecast", "for", "LUNCH"],
+        ),
+        (
+            "main+other!faq/ask+language",
+            INTENT_RESPONSE_KEY,
+            ["main", "other", "faq", "ask", "language"],
+        ),
     ],
 )
 def test_split_intent_with_prefix(text: Text, attribute, expected_tokens: List[Text]):

--- a/tests/nlu/tokenizers/test_tokenizer.py
+++ b/tests/nlu/tokenizers/test_tokenizer.py
@@ -293,3 +293,39 @@ def test_token_fingerprints_are_unique():
     ]
     fingerprints = {t.fingerprint() for t in tokens}
     assert len(fingerprints) == len(tokens)
+
+
+@pytest.mark.parametrize(
+    "text, attribute, expected_tokens",
+    [
+        ("Forecast_for_LUNCH", INTENT, ["Forecast_for_LUNCH"]),
+        ("Forecast for LUNCH", INTENT, ["Forecast for LUNCH"]),
+        ("Forecast+for+LUNCH", INTENT, ["Forecast", "for", "LUNCH"]),
+        ("PREFIX!Forecast+for+LUNCH", INTENT, ["PREFIX", "Forecast", "for", "LUNCH"]),
+        ("prefix!Forecast_for_LUNCH", INTENT, ["prefix", "Forecast_for_LUNCH"]),
+        (
+            "prefix!faq/ask_language",
+            INTENT_RESPONSE_KEY,
+            ["prefix", "faq", "ask_language"],
+        ),
+        (
+            "prefix!faq/ask+language",
+            INTENT_RESPONSE_KEY,
+            ["prefix", "faq", "ask", "language"],
+        ),
+        ("prefix_forecast_for_LUNCH", INTENT, ["prefix_forecast_for_LUNCH"]),
+    ],
+)
+def test_split_intent_with_prefix(text: Text, attribute, expected_tokens: List[Text]):
+    component_config = {
+        "intent_tokenization_flag": True,
+        "intent_split_symbol": "+",
+        "prefix_separator_symbol": "!",
+    }
+
+    tk = create_whitespace_tokenizer(component_config)
+
+    message = Message.build(text=text)
+    message.set(attribute, text)
+
+    assert [t.text for t in tk._split_name(message, attribute)] == expected_tokens


### PR DESCRIPTION
**Proposed changes**:
When tokenising intent, preserve the prefix as a word

When the intent is constructed as a `space+name!ask+language` prefix (`space+name`) needs to be processed separately and as a word. 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
