### PR TITLE
Pin Tensorflow dependencies to `2.11.0`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3901,7 +3901,7 @@ transformers = ["transformers", "sentencepiece"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "de8aa558bd96517cb73e83add8cb26bec974a6926ff28e5a0a0edb3796995425"
+content-hash = "d0d8a8fbf403b4e7d643c48768ff3c53dcf359940a0a5eecfb0b3509fa0ec233"
 
 [metadata.files]
 absl-py = [
@@ -5094,6 +5094,7 @@ langcodes = [
 ]
 libclang = [
     {file = "libclang-15.0.6.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:8621795e07b87e17fc7aac9f071bc7fe6b52ed6110c0a96a9975d8113c8c2527"},
+    {file = "libclang-15.0.6.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0bf192c48a8d2992fc5034393ddc99e772ac30e105df84927d62fc88ef8a659f"},
     {file = "libclang-15.0.6.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:69b01a23ab543908a661532595daa23cf88bd96d80e41f58ba0eaa6a378fe0d8"},
     {file = "libclang-15.0.6.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:4a5188184b937132c198ee9de9a8a2316d5fdd1a825398d5ad1a8f5e06f9b40e"},
     {file = "libclang-15.0.6.1-py2.py3-none-manylinux2014_armv7l.whl", hash = "sha256:f7ffa02ac5e586cfffde039dcccc439d88d0feac7d77bf9426d9ba7543d16545"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,15 +257,15 @@ timeout = 60
 timeout_func_only = true
 
 [tool.poetry.dependencies.tensorflow]
-version = "~2.11.0"
+version = "2.11.0"
 markers = "sys_platform != 'darwin' or platform_machine != 'arm64'"
 
 [tool.poetry.dependencies.tensorflow-intel]
-version = "~2.11.0"
+version = "2.11.0"
 markers = "sys_platform == 'win32'"
 
 [tool.poetry.dependencies.tensorflow-cpu-aws]
-version = "~2.11.0"
+version = "2.11.0"
 markers = "sys_platform == 'linux' and (platform_machine == 'arm64' or platform_machine == 'aarch64')"
 
 [tool.poetry.dependencies.tensorflow-macos]
@@ -286,7 +286,7 @@ markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"
 optional = true
 
 [tool.poetry.dependencies.tensorflow-text]
-version = "~2.11.0"
+version = "2.11.0"
 markers = "sys_platform!='win32' and platform_machine!='arm64'"
 
 [tool.poetry.dependencies."github3.py"]


### PR DESCRIPTION
**Proposed changes**:
-  Pin TF dependencies to `2.11.0` because in versions >=2.11.1, Python 3.7 support was dropped.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
