### PR TITLE
Fix bug in from_intent slot mapping without intent specified

### DIFF
--- a/changelog/12096.bugfix.md
+++ b/changelog/12096.bugfix.md
@@ -1,0 +1,1 @@
+Fixes the bug when a slot (with `from_intent` mapping which contains no input for `intent` parameter) will no longer fill for any intent that is not under the `not_intent` parameter.

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -1026,7 +1026,7 @@ class ActionExtractSlots(Action):
     Action is executed automatically in MessageProcessor.handle_message(...)
     before the next predicted action is run.
 
-    Sets slots to extracted values from user message
+    Set slots to extracted values from user message
     according to assigned slot mappings.
     """
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -178,7 +178,7 @@ class MessageProcessor:
 
         tracker.update_with_events(extraction_events, self.domain)
 
-        events_as_str = "\n".join([str(e) for e in extraction_events])
+        events_as_str = ", ".join([repr(e) or str(e) for e in extraction_events])
         logger.debug(
             f"Default action '{ACTION_EXTRACT_SLOTS}' was executed, "
             f"resulting in {len(extraction_events)} events: {events_as_str}"

--- a/rasa/shared/core/slot_mappings.py
+++ b/rasa/shared/core/slot_mappings.py
@@ -204,6 +204,7 @@ class SlotMapping:
 
         if (
             mapping_type == SlotMappingType.FROM_INTENT
+            and mapping.get(INTENT) is not None
             and mapping.get(INTENT) not in domain.intents
         ):
             rasa.shared.utils.io.raise_warning(


### PR DESCRIPTION
**Proposed changes**:
- Fixes bug where a slot  - with `from_intent` mapping which contains no input for `intent` parameter - will no longer fill for any intent that is not under the `not_intent` parameter. Instead this warning is issued due to this check [here](https://github.com/RasaHQ/rasa/blob/3.4.x/rasa/shared/core/slot_mappings.py#L207):

```
/opt/venv/lib/python3.10/site-packages/rasa/shared/utils/io.py:98: UserWarning: Slot 'test_slot' uses a 'from_intent' mapping for a non-existent intent 'None'. Skipping slot extraction because of invalid mapping.
```

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
