### PR TITLE
add a self-reference in synonyms map

### DIFF
--- a/changelog/12144.improvement.md
+++ b/changelog/12144.improvement.md
@@ -1,0 +1,1 @@
+Add a self-reference of the synonym in the EntitySynonymMapper to handle entities extracted in a casing different to synonym case. (For example if a synonym `austria` is added, entities extracted with any alternate casing of the synonym will also be mapped to `austria`). It addresses ATO-616

--- a/docs/docs/generating-nlu-data.mdx
+++ b/docs/docs/generating-nlu-data.mdx
@@ -157,6 +157,9 @@ It would be a good idea to map `truck`, `car`, and `batmobile` to the normalized
 `auto` so that the processing logic will only need to account for a narrow set of
 possibilities (see [synonyms](./training-data-format.mdx#synonyms)).
 
+Synonyms can also be used to standardize the extracted entites. A synonym for `iPhone` can 
+map `iphone` or `IPHONE` to the synonym without adding these options in the synonym examples.
+
 ## Handling Edge Cases
 
 ### Misspellings

--- a/docs/docs/generating-nlu-data.mdx
+++ b/docs/docs/generating-nlu-data.mdx
@@ -157,7 +157,7 @@ It would be a good idea to map `truck`, `car`, and `batmobile` to the normalized
 `auto` so that the processing logic will only need to account for a narrow set of
 possibilities (see [synonyms](./training-data-format.mdx#synonyms)).
 
-Synonyms can also be used to standardize the extracted entites. A synonym for `iPhone` can 
+Synonyms can also be used to standardize the extracted entities. A synonym for `iPhone` can 
 map `iphone` or `IPHONE` to the synonym without adding these options in the synonym examples.
 
 ## Handling Edge Cases

--- a/docs/docs/nlu-training-data.mdx
+++ b/docs/docs/nlu-training-data.mdx
@@ -36,7 +36,7 @@ See the [training data format](./training-data-format.mdx) for details on how to
 
 ## Synonyms
 
-Synonyms map extracted entities to a value other than the literal text extracted. 
+Synonyms map extracted entities to a value other than the literal text extracted in a case-insensitive manner. 
 You can use synonyms when there are multiple ways users refer to the same
 thing. Think of the end goal of extracting an entity, and figure out from there which values should be considered equivalent. 
 
@@ -55,7 +55,7 @@ nlu:
 ```
 
 Then, if either of these phrases is extracted as an entity, it will be
-mapped to the value `credit`.
+mapped to the value `credit`. Any alternate casing of these phrases (E.g. `CREDIT`, `credit ACCOUNT`, etc) will also be mapped to the synonym.
 
 :::note Provide Training Examples
 Synonym mapping only happens **after** entities have been extracted.

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -165,3 +165,9 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                     )
 
                 self.synonyms[original] = replacement
+
+            # add a self-reference to handle entities extracted in alternate cases
+            # i.e. for a synonym Austria, entities extracted as AUSTRIA, austria, ausTRIA, etc
+            # should also have the value of `Austria`
+            if replacement not in self.synonyms:
+                self.synonyms[replacement.lower()] = replacement

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -167,7 +167,7 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 self.synonyms[original] = replacement
 
             # add a self-reference to handle entities extracted in alternate cases
-            # i.e. for a synonym Austria, 
+            # i.e. for a synonym Austria,
             # entities extracted as AUSTRIA, austria, ausTRIA, etc
             # should also have the value of `Austria`
             if replacement not in self.synonyms:

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -150,11 +150,11 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
         Adds entities to the synonym lookup table.
         Lowercase is used as keys to make the lookup case-insensitive.
         """
-        if entity is not None:
+        if synonym is not None:
             if entity != synonym:
                 entity_lowercase = entity.lower()
-                if (entity_lowercase in self.synonyms and 
-                        self.synonyms[entity_lowercase] != synonym):
+                if (entity_lowercase in self.synonyms
+                        and self.synonyms[entity_lowercase] != synonym):
                     rasa.shared.utils.io.raise_warning(
                         f"Found conflicting synonym definitions "
                         f"for {repr(entity_lowercase)}. Overwriting target "

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -151,6 +151,8 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
         Lowercase is used as keys to make the lookup case-insensitive.
         """
         if synonym is not None:
+            entity = str(entity)
+            synonym = str(synonym)
             if entity != synonym:
                 entity_lowercase = entity.lower()
                 if (entity_lowercase in self.synonyms

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -93,7 +93,6 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
         return messages
 
     def _persist(self) -> None:
-
         if self.synonyms:
             with self._model_storage.write_to(self._resource) as storage:
                 entity_synonyms_file = storage / EntitySynonymMapper.SYNONYM_FILENAME
@@ -143,9 +142,7 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 entity["value"] = self.synonyms[entity_value.lower()]
                 self.add_processor_name(entity)
 
-    def _add_entities_if_synonyms(
-        self, entity: Text, synonym: Optional[Text]
-    ) -> None:
+    def _add_entities_if_synonyms(self, entity: Text, synonym: Optional[Text]) -> None:
         """
         Adds entities to the synonym lookup table.
         Lowercase is used as keys to make the lookup case-insensitive.
@@ -155,8 +152,10 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
             synonym = str(synonym)
             if entity != synonym:
                 entity_lowercase = entity.lower()
-                if (entity_lowercase in self.synonyms
-                        and self.synonyms[entity_lowercase] != synonym):
+                if (
+                    entity_lowercase in self.synonyms
+                    and self.synonyms[entity_lowercase] != synonym
+                ):
                     rasa.shared.utils.io.raise_warning(
                         f"Found conflicting synonym definitions "
                         f"for {repr(entity_lowercase)}. Overwriting target "

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -170,5 +170,5 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
             # i.e. for a synonym Austria,
             # entities extracted as AUSTRIA, austria, ausTRIA, etc
             # should also have the value of `Austria`
-            if replacement not in self.synonyms:
+            if replacement.lower() not in self.synonyms:
                 self.synonyms[replacement.lower()] = replacement

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -153,7 +153,8 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
         if entity is not None:
             if entity != synonym:
                 entity_lowercase = entity.lower()
-                if entity_lowercase in self.synonyms and self.synonyms[entity_lowercase] != synonym:
+                if (entity_lowercase in self.synonyms and 
+                        self.synonyms[entity_lowercase] != synonym):
                     rasa.shared.utils.io.raise_warning(
                         f"Found conflicting synonym definitions "
                         f"for {repr(entity_lowercase)}. Overwriting target "

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -144,7 +144,7 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
 
     def _add_entities_if_synonyms(self, entity: Text, synonym: Optional[Text]) -> None:
         """Adds entities to the synonym lookup table.
-        
+
         Lowercase is used as keys to make the lookup case-insensitive.
         """
         if synonym is not None:

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -143,8 +143,8 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 self.add_processor_name(entity)
 
     def _add_entities_if_synonyms(self, entity: Text, synonym: Optional[Text]) -> None:
-        """
-        Adds entities to the synonym lookup table.
+        """Adds entities to the synonym lookup table.
+        
         Lowercase is used as keys to make the lookup case-insensitive.
         """
         if synonym is not None:

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -144,31 +144,33 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 self.add_processor_name(entity)
 
     def _add_entities_if_synonyms(
-        self, entity_a: Text, entity_b: Optional[Text]
+        self, entity: Text, synonym: Optional[Text]
     ) -> None:
-        if entity_b is not None:
-            original = str(entity_a)
-            replacement = str(entity_b)
-
-            if original != replacement:
-                original = original.lower()
-                if original in self.synonyms and self.synonyms[original] != replacement:
+        """
+        Adds entities to the synonym lookup table.
+        Lowercase is used as keys to make the lookup case-insensitive.
+        """
+        if entity is not None:
+            if entity != synonym:
+                entity_lowercase = entity.lower()
+                if entity_lowercase in self.synonyms and self.synonyms[entity_lowercase] != synonym:
                     rasa.shared.utils.io.raise_warning(
                         f"Found conflicting synonym definitions "
-                        f"for {repr(original)}. Overwriting target "
-                        f"{repr(self.synonyms[original])} with "
-                        f"{repr(replacement)}. "
+                        f"for {repr(entity_lowercase)}. Overwriting target "
+                        f"{repr(self.synonyms[entity_lowercase])} with "
+                        f"{repr(synonym)}. "
                         f"Check your training data and remove "
                         f"conflicting synonym definitions to "
                         f"prevent this from happening.",
                         docs=DOCS_URL_TRAINING_DATA + "#synonyms",
                     )
 
-                self.synonyms[original] = replacement
+                self.synonyms[entity_lowercase] = synonym
 
             # add a self-reference to handle entities extracted in alternate cases
             # i.e. for a synonym Austria,
             # entities extracted as AUSTRIA, austria, ausTRIA, etc
             # should also have the value of `Austria`
-            if replacement.lower() not in self.synonyms:
-                self.synonyms[replacement.lower()] = replacement
+            synonym_lowercase = synonym.lower()
+            if synonym_lowercase not in self.synonyms:
+                self.synonyms[synonym_lowercase] = synonym

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -167,7 +167,8 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 self.synonyms[original] = replacement
 
             # add a self-reference to handle entities extracted in alternate cases
-            # i.e. for a synonym Austria, entities extracted as AUSTRIA, austria, ausTRIA, etc
+            # i.e. for a synonym Austria, 
+            # entities extracted as AUSTRIA, austria, ausTRIA, etc
             # should also have the value of `Austria`
             if replacement not in self.synonyms:
                 self.synonyms[replacement.lower()] = replacement

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -141,4 +141,5 @@ def test_synonym_alternate_case(
     assert entities[1]["value"] == "austria"
     assert entities[2]["value"] == "austria"
     assert entities[3]["value"] == "austria"
-    assert entities[4]["value"] != "austria"
+    assert entities[4]["value"] == "austria"
+    assert entities[5]["value"] != "austria"

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -103,7 +103,7 @@ def test_synonym_alternate_case(
         Message(
             data={
                 TEXT: "What's the weather in austria?",
-                "intent": "restaurant_search",
+                "intent": "whats_weather",
                 "entities": [
                     {"start": 22, "end": 29, "value": "austria", "entity": "GPE"}
                 ],
@@ -112,7 +112,7 @@ def test_synonym_alternate_case(
         Message(
             data={
                 TEXT: "weather vienna?",
-                "intent": "restaurant_search",
+                "intent": "whats_weather",
                 "entities": [
                     {"start": 8, "end": 14, "value": "austria", "entity": "GPE"}
                 ],

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -90,6 +90,7 @@ def test_synonym_mapper_with_ints(
 
     assert message.get(ENTITIES) == entities
 
+
 def test_synonym_alternate_case(
     default_model_storage: ModelStorage, default_execution_context: ExecutionContext
 ):
@@ -135,7 +136,7 @@ def test_synonym_alternate_case(
 
     # synonym key for self is present
     assert mapper.synonyms.get("austria") == "austria"
-    
+
     # all replacement values are correct
     assert entities[0]["value"] == "austria"
     assert entities[1]["value"] == "austria"

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -15,6 +15,7 @@ def test_entity_synonyms(
         {"entity": "test", "value": "chines", "start": 0, "end": 6},
         {"entity": "test", "value": "chinese", "start": 0, "end": 6},
         {"entity": "test", "value": "china", "start": 0, "end": 6},
+        {"entity": "test", "value": "nyc", "start": 0, "end": 6},
     ]
     ent_synonyms = {"chines": "chinese", "NYC": "New York City"}
 
@@ -23,10 +24,11 @@ def test_entity_synonyms(
     )
     mapper.replace_synonyms(entities)
 
-    assert len(entities) == 3
+    assert len(entities) == 4
     assert entities[0]["value"] == "chinese"
     assert entities[1]["value"] == "chinese"
     assert entities[2]["value"] == "china"
+    assert entities[3]["value"] == "New York City"
 
 
 def test_unintentional_synonyms_capitalized(

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -130,17 +130,18 @@ def test_synonym_alternate_case(
 
     mapper.train(TrainingData(training_examples=examples))
     mapper.replace_synonyms(entities)
+    expected_synonym_value = "austria"
 
     # synonym key for example value is present
-    assert mapper.synonyms.get("vienna") == "austria"
+    assert mapper.synonyms.get("vienna") == expected_synonym_value
 
     # synonym key for self is present
-    assert mapper.synonyms.get("austria") == "austria"
+    assert mapper.synonyms.get("austria") == expected_synonym_value
 
     # all replacement values are correct
-    assert entities[0]["value"] == "austria"
-    assert entities[1]["value"] == "austria"
-    assert entities[2]["value"] == "austria"
-    assert entities[3]["value"] == "austria"
-    assert entities[4]["value"] == "austria"
-    assert entities[5]["value"] != "austria"
+    assert entities[0]["value"] == expected_synonym_value
+    assert entities[1]["value"] == expected_synonym_value
+    assert entities[2]["value"] == expected_synonym_value
+    assert entities[3]["value"] == expected_synonym_value
+    assert entities[4]["value"] == expected_synonym_value
+    assert entities[5]["value"] != expected_synonym_value

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -60,7 +60,7 @@ def test_unintentional_synonyms_capitalized(
 
     mapper.train(TrainingData(training_examples=examples))
 
-    assert mapper.synonyms.get("mexican") is None
+    assert mapper.synonyms.get("mexican") == "Mexican"
     assert mapper.synonyms.get("tacos") == "Mexican"
 
 

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -124,7 +124,7 @@ def test_synonym_alternate_case(
         {"entity": "test", "value": "Austria", "start": 0, "end": 7},
         {"entity": "test", "value": "AUSTRIA", "start": 0, "end": 7},
         {"entity": "test", "value": "ausTRIA", "start": 0, "end": 7},
-        {"entity": "test", "value": "ausTRIA", "start": 0, "end": 7},
+        {"entity": "test", "value": "Vienna", "start": 0, "end": 7},
         {"entity": "test", "value": "brazil", "start": 0, "end": 7},
     ]
 


### PR DESCRIPTION
**Proposed changes**:
- Add a self-reference of the synonym in the EntitySynonymMapper to handle entities extracted in a casing different to synonym case. (For example if a synonym `austria` is added, entities extracted with any alternate casing of the synonym will also be mapped to `austria`). It addresses [ATO-616](https://rasahq.atlassian.net/browse/ATO-616)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-616]: https://rasahq.atlassian.net/browse/ATO-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ