### PR TITLE
Fix skipping evaluation when batch_size is dynamic (#12099)

### DIFF
--- a/changelog/12099.bugfix.md
+++ b/changelog/12099.bugfix.md
@@ -1,0 +1,1 @@
+Fix validation metrics calculation when batch_size is dynamic.

--- a/rasa/utils/tensorflow/temp_keras_modules.py
+++ b/rasa/utils/tensorflow/temp_keras_modules.py
@@ -435,7 +435,17 @@ class TmpKerasModel(Model):
                         workers=workers,
                         use_multiprocessing=use_multiprocessing,
                         return_dict=True,
-                        _use_cached_eval_dataset=True,
+                        # When batch_size is dynamic then the length
+                        # of dataset is changing, which triggers
+                        # _insufficient_data and validation stops (ENG-133)
+                        _use_cached_eval_dataset=(
+                            False
+                            if (
+                                hasattr(val_x, "batch_size")
+                                and isinstance(val_x.batch_size, list)
+                            )
+                            else True
+                        ),
                     )
                     val_logs = {"val_" + name: val for name, val in val_logs.items()}
                     epoch_logs.update(val_logs)


### PR DESCRIPTION
Use validation dataset caching only when batch_size is static.

When `batch_size` is dynamic, it changes the length of the dataset, what causes skipping the evaluation step.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
