### PR TITLE
Fix retrieving a conversation tracker from HTTP API endpoint dependent on query params

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -597,6 +597,16 @@ jobs:
         ports:
           - 5672:5672
 
+      mongodb:
+        image: mongodb/mongodb-community-server:6.0.4-ubuntu2204
+        options: >-
+          --health-cmd "echo 'db.runCommand("ping").ok' | mongosh --quiet"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 27017:27017
+
     steps:
       - name: Checkout git repository 🕝
         if: needs.changes.outputs.backend == 'true'

--- a/changelog/12139.bugfix.md
+++ b/changelog/12139.bugfix.md
@@ -1,0 +1,6 @@
+Fix 2 issues detected with the HTTP API:
+- The `GET /conversations/{conversation_id}/tracker` endpoint was not returning the tracker with all sessions when `include_events` query parameter was set to `ALL`.
+The fix constituted in using `TrackerStore.retrieve_full_tracker` method instead of `TrackerStore.retrieve` method in the function handling the `GET /conversations/{conversation_id}/tracker` endpoint.
+Implemented or updated this method across all tracker store subclasses.
+- The `GET /conversations/{conversation_id}/story` endpoint was not returning all the stories for all sessions when `all_sessions` query parameter was set to `true`.
+The fix constituted in using all events of the tracker to be converted in stories instead of only the `applied_events`.

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -351,7 +351,7 @@ class MessageProcessor:
         tracker.model_id = self.model_metadata.model_id
         return tracker
 
-    async def fetch_full_tracker_and_update_session(
+    async def fetch_full_tracker_with_initial_session(
         self,
         conversation_id: Text,
         output_channel: Optional[OutputChannel] = None,
@@ -374,7 +374,8 @@ class MessageProcessor:
         )
         tracker.model_id = self.model_metadata.model_id
 
-        await self._update_tracker_session(tracker, output_channel, metadata)
+        if not tracker.events:
+            await self._update_tracker_session(tracker, output_channel, metadata)
 
         return tracker
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -362,10 +362,12 @@ class MessageProcessor:
         Args:
             conversation_id: The ID of the conversation for which the history should be
                 retrieved.
+            output_channel: Output channel associated with the incoming user message.
+            metadata: Data sent from client associated with the incoming user message.
 
         Returns:
-            Tracker for the conversation. Creates an empty tracker in case it's a new
-            conversation.
+            Tracker for the conversation. Creates an empty tracker with a new session
+            initialized in case it's a new conversation.
         """
         conversation_id = conversation_id or DEFAULT_SENDER_ID
 

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -351,6 +351,33 @@ class MessageProcessor:
         tracker.model_id = self.model_metadata.model_id
         return tracker
 
+    async def fetch_full_tracker_and_update_session(
+        self,
+        conversation_id: Text,
+        output_channel: Optional[OutputChannel] = None,
+        metadata: Optional[Dict] = None,
+    ) -> DialogueStateTracker:
+        """Get the full tracker for a conversation, including events after a restart.
+
+        Args:
+            conversation_id: The ID of the conversation for which the history should be
+                retrieved.
+
+        Returns:
+            Tracker for the conversation. Creates an empty tracker in case it's a new
+            conversation.
+        """
+        conversation_id = conversation_id or DEFAULT_SENDER_ID
+
+        tracker = await self.tracker_store.get_or_create_full_tracker(
+            conversation_id, False
+        )
+        tracker.model_id = self.model_metadata.model_id
+
+        await self._update_tracker_session(tracker, output_channel, metadata)
+
+        return tracker
+
     async def get_trackers_for_all_conversation_sessions(
         self, conversation_id: Text
     ) -> List[DialogueStateTracker]:

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -429,8 +429,7 @@ class InMemoryTrackerStore(TrackerStore, SerializedTrackerAsText):
             rasa.shared.core.trackers.get_trackers_for_conversation_sessions(tracker)
         )
 
-        if not multiple_tracker_sessions:
-            logger.debug(f"Tracker for conversation ID '{sender_id}' is empty.")
+        if 0 <= len(multiple_tracker_sessions) <= 1:
             return tracker
 
         return multiple_tracker_sessions[-1]

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -402,13 +402,22 @@ class InMemoryTrackerStore(TrackerStore, SerializedTrackerAsText):
     async def retrieve_full_tracker(
         self, sender_id: Text
     ) -> Optional[DialogueStateTracker]:
-        """Returns tracker matching sender_id."""
+        """Returns tracker matching sender_id.
+
+        Args:
+            sender_id: Conversation ID to fetch the tracker for.
+        """
         return await self._retrieve(sender_id, fetch_all_sessions=True)
 
     async def _retrieve(
         self, sender_id: Text, fetch_all_sessions: bool
     ) -> Optional[DialogueStateTracker]:
-        """Returns tracker matching sender_id."""
+        """Returns tracker matching sender_id.
+
+        Args:
+            sender_id: Conversation ID to fetch the tracker for.
+            fetch_all_sessions: Whether to fetch all sessions or only the last one.
+        """
         if sender_id not in self.store:
             logger.debug(f"Could not find tracker for conversation ID '{sender_id}'.")
             return None
@@ -541,7 +550,12 @@ class RedisTrackerStore(TrackerStore, SerializedTrackerAsText):
     async def _retrieve(
         self, sender_id: Text, fetch_all_sessions: bool
     ) -> Optional[DialogueStateTracker]:
-        """Returns tracker matching sender_id."""
+        """Returns tracker matching sender_id.
+
+        Args:
+            sender_id: Conversation ID to fetch the tracker for.
+            fetch_all_sessions: Whether to fetch all sessions or only the last one.
+        """
         stored = self.red.get(self.key_prefix + sender_id)
         if stored is None:
             logger.debug(f"Could not find tracker for conversation ID '{sender_id}'.")
@@ -569,6 +583,13 @@ class RedisTrackerStore(TrackerStore, SerializedTrackerAsText):
     def _merge_trackers(
         prior_tracker: DialogueStateTracker, tracker: DialogueStateTracker
     ) -> DialogueStateTracker:
+        """Merges two trackers.
+
+        Args:
+            prior_tracker: Tracker containing events from the previous conversation
+                sessions.
+            tracker: Tracker containing events from the current conversation session.
+        """
         if not prior_tracker.events:
             return tracker
 
@@ -682,13 +703,22 @@ class DynamoTrackerStore(TrackerStore, SerializedTrackerAsDict):
     async def retrieve_full_tracker(
         self, sender_id: Text
     ) -> Optional[DialogueStateTracker]:
-        """Retrieves tracker for all conversation sessions."""
+        """Retrieves tracker for all conversation sessions.
+
+        Args:
+            sender_id: Conversation ID to fetch the tracker for.
+        """
         return await self._retrieve(sender_id, fetch_all_sessions=True)
 
     async def _retrieve(
         self, sender_id: Text, fetch_all_sessions: bool
     ) -> Optional[DialogueStateTracker]:
-        """Returns tracker matching sender_id."""
+        """Returns tracker matching sender_id.
+
+        Args:
+            sender_id: Conversation ID to fetch the tracker for.
+            fetch_all_sessions: Whether to fetch all sessions or only the last one.
+        """
         dialogues = self.db.query(
             KeyConditionExpression=Key("sender_id").eq(sender_id),
             ScanIndexForward=False,
@@ -1431,7 +1461,11 @@ class FailSafeTrackerStore(TrackerStore):
     async def retrieve_full_tracker(
         self, sender_id: Text
     ) -> Optional[DialogueStateTracker]:
-        """Calls `retrieve_full_tracker` method of primary tracker store."""
+        """Calls `retrieve_full_tracker` method of primary tracker store.
+
+        Args:
+            sender_id: The sender id of the tracker to retrieve.
+        """
         try:
             return await self._tracker_store.retrieve_full_tracker(sender_id)
         except Exception as e:
@@ -1442,6 +1476,9 @@ class FailSafeTrackerStore(TrackerStore):
         """Calls `_on_tracker_store_error` callable attribute if set.
 
         Otherwise, logs the error.
+
+        Args:
+            error: The error that occurred.
         """
         if self._on_tracker_store_error:
             self._on_tracker_store_error(error)

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -691,7 +691,6 @@ class DynamoTrackerStore(TrackerStore, SerializedTrackerAsDict):
         """Returns tracker matching sender_id."""
         dialogues = self.db.query(
             KeyConditionExpression=Key("sender_id").eq(sender_id),
-            Limit=1,
             ScanIndexForward=False,
         )["Items"]
 
@@ -699,11 +698,11 @@ class DynamoTrackerStore(TrackerStore, SerializedTrackerAsDict):
             return None
 
         if fetch_all_sessions:
-            events_with_floats = [
-                core_utils.replace_decimals_with_floats(dialogue["events"])
-                for dialogue in dialogues
-                if dialogue.get("events")
-            ]
+            events_with_floats = []
+            for dialogue in dialogues:
+                if dialogue.get("events"):
+                    events = core_utils.replace_decimals_with_floats(dialogue["events"])
+                    events_with_floats += events
         else:
             events = dialogues[0].get("events", [])
             # `float`s are stored as `Decimal` objects - we need to convert them back

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1289,7 +1289,7 @@ class FailSafeTrackerStore(TrackerStore):
         try:
             return await self._tracker_store.retrieve(sender_id)
         except Exception as e:
-            self.on_tracker_store_error(e)
+            self.on_tracker_store_retrieve_error(e)
             return None
 
     async def keys(self) -> Iterable[Text]:
@@ -1315,8 +1315,23 @@ class FailSafeTrackerStore(TrackerStore):
         try:
             return await self._tracker_store.retrieve_full_tracker(sender_id)
         except Exception as e:
-            self.on_tracker_store_error(e)
+            self.on_tracker_store_retrieve_error(e)
             return None
+
+    def on_tracker_store_retrieve_error(self, error: Exception) -> None:
+        """Calls `_on_tracker_store_error` callable attribute if set.
+
+        Otherwise, logs the error.
+        """
+        if self._on_tracker_store_error:
+            self._on_tracker_store_error(error)
+        else:
+            logger.error(
+                f"Error happened when trying to retrieve conversation tracker from "
+                f"'{self._tracker_store.__class__.__name__}'. Falling back to use "
+                f"the '{InMemoryTrackerStore.__name__}'. Please "
+                f"investigate the following error: {error}."
+            )
 
 
 def _create_from_endpoint_config(

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -723,7 +723,7 @@ def create_app(
         verbosity = event_verbosity_parameter(request, EventVerbosity.AFTER_RESTART)
         until_time = rasa.utils.endpoints.float_arg(request, "until")
 
-        tracker = await app.ctx.agent.processor.fetch_tracker_with_initial_session(
+        tracker = await app.ctx.agent.processor.fetch_full_tracker_and_update_session(
             conversation_id
         )
 

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -723,7 +723,7 @@ def create_app(
         verbosity = event_verbosity_parameter(request, EventVerbosity.AFTER_RESTART)
         until_time = rasa.utils.endpoints.float_arg(request, "until")
 
-        tracker = await app.ctx.agent.processor.fetch_full_tracker_and_update_session(
+        tracker = await app.ctx.agent.processor.fetch_full_tracker_with_initial_session(
             conversation_id
         )
 

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -937,6 +937,7 @@ def get_trackers_for_conversation_sessions(
             evts,
             tracker.slots.values(),
             sender_source=tracker.sender_source,
+            max_event_history=tracker._max_event_history,
         )
         for evts in split_conversations
     ]

--- a/rasa/shared/core/trackers.py
+++ b/rasa/shared/core/trackers.py
@@ -687,7 +687,7 @@ class DialogueStateTracker:
             if include_source
             else self.sender_id
         )
-        return Story.from_events(self.applied_events(), story_name)
+        return Story.from_events(list(self.events), story_name)
 
     def export_stories(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,12 @@ from sanic import Sanic
 from typing import Text, List, Optional, Dict, Any
 from unittest.mock import Mock
 
+from rasa.shared.core.constants import (
+    ACTION_LISTEN_NAME,
+    ACTION_RESTART_NAME,
+    ACTION_SESSION_START_NAME,
+)
+from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.shared.nlu.constants import METADATA_MODEL_ID
 import rasa.shared.utils.io
 from rasa import server
@@ -39,7 +45,13 @@ from rasa.nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
 from rasa.nlu.utils.spacy_utils import SpacyNLP, SpacyModel
 from rasa.shared.constants import LATEST_TRAINING_DATA_FORMAT_VERSION
 from rasa.shared.core.domain import SessionConfig, Domain
-from rasa.shared.core.events import Event, UserUttered
+from rasa.shared.core.events import (
+    ActionExecuted,
+    Event,
+    Restarted,
+    SessionStarted,
+    UserUttered,
+)
 from rasa.core.exporter import Exporter
 
 import rasa.core.run
@@ -872,3 +884,39 @@ def filter_expected_warnings(records: WarningsRecorder) -> WarningsRecorder:
                 records.pop(type(record.message))
 
     return records
+
+
+@pytest.fixture
+def initial_events_including_restart() -> List[Event]:
+    return [
+        ActionExecuted(ACTION_SESSION_START_NAME, timestamp=1),
+        SessionStarted(timestamp=2),
+        ActionExecuted(ACTION_LISTEN_NAME, timestamp=3),
+        UserUttered("hi", timestamp=4),
+        ActionExecuted("utter_greet", timestamp=5),
+        ActionExecuted(ACTION_LISTEN_NAME, timestamp=6),
+        UserUttered("/restart", timestamp=7),
+        Restarted(timestamp=8),
+        ActionExecuted(ACTION_RESTART_NAME, timestamp=9),
+    ]
+
+
+@pytest.fixture
+def events_after_restart() -> List[Event]:
+    return [
+        ActionExecuted(ACTION_SESSION_START_NAME, timestamp=10),
+        SessionStarted(timestamp=11),
+        ActionExecuted(ACTION_LISTEN_NAME, timestamp=12),
+        UserUttered("Let's start again.", timestamp=13),
+    ]
+
+
+@pytest.fixture
+def tracker_with_restarted_event(
+    initial_events_including_restart: List[Event],
+    events_after_restart: List[Event],
+) -> DialogueStateTracker:
+    sender_id = uuid.uuid4().hex
+    events = initial_events_including_restart + events_after_restart
+
+    return DialogueStateTracker.from_events(sender_id=sender_id, evts=events)

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -582,7 +582,7 @@ async def test_update_tracker_session(
     await default_processor.save_tracker(tracker)
 
     # inspect tracker and make sure all events are present
-    tracker = await default_processor.tracker_store.retrieve(sender_id)
+    tracker = await default_processor.tracker_store.retrieve_full_tracker(sender_id)
 
     assert list(tracker.events) == [
         ActionExecuted(ACTION_LISTEN_NAME),
@@ -606,7 +606,7 @@ async def test_update_tracker_session_with_metadata(
     )
     await default_processor.handle_message(message)
 
-    tracker = await default_processor.tracker_store.retrieve(sender_id)
+    tracker = await default_processor.tracker_store.retrieve_full_tracker(sender_id)
     events = list(tracker.events)
 
     assert events[0] == with_model_id(
@@ -699,7 +699,7 @@ async def test_update_tracker_session_with_slots(
     await default_processor.save_tracker(tracker)
 
     # inspect tracker and make sure all events are present
-    tracker = await default_processor.tracker_store.retrieve(sender_id)
+    tracker = await default_processor.tracker_store.retrieve_full_tracker(sender_id)
     events = list(tracker.events)
 
     # the first three events should be up to the user utterance
@@ -852,7 +852,9 @@ async def test_handle_message_with_session_start(
         UserMessage(f"/greet{json.dumps(slot_2)}", default_channel, sender_id)
     )
 
-    tracker = await default_processor.tracker_store.get_or_create_tracker(sender_id)
+    tracker = await default_processor.tracker_store.get_or_create_full_tracker(
+        sender_id
+    )
 
     # make sure the sequence of events is as expected
     expected = with_model_ids(

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1809,6 +1809,10 @@ async def test_processor_fetch_full_tracker_with_initial_session_inexistent_trac
 
     assert isinstance(tracker.events[1], SessionStarted)
 
+    last_recorded_event = tracker.events[2]
+    assert isinstance(last_recorded_event, ActionExecuted)
+    assert last_recorded_event.action_name == ACTION_LISTEN_NAME
+
 
 async def test_processor_fetch_full_tracker_with_initial_session_existing_tracker(
     default_processor: MessageProcessor,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ from http import HTTPStatus
 from multiprocessing import Manager
 from multiprocessing.managers import DictProxy
 from pathlib import Path
-from typing import List, Text, Type, Generator, NoReturn, Dict, Optional
+from typing import List, Text, Tuple, Type, Generator, NoReturn, Dict, Optional
 from unittest.mock import Mock, ANY
 
 from _pytest.tmpdir import TempPathFactory
@@ -55,6 +55,7 @@ from rasa.shared.core.constants import (
 from rasa.shared.core.domain import Domain, SessionConfig
 from rasa.shared.core.events import (
     Event,
+    Restarted,
     UserUttered,
     SlotSet,
     BotUttered,
@@ -2066,3 +2067,121 @@ async def test_append_events_does_not_repeat_session_start(
     )
 
     assert response.json["events"] == session_start_events
+
+
+async def _create_tracker_for_query_params(
+    rasa_app: SanicASGITestClient,
+) -> Tuple[Text, List[Event]]:
+    sender_id = uuid.uuid4().hex
+
+    events_to_store: List[Event] = [
+        UserUttered("hi"),
+        Restarted(),
+        ActionExecuted(ACTION_SESSION_START_NAME),
+        SessionStarted(),
+        ActionExecuted(ACTION_LISTEN_NAME),
+        UserUttered("hi again"),
+    ]
+    serialized_events_to_store = [event.as_dict() for event in events_to_store]
+
+    _, response = await rasa_app.post(
+        f"/conversations/{sender_id}/tracker/events", json=serialized_events_to_store
+    )
+    assert response.status == 200
+
+    return sender_id, events_to_store
+
+
+async def test_get_tracker_with_query_param_include_events_all(
+    rasa_app: SanicASGITestClient,
+) -> None:
+    model_id = rasa_app.sanic_app.ctx.agent.model_id
+    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+
+    _, response = await rasa_app.get(
+        f"/conversations/{sender_id}/tracker?include_events=ALL"
+    )
+    assert response.status == 200
+
+    tracker = response.json
+    assert tracker["sender_id"] == sender_id
+
+    serialized_actual_events = tracker["events"]
+    actual_events = [Event.from_parameters(event) for event in serialized_actual_events]
+    expected_events = with_model_ids(session_start_sequence + events_to_store, model_id)
+
+    assert actual_events == expected_events
+
+
+async def test_get_tracker_with_query_param_include_events_after_restart(
+    rasa_app: SanicASGITestClient,
+) -> None:
+    model_id = rasa_app.sanic_app.ctx.agent.model_id
+    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+
+    _, response = await rasa_app.get(
+        f"/conversations/{sender_id}/tracker?include_events=AFTER_RESTART"
+    )
+    assert response.status == 200
+
+    tracker = response.json
+    assert tracker["sender_id"] == sender_id
+
+    serialized_actual_events = tracker["events"]
+    actual_events = [Event.from_parameters(event) for event in serialized_actual_events]
+
+    restarted_event = [
+        event for event in events_to_store if isinstance(event, Restarted)
+    ][0]
+    truncated_events = events_to_store[events_to_store.index(restarted_event) + 1 :]
+    expected_events = with_model_ids(truncated_events, model_id)
+
+    assert actual_events == expected_events
+
+
+async def test_get_tracker_with_query_param_include_events_applied(
+    rasa_app: SanicASGITestClient,
+) -> None:
+    model_id = rasa_app.sanic_app.ctx.agent.model_id
+    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+
+    _, response = await rasa_app.get(
+        f"/conversations/{sender_id}/tracker?include_events=APPLIED"
+    )
+    assert response.status == 200
+
+    tracker = response.json
+    assert tracker["sender_id"] == sender_id
+
+    serialized_actual_events = tracker["events"]
+    actual_events = [Event.from_parameters(event) for event in serialized_actual_events]
+
+    restarted_event = [
+        event for event in events_to_store if isinstance(event, Restarted)
+    ][0]
+    truncated_events = events_to_store[events_to_store.index(restarted_event) + 1 :]
+    session_started = [
+        event for event in truncated_events if isinstance(event, SessionStarted)
+    ][0]
+    truncated_events = truncated_events[truncated_events.index(session_started) + 1 :]
+
+    expected_events = with_model_ids(truncated_events, model_id)
+
+    assert actual_events == expected_events
+
+
+async def test_get_tracker_with_query_param_include_events_none(
+    rasa_app: SanicASGITestClient,
+) -> None:
+    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+
+    _, response = await rasa_app.get(
+        f"/conversations/{sender_id}/tracker?include_events=NONE"
+    )
+    assert response.status == 200
+
+    tracker = response.json
+    assert tracker["sender_id"] == sender_id
+
+    serialized_actual_events = tracker["events"]
+    assert serialized_actual_events is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import textwrap
 import time
 import urllib.parse
 import uuid
@@ -47,6 +48,7 @@ import rasa.nlu.test
 from rasa.nlu.test import CVEvaluationResult
 from rasa.shared.core import events
 from rasa.shared.core.constants import (
+    ACTION_RESTART_NAME,
     ACTION_SESSION_START_NAME,
     ACTION_LISTEN_NAME,
     REQUESTED_SLOT,
@@ -2071,17 +2073,44 @@ async def test_append_events_does_not_repeat_session_start(
 
 async def _create_tracker_for_query_params(
     rasa_app: SanicASGITestClient,
+    model_id: Text,
 ) -> Tuple[Text, List[Event]]:
     sender_id = uuid.uuid4().hex
 
-    events_to_store: List[Event] = [
-        UserUttered("hi"),
-        Restarted(),
-        ActionExecuted(ACTION_SESSION_START_NAME),
-        SessionStarted(),
-        ActionExecuted(ACTION_LISTEN_NAME),
-        UserUttered("hi again"),
-    ]
+    events_to_store: List[Event] = (
+        session_start_sequence
+        + [
+            UserUttered(
+                "hi",
+                parse_data={
+                    "intent": {"name": "greet"},
+                    "metadata": {"model_id": model_id},
+                },
+            ),
+            ActionExecuted("utter_greet"),
+            BotUttered("hey there"),
+            ActionExecuted(ACTION_LISTEN_NAME),
+            UserUttered(
+                "/restart",
+                parse_data={
+                    "intent": {"name": "restart"},
+                    "metadata": {"model_id": model_id},
+                },
+            ),
+            ActionExecuted(ACTION_RESTART_NAME),
+            Restarted(),
+        ]
+        + session_start_sequence
+        + [
+            UserUttered(
+                "hi again",
+                parse_data={
+                    "intent": {"name": "greet"},
+                    "metadata": {"model_id": model_id},
+                },
+            ),
+        ]
+    )
     serialized_events_to_store = [event.as_dict() for event in events_to_store]
 
     _, response = await rasa_app.post(
@@ -2096,7 +2125,9 @@ async def test_get_tracker_with_query_param_include_events_all(
     rasa_app: SanicASGITestClient,
 ) -> None:
     model_id = rasa_app.sanic_app.ctx.agent.model_id
-    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+    sender_id, events_to_store = await _create_tracker_for_query_params(
+        rasa_app, model_id
+    )
 
     _, response = await rasa_app.get(
         f"/conversations/{sender_id}/tracker?include_events=ALL"
@@ -2107,17 +2138,20 @@ async def test_get_tracker_with_query_param_include_events_all(
     assert tracker["sender_id"] == sender_id
 
     serialized_actual_events = tracker["events"]
-    actual_events = [Event.from_parameters(event) for event in serialized_actual_events]
-    expected_events = with_model_ids(session_start_sequence + events_to_store, model_id)
 
-    assert actual_events == expected_events
+    expected_events = with_model_ids(events_to_store, model_id)
+    serialized_expected_events = [event.as_dict() for event in expected_events]
+
+    assert serialized_actual_events == serialized_expected_events
 
 
 async def test_get_tracker_with_query_param_include_events_after_restart(
     rasa_app: SanicASGITestClient,
 ) -> None:
     model_id = rasa_app.sanic_app.ctx.agent.model_id
-    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+    sender_id, events_to_store = await _create_tracker_for_query_params(
+        rasa_app, model_id
+    )
 
     _, response = await rasa_app.get(
         f"/conversations/{sender_id}/tracker?include_events=AFTER_RESTART"
@@ -2128,22 +2162,24 @@ async def test_get_tracker_with_query_param_include_events_after_restart(
     assert tracker["sender_id"] == sender_id
 
     serialized_actual_events = tracker["events"]
-    actual_events = [Event.from_parameters(event) for event in serialized_actual_events]
 
     restarted_event = [
         event for event in events_to_store if isinstance(event, Restarted)
     ][0]
     truncated_events = events_to_store[events_to_store.index(restarted_event) + 1 :]
     expected_events = with_model_ids(truncated_events, model_id)
+    serialized_expected_events = [e.as_dict() for e in expected_events]
 
-    assert actual_events == expected_events
+    assert serialized_actual_events == serialized_expected_events
 
 
 async def test_get_tracker_with_query_param_include_events_applied(
     rasa_app: SanicASGITestClient,
 ) -> None:
     model_id = rasa_app.sanic_app.ctx.agent.model_id
-    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+    sender_id, events_to_store = await _create_tracker_for_query_params(
+        rasa_app, model_id
+    )
 
     _, response = await rasa_app.get(
         f"/conversations/{sender_id}/tracker?include_events=APPLIED"
@@ -2154,7 +2190,6 @@ async def test_get_tracker_with_query_param_include_events_applied(
     assert tracker["sender_id"] == sender_id
 
     serialized_actual_events = tracker["events"]
-    actual_events = [Event.from_parameters(event) for event in serialized_actual_events]
 
     restarted_event = [
         event for event in events_to_store if isinstance(event, Restarted)
@@ -2166,14 +2201,18 @@ async def test_get_tracker_with_query_param_include_events_applied(
     truncated_events = truncated_events[truncated_events.index(session_started) + 1 :]
 
     expected_events = with_model_ids(truncated_events, model_id)
+    serialized_expected_events = [e.as_dict() for e in expected_events]
 
-    assert actual_events == expected_events
+    assert serialized_actual_events == serialized_expected_events
 
 
 async def test_get_tracker_with_query_param_include_events_none(
     rasa_app: SanicASGITestClient,
 ) -> None:
-    sender_id, events_to_store = await _create_tracker_for_query_params(rasa_app)
+    model_id = rasa_app.sanic_app.ctx.agent.model_id
+    sender_id, events_to_store = await _create_tracker_for_query_params(
+        rasa_app, model_id
+    )
 
     _, response = await rasa_app.get(
         f"/conversations/{sender_id}/tracker?include_events=NONE"
@@ -2185,3 +2224,69 @@ async def test_get_tracker_with_query_param_include_events_none(
 
     serialized_actual_events = tracker["events"]
     assert serialized_actual_events is None
+
+
+async def test_retrieve_story_with_query_param_all_sessions_true(
+    rasa_app: SanicASGITestClient,
+) -> None:
+    model_id = rasa_app.sanic_app.ctx.agent.model_id
+    sender_id, events_to_store = await _create_tracker_for_query_params(
+        rasa_app, model_id
+    )
+
+    _, response = await rasa_app.get(
+        f"/conversations/{sender_id}/story?all_sessions=true"
+    )
+    assert response.status == 200
+
+    story_content = response.body.decode("utf-8")
+
+    expected_first_story = textwrap.dedent(
+        f"""
+    - story: {sender_id}, story 1
+      steps:
+      - intent: greet
+        user: |-
+          hi
+      - action: utter_greet
+      - intent: restart
+        user: |-
+          /restart
+      - action: action_restart"""
+    )
+    assert expected_first_story in story_content
+
+    expected_second_story = textwrap.dedent(
+        f"""
+    - story: {sender_id}, story 2
+      steps:
+      - intent: greet
+        user: |-
+          hi again"""
+    )
+    assert expected_second_story in story_content
+
+
+async def test_retrieve_story_with_query_param_all_sessions_false(
+    rasa_app: SanicASGITestClient,
+) -> None:
+    model_id = rasa_app.sanic_app.ctx.agent.model_id
+    sender_id, events_to_store = await _create_tracker_for_query_params(
+        rasa_app, model_id
+    )
+
+    _, response = await rasa_app.get(
+        f"/conversations/{sender_id}/story?all_sessions=false"
+    )
+    assert response.status == 200
+
+    story_content = response.body.decode("utf-8")
+    expected_story = textwrap.dedent(
+        f"""
+    - story: {sender_id}
+      steps:
+      - intent: greet
+        user: |-
+          hi again"""
+    )
+    assert expected_story in story_content

--- a/tests_deployment/docker-compose.integration.yml
+++ b/tests_deployment/docker-compose.integration.yml
@@ -70,3 +70,8 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
     volumes:
       - ${PWD}/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
+
+  mongodb:
+    image: mongodb/mongodb-community-server:6.0.4-ubuntu2204
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-694](https://rasahq.atlassian.net/browse/ATO-694) ticket in 2 parts:

1. The cause for not retrieving full tracker from GET endpoint `conversations/{conversation_id}/tracker?include_events=ALL` was two-fold: 

-  The endpoint was retrieving only the latest session of the tracker
-  Updated the implementation  using `TrackerStore.retrieve_full_tracker` method and therefore discovered that `FailSafeTrackerStore` was missing the implementation for this method.  
- Added the implementation of this method in this interface as well as in all other TrackerStore interfaces missing this implementation (e.g. `InMemoryTrackerStore`, `RedisTrackerStore`, `DynamoTrackerStore`).

2. Retrieving empty stories for a tracker which included a `Restarted` event was fixed by using all tracker events in the output of a story, not only the result of `self.applied_events()` (this results in empty list for any events before a `Restarted` event).

- In addition, fixed tracker saving mechanism to `RedisTrackerStore` (current mechanism was overwriting past tracker with new sessions).
- Tested locally with Docker with Redis, DynamoDB and MongoDB (all good! endpoints work as expected with the different query params.)
- Tested locally with sqlite (all good)

TODO: 
- [x] investigate why `retrieve_full_tracker` implementation for Redis is broken when testing locally the fixed endpoints.
- [x] add integration tests for redis, mongodb, postgres
- [x] open ticket to add support for required credentials for DynamoDB

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-694]: https://rasahq.atlassian.net/browse/ATO-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ