### PR TITLE
Port ATO-616 for 3.5.x

### DIFF
--- a/changelog/12144.improvement.md
+++ b/changelog/12144.improvement.md
@@ -1,0 +1,1 @@
+Add a self-reference of the synonym in the EntitySynonymMapper to handle entities extracted in a casing different to synonym case. (For example if a synonym `austria` is added, entities extracted with any alternate casing of the synonym will also be mapped to `austria`). It addresses ATO-616

--- a/changelog/12144.improvement.md
+++ b/changelog/12144.improvement.md
@@ -1,1 +1,0 @@
-Add a self-reference of the synonym in the EntitySynonymMapper to handle entities extracted in a casing different to synonym case. (For example if a synonym `austria` is added, entities extracted with any alternate casing of the synonym will also be mapped to `austria`). It addresses ATO-616

--- a/docs/docs/generating-nlu-data.mdx
+++ b/docs/docs/generating-nlu-data.mdx
@@ -157,9 +157,6 @@ It would be a good idea to map `truck`, `car`, and `batmobile` to the normalized
 `auto` so that the processing logic will only need to account for a narrow set of
 possibilities (see [synonyms](./training-data-format.mdx#synonyms)).
 
-Synonyms can also be used to standardize the extracted entities. A synonym for `iPhone` can 
-map `iphone` or `IPHONE` to the synonym without adding these options in the synonym examples.
-
 ## Handling Edge Cases
 
 ### Misspellings

--- a/docs/docs/generating-nlu-data.mdx
+++ b/docs/docs/generating-nlu-data.mdx
@@ -157,6 +157,9 @@ It would be a good idea to map `truck`, `car`, and `batmobile` to the normalized
 `auto` so that the processing logic will only need to account for a narrow set of
 possibilities (see [synonyms](./training-data-format.mdx#synonyms)).
 
+Synonyms can also be used to standardize the extracted entities. A synonym for `iPhone` can 
+map `iphone` or `IPHONE` to the synonym without adding these options in the synonym examples.
+
 ## Handling Edge Cases
 
 ### Misspellings

--- a/docs/docs/nlu-training-data.mdx
+++ b/docs/docs/nlu-training-data.mdx
@@ -36,7 +36,7 @@ See the [training data format](./training-data-format.mdx) for details on how to
 
 ## Synonyms
 
-Synonyms map extracted entities to a value other than the literal text extracted. 
+Synonyms map extracted entities to a value other than the literal text extracted in a case-insensitive manner. 
 You can use synonyms when there are multiple ways users refer to the same
 thing. Think of the end goal of extracting an entity, and figure out from there which values should be considered equivalent. 
 
@@ -55,7 +55,7 @@ nlu:
 ```
 
 Then, if either of these phrases is extracted as an entity, it will be
-mapped to the value `credit`.
+mapped to the value `credit`. Any alternate casing of these phrases (e.g. `CREDIT`, `credit ACCOUNT`) will also be mapped to the synonym.
 
 :::note Provide Training Examples
 Synonym mapping only happens **after** entities have been extracted.

--- a/docs/docs/nlu-training-data.mdx
+++ b/docs/docs/nlu-training-data.mdx
@@ -36,7 +36,7 @@ See the [training data format](./training-data-format.mdx) for details on how to
 
 ## Synonyms
 
-Synonyms map extracted entities to a value other than the literal text extracted in a case-insensitive manner. 
+Synonyms map extracted entities to a value other than the literal text extracted. 
 You can use synonyms when there are multiple ways users refer to the same
 thing. Think of the end goal of extracting an entity, and figure out from there which values should be considered equivalent. 
 
@@ -55,7 +55,7 @@ nlu:
 ```
 
 Then, if either of these phrases is extracted as an entity, it will be
-mapped to the value `credit`. Any alternate casing of these phrases (e.g. `CREDIT`, `credit ACCOUNT`) will also be mapped to the synonym.
+mapped to the value `credit`.
 
 :::note Provide Training Examples
 Synonym mapping only happens **after** entities have been extracted.

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -93,6 +93,7 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
         return messages
 
     def _persist(self) -> None:
+
         if self.synonyms:
             with self._model_storage.write_to(self._resource) as storage:
                 entity_synonyms_file = storage / EntitySynonymMapper.SYNONYM_FILENAME
@@ -142,37 +143,25 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 entity["value"] = self.synonyms[entity_value.lower()]
                 self.add_processor_name(entity)
 
-    def _add_entities_if_synonyms(self, entity: Text, synonym: Optional[Text]) -> None:
-        """Adds entities to the synonym lookup table.
+    def _add_entities_if_synonyms(
+        self, entity_a: Text, entity_b: Optional[Text]
+    ) -> None:
+        if entity_b is not None:
+            original = str(entity_a)
+            replacement = str(entity_b)
 
-        Lowercase is used as keys to make the lookup case-insensitive.
-        """
-        if synonym is not None:
-            entity = str(entity)
-            synonym = str(synonym)
-            if entity != synonym:
-                entity_lowercase = entity.lower()
-                if (
-                    entity_lowercase in self.synonyms
-                    and self.synonyms[entity_lowercase] != synonym
-                ):
+            if original != replacement:
+                original = original.lower()
+                if original in self.synonyms and self.synonyms[original] != replacement:
                     rasa.shared.utils.io.raise_warning(
                         f"Found conflicting synonym definitions "
-                        f"for {repr(entity_lowercase)}. Overwriting target "
-                        f"{repr(self.synonyms[entity_lowercase])} with "
-                        f"{repr(synonym)}. "
+                        f"for {repr(original)}. Overwriting target "
+                        f"{repr(self.synonyms[original])} with "
+                        f"{repr(replacement)}. "
                         f"Check your training data and remove "
                         f"conflicting synonym definitions to "
                         f"prevent this from happening.",
                         docs=DOCS_URL_TRAINING_DATA + "#synonyms",
                     )
 
-                self.synonyms[entity_lowercase] = synonym
-
-            # add a self-reference to handle entities extracted in alternate cases
-            # i.e. for a synonym Austria,
-            # entities extracted as AUSTRIA, austria, ausTRIA, etc
-            # should also have the value of `Austria`
-            synonym_lowercase = synonym.lower()
-            if synonym_lowercase not in self.synonyms:
-                self.synonyms[synonym_lowercase] = synonym
+                self.synonyms[original] = replacement

--- a/rasa/nlu/extractors/entity_synonyms.py
+++ b/rasa/nlu/extractors/entity_synonyms.py
@@ -93,7 +93,6 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
         return messages
 
     def _persist(self) -> None:
-
         if self.synonyms:
             with self._model_storage.write_to(self._resource) as storage:
                 entity_synonyms_file = storage / EntitySynonymMapper.SYNONYM_FILENAME
@@ -143,25 +142,37 @@ class EntitySynonymMapper(GraphComponent, EntityExtractorMixin):
                 entity["value"] = self.synonyms[entity_value.lower()]
                 self.add_processor_name(entity)
 
-    def _add_entities_if_synonyms(
-        self, entity_a: Text, entity_b: Optional[Text]
-    ) -> None:
-        if entity_b is not None:
-            original = str(entity_a)
-            replacement = str(entity_b)
+    def _add_entities_if_synonyms(self, entity: Text, synonym: Optional[Text]) -> None:
+        """Adds entities to the synonym lookup table.
 
-            if original != replacement:
-                original = original.lower()
-                if original in self.synonyms and self.synonyms[original] != replacement:
+        Lowercase is used as keys to make the lookup case-insensitive.
+        """
+        if synonym is not None:
+            entity = str(entity)
+            synonym = str(synonym)
+            if entity != synonym:
+                entity_lowercase = entity.lower()
+                if (
+                    entity_lowercase in self.synonyms
+                    and self.synonyms[entity_lowercase] != synonym
+                ):
                     rasa.shared.utils.io.raise_warning(
                         f"Found conflicting synonym definitions "
-                        f"for {repr(original)}. Overwriting target "
-                        f"{repr(self.synonyms[original])} with "
-                        f"{repr(replacement)}. "
+                        f"for {repr(entity_lowercase)}. Overwriting target "
+                        f"{repr(self.synonyms[entity_lowercase])} with "
+                        f"{repr(synonym)}. "
                         f"Check your training data and remove "
                         f"conflicting synonym definitions to "
                         f"prevent this from happening.",
                         docs=DOCS_URL_TRAINING_DATA + "#synonyms",
                     )
 
-                self.synonyms[original] = replacement
+                self.synonyms[entity_lowercase] = synonym
+
+            # add a self-reference to handle entities extracted in alternate cases
+            # i.e. for a synonym Austria,
+            # entities extracted as AUSTRIA, austria, ausTRIA, etc
+            # should also have the value of `Austria`
+            synonym_lowercase = synonym.lower()
+            if synonym_lowercase not in self.synonyms:
+                self.synonyms[synonym_lowercase] = synonym

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -60,7 +60,7 @@ def test_unintentional_synonyms_capitalized(
 
     mapper.train(TrainingData(training_examples=examples))
 
-    assert mapper.synonyms.get("mexican") is None
+    assert mapper.synonyms.get("mexican") == "Mexican"
     assert mapper.synonyms.get("tacos") == "Mexican"
 
 
@@ -89,3 +89,59 @@ def test_synonym_mapper_with_ints(
     mapper.process([message])
 
     assert message.get(ENTITIES) == entities
+
+
+def test_synonym_alternate_case(
+    default_model_storage: ModelStorage, default_execution_context: ExecutionContext
+):
+    resource = Resource("xy")
+    mapper = EntitySynonymMapper.create(
+        {}, default_model_storage, resource, default_execution_context
+    )
+
+    examples = [
+        Message(
+            data={
+                TEXT: "What's the weather in austria?",
+                "intent": "whats_weather",
+                "entities": [
+                    {"start": 22, "end": 29, "value": "austria", "entity": "GPE"}
+                ],
+            }
+        ),
+        Message(
+            data={
+                TEXT: "weather vienna?",
+                "intent": "whats_weather",
+                "entities": [
+                    {"start": 8, "end": 14, "value": "austria", "entity": "GPE"}
+                ],
+            }
+        ),
+    ]
+    entities = [
+        {"entity": "test", "value": "austria", "start": 0, "end": 7},
+        {"entity": "test", "value": "Austria", "start": 0, "end": 7},
+        {"entity": "test", "value": "AUSTRIA", "start": 0, "end": 7},
+        {"entity": "test", "value": "ausTRIA", "start": 0, "end": 7},
+        {"entity": "test", "value": "Vienna", "start": 0, "end": 7},
+        {"entity": "test", "value": "brazil", "start": 0, "end": 7},
+    ]
+
+    mapper.train(TrainingData(training_examples=examples))
+    mapper.replace_synonyms(entities)
+    expected_synonym_value = "austria"
+
+    # synonym key for example value is present
+    assert mapper.synonyms.get("vienna") == expected_synonym_value
+
+    # synonym key for self is present
+    assert mapper.synonyms.get("austria") == expected_synonym_value
+
+    # all replacement values are correct
+    assert entities[0]["value"] == expected_synonym_value
+    assert entities[1]["value"] == expected_synonym_value
+    assert entities[2]["value"] == expected_synonym_value
+    assert entities[3]["value"] == expected_synonym_value
+    assert entities[4]["value"] == expected_synonym_value
+    assert entities[5]["value"] != expected_synonym_value

--- a/tests/nlu/extractors/test_entity_synonyms.py
+++ b/tests/nlu/extractors/test_entity_synonyms.py
@@ -60,7 +60,7 @@ def test_unintentional_synonyms_capitalized(
 
     mapper.train(TrainingData(training_examples=examples))
 
-    assert mapper.synonyms.get("mexican") == "Mexican"
+    assert mapper.synonyms.get("mexican") is None
     assert mapper.synonyms.get("tacos") == "Mexican"
 
 
@@ -89,59 +89,3 @@ def test_synonym_mapper_with_ints(
     mapper.process([message])
 
     assert message.get(ENTITIES) == entities
-
-
-def test_synonym_alternate_case(
-    default_model_storage: ModelStorage, default_execution_context: ExecutionContext
-):
-    resource = Resource("xy")
-    mapper = EntitySynonymMapper.create(
-        {}, default_model_storage, resource, default_execution_context
-    )
-
-    examples = [
-        Message(
-            data={
-                TEXT: "What's the weather in austria?",
-                "intent": "whats_weather",
-                "entities": [
-                    {"start": 22, "end": 29, "value": "austria", "entity": "GPE"}
-                ],
-            }
-        ),
-        Message(
-            data={
-                TEXT: "weather vienna?",
-                "intent": "whats_weather",
-                "entities": [
-                    {"start": 8, "end": 14, "value": "austria", "entity": "GPE"}
-                ],
-            }
-        ),
-    ]
-    entities = [
-        {"entity": "test", "value": "austria", "start": 0, "end": 7},
-        {"entity": "test", "value": "Austria", "start": 0, "end": 7},
-        {"entity": "test", "value": "AUSTRIA", "start": 0, "end": 7},
-        {"entity": "test", "value": "ausTRIA", "start": 0, "end": 7},
-        {"entity": "test", "value": "Vienna", "start": 0, "end": 7},
-        {"entity": "test", "value": "brazil", "start": 0, "end": 7},
-    ]
-
-    mapper.train(TrainingData(training_examples=examples))
-    mapper.replace_synonyms(entities)
-    expected_synonym_value = "austria"
-
-    # synonym key for example value is present
-    assert mapper.synonyms.get("vienna") == expected_synonym_value
-
-    # synonym key for self is present
-    assert mapper.synonyms.get("austria") == expected_synonym_value
-
-    # all replacement values are correct
-    assert entities[0]["value"] == expected_synonym_value
-    assert entities[1]["value"] == expected_synonym_value
-    assert entities[2]["value"] == expected_synonym_value
-    assert entities[3]["value"] == expected_synonym_value
-    assert entities[4]["value"] == expected_synonym_value
-    assert entities[5]["value"] != expected_synonym_value


### PR DESCRIPTION
**Proposed changes**:
- Changes from https://github.com/RasaHQ/rasa/pull/12144 and [ATO-616](https://rasahq.atlassian.net/browse/ATO-616) to change the behaviour of Synonym 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-616]: https://rasahq.atlassian.net/browse/ATO-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ