### PR TITLE
Remove workflow conditions to redeploy 3.5.0 pypi

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -973,7 +973,6 @@ jobs:
 
     # deploy will only be run when there is a tag available
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'RasaHQ/rasa'
-    needs: [quality, test, wait_for_docs_tests, docker] # only run after all other stages succeeded
 
     steps:
       - name: Checkout git repository 🕝


### PR DESCRIPTION
**Proposed changes**:
- Deploying of 3.5.0 to pypi failed because the workflow had dependencies on the test runs and quality checks that were recently skipped during tag push.
- Removed condition to to redeploy tag to pypi
- Docker images were successfully published, so docker build step will fail so also had to remove any dependencies to the step: docker.
