### PR TITLE
Feature/oss 682

### DIFF
--- a/docs/docs/tracker-stores.mdx
+++ b/docs/docs/tracker-stores.mdx
@@ -101,6 +101,10 @@ To set up Rasa with SQL the following steps are required:
 
 * `query` (default: `None`): Dictionary of options to be passed to the dialect and/or the DBAPI upon connect
 
+* `table` (default: `None`): Alternative table name for storing events
+
+* `bot_id` (default: `None`): Alternative table field for storing additional information about chatbot. Allows using the same table for storing events from multiple chatbots.
+
 
 
 #### Compatible Databases

--- a/docs/docs/tracker-stores.mdx
+++ b/docs/docs/tracker-stores.mdx
@@ -101,7 +101,7 @@ To set up Rasa with SQL the following steps are required:
 
 * `query` (default: `None`): Dictionary of options to be passed to the dialect and/or the DBAPI upon connect
 
-* `table` (default: `None`): Alternative table name for storing events
+* `table_name` (default: `None`): Alternative table name for storing events
 
 * `bot_id` (default: `None`): Alternative table field for storing additional information about chatbot. Allows using the same table for storing events from multiple chatbots.
 

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1326,7 +1326,7 @@ def _create_from_endpoint_config(
             domain=domain,
             host=endpoint_config.url,
             event_broker=event_broker,
-            table_name=endpoint_config.kwargs.get('table',None),
+            table_name=endpoint_config.kwargs.get('table_name',None),
             **endpoint_config.kwargs,
         )
     elif endpoint_config.type.lower() == "dynamo":


### PR DESCRIPTION
**Proposed changes**:
- The proposed changes will allow custom configuration of tracker events table name for the SQL tracker and an additional events table field with chatbot id. We need this feature in order to save tracker events from multiple chatbots in the same SQL database. Please consider adding the feature in this pull request to the main code base. 

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
