### PR TITLE
Add run_eagerly parameter

### DIFF
--- a/changelog/12137.misc.md
+++ b/changelog/12137.misc.md
@@ -1,0 +1,3 @@
+Add run_eagerly parameter to control whether to compile DIET based model before running or not
+
+Saves computation time when user prelimienerly knows that model will be executed only for few steps.

--- a/rasa/nlu/classifiers/diet_classifier.py
+++ b/rasa/nlu/classifiers/diet_classifier.py
@@ -105,6 +105,7 @@ from rasa.utils.tensorflow.constants import (
     CONSTRAIN_SIMILARITIES,
     MODEL_CONFIDENCE,
     SOFTMAX,
+    RUN_EAGERLY,
 )
 
 logger = logging.getLogger(__name__)
@@ -282,6 +283,11 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
             # Note that renormalization only makes sense if confidences are generated
             # via `softmax`.
             RENORMALIZE_CONFIDENCES: False,
+            # Determines whether to construct the model graph or not.
+            # This is advantageous when the model is only trained or inferred for
+            # a few steps, as the compilation of the graph tends to take more time than
+            # running it. It is recommended to not adjust the optimization parameter.
+            RUN_EAGERLY: False,
         }
 
     def __init__(
@@ -905,7 +911,10 @@ class DIETClassifier(GraphComponent, IntentClassifier, EntityExtractorMixin):
             # No pre-trained model to load from. Create a new instance of the model.
             self.model = self._instantiate_model_class(model_data)
             self.model.compile(
-                optimizer=tf.keras.optimizers.Adam(self.component_config[LEARNING_RATE])
+                optimizer=tf.keras.optimizers.Adam(
+                    self.component_config[LEARNING_RATE]
+                ),
+                run_eagerly=self.component_config[RUN_EAGERLY],
             )
         else:
             if self.model is None:

--- a/rasa/utils/tensorflow/constants.py
+++ b/rasa/utils/tensorflow/constants.py
@@ -112,3 +112,4 @@ TF_DETERMINISTIC_OPS = "TF_DETERMINISTIC_OPS"
 EPOCH_OVERRIDE = "epoch_override"
 
 USE_GPU = "use_gpu"
+RUN_EAGERLY = "run_eagerly"

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -30,6 +30,7 @@ from rasa.utils.tensorflow.constants import (
     LEARNING_RATE,
     CONSTRAIN_SIMILARITIES,
     MODEL_CONFIDENCE,
+    RUN_EAGERLY,
 )
 from rasa.utils.tensorflow.model_data import (
     RasaModelData,
@@ -427,8 +428,11 @@ class RasaModel(Model):
         # create empty model
         model = cls(*args, **kwargs)
         learning_rate = kwargs.get("config", {}).get(LEARNING_RATE, 0.001)
+        run_eagerly = kwargs.get("config", {}).get(RUN_EAGERLY)
         # need to train on 1 example to build weights of the correct size
-        model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate))
+        model.compile(
+            optimizer=tf.keras.optimizers.Adam(learning_rate), run_eagerly=run_eagerly
+        )
         data_generator = RasaBatchDataGenerator(model_data_example, batch_size=1)
         model.fit(data_generator, verbose=False)
         # load trained weights
@@ -712,7 +716,10 @@ class TransformerRasaModel(RasaModel):
         Args:
             data_example: a data example that is stored with the ML component.
         """
-        self.compile(optimizer=tf.keras.optimizers.Adam(self.config[LEARNING_RATE]))
+        self.compile(
+            optimizer=tf.keras.optimizers.Adam(self.config[LEARNING_RATE]),
+            run_eagerly=self.config[RUN_EAGERLY],
+        )
         label_key = LABEL_KEY if self.config[INTENT_CLASSIFICATION] else None
         label_sub_key = LABEL_SUB_KEY if self.config[INTENT_CLASSIFICATION] else None
 

--- a/tests/nlu/classifiers/test_diet_classifier.py
+++ b/tests/nlu/classifiers/test_diet_classifier.py
@@ -41,6 +41,7 @@ from rasa.utils.tensorflow.constants import (
     INTENT_CLASSIFICATION,
     MODEL_CONFIDENCE,
     HIDDEN_LAYERS_SIZES,
+    RUN_EAGERLY,
 )
 from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier
@@ -449,7 +450,6 @@ async def test_softmax_normalization(
 async def test_margin_loss_is_not_normalized(
     create_train_load_and_process_diet: Callable[..., Message]
 ):
-
     _, parsed_message = create_train_load_and_process_diet(
         {LOSS_TYPE: "margin", RANDOM_SEED: 42, EPOCHS: 1, EVAL_NUM_EPOCHS: 1},
         training_data="data/test/many_intents.yml",
@@ -628,15 +628,13 @@ async def test_doesnt_checkpoint_with_zero_eval_num_examples(
         assert not any(["from_checkpoint" in str(filename) for filename in all_files])
 
 
-@pytest.mark.skip_on_windows
 @pytest.mark.parametrize(
     "classifier_params",
     [
-        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: False},
-        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: True},
+        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: False, RUN_EAGERLY: True},
+        {RANDOM_SEED: 1, EPOCHS: 1, BILOU_FLAG: True, RUN_EAGERLY: True},
     ],
 )
-@pytest.mark.timeout(300, func_only=True)
 async def test_train_persist_load_with_composite_entities(
     classifier_params: Dict[Text, Any],
     create_train_load_and_process_diet: Callable[..., Message],


### PR DESCRIPTION
Add run_eagerly parameter to control whether to compile model before running or not

Saves computation time when user prelimienerly knows that model will be executed only for few steps.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
