### PR TITLE
Remove tensorflow ops force being deterministic

### DIFF
--- a/changelog/12174.bugfix.md
+++ b/changelog/12174.bugfix.md
@@ -1,0 +1,3 @@
+Fixes training `DIETCLassifier` on the GPU.
+
+A deterministic GPU implementation of SparseTensorDenseMatmulOp is not currently available

--- a/rasa/utils/tensorflow/models.py
+++ b/rasa/utils/tensorflow/models.py
@@ -105,9 +105,6 @@ class RasaModel(Model):
         tf.random.set_seed(self.random_seed)
         tf.experimental.numpy.random.seed(self.random_seed)
         tf.keras.utils.set_random_seed(self.random_seed)
-        # When running on the CuDNN backend, two further options must be set
-        os.environ["TF_CUDNN_DETERMINISTIC"] = "1"
-        os.environ["TF_DETERMINISTIC_OPS"] = "1"
         # Set a fixed value for the hash seed
         os.environ["PYTHONHASHSEED"] = str(self.random_seed)
 


### PR DESCRIPTION
**Proposed changes**:
Training `DIETClassifier` fails on the GPU with an error
```
A deterministic GPU implementation of SparseTensorDenseMatmulOp is not currently available
```

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
