### PR TITLE
Eng 248 policy tests speedup

### DIFF
--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -578,7 +578,68 @@ class TestTEDPolicy(PolicyTestCollection):
         assert isinstance(featurizer.state_featurizer, state_featurizer)
 
 
-class TestTEDPolicyMargin(TestTEDPolicy):
+class TestTEDPolicyConfigurationOptions:
+    """Helper class to skip redundant and long-running tests in subclasses."""
+    @pytest.mark.parametrize("should_finetune", [False])
+    @pytest.mark.skip()
+    def test_persist_and_load(
+        self,
+        trained_policy: Policy,
+        default_domain: Domain,
+        should_finetune: bool,
+        stories_path: Text,
+        model_storage: ModelStorage,
+        resource: Resource,
+        execution_context: ExecutionContext,
+    ):
+        """This takes long and does not need to be tested for every config change."""
+        pass
+
+    @pytest.mark.skip()
+    def test_train_model_checkpointing(
+            self, tmp_path: Path, tmp_path_factory: TempPathFactory
+    ):
+        """This takes long and does not need to be tested for every config change."""
+        pass
+
+    @pytest.mark.skip()
+    def test_doesnt_checkpoint_with_no_checkpointing(
+        self, tmp_path: Path, tmp_path_factory: TempPathFactory
+    ):
+        """This takes long and does not need to be tested for every config change."""
+        pass
+
+    @pytest.mark.skip()
+    def test_doesnt_checkpoint_with_zero_eval_num_examples(
+            self, tmp_path: Path, tmp_path_factory: TempPathFactory
+    ):
+        """This takes long and does not need to be tested for every config change."""
+
+    @pytest.mark.parametrize(
+        "should_finetune, epoch_override, expected_epoch_value",
+        [
+            (
+                    True,
+                    TEDPolicy.get_default_config()[EPOCHS] + 1,
+                    TEDPolicy.get_default_config()[EPOCHS] + 1,
+            )
+        ]
+    )
+    @pytest.mark.skip()
+    def test_epoch_override_when_loaded(
+            self,
+            trained_policy: TEDPolicy,
+            should_finetune: bool,
+            epoch_override: int,
+            expected_epoch_value: int,
+            resource: Resource,
+            model_storage: ModelStorage,
+            execution_context: ExecutionContext,
+    ):
+        """This takes long and does not need to be tested for every config change."""
+        pass
+
+class TestTEDPolicyMargin(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -586,6 +647,7 @@ class TestTEDPolicyMargin(TestTEDPolicy):
         return {
             **TEDPolicy.get_default_config(),
             LOSS_TYPE: "margin",
+            EPOCHS: 2,
             **config_override,
         }
 
@@ -619,7 +681,7 @@ class TestTEDPolicyMargin(TestTEDPolicy):
         assert min(prediction.probabilities) >= -1.0
 
 
-class TestTEDPolicyWithEval(TestTEDPolicy):
+class TestTEDPolicyWithEval(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -632,7 +694,7 @@ class TestTEDPolicyWithEval(TestTEDPolicy):
         }
 
 
-class TestTEDPolicyNormalization(TestTEDPolicy):
+class TestTEDPolicyNormalization(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -662,7 +724,7 @@ class TestTEDPolicyNormalization(TestTEDPolicy):
         assert sum(predicted_probabilities) == pytest.approx(1)
 
 
-class TestTEDPolicyLowRankingLength(TestTEDPolicy):
+class TestTEDPolicyLowRankingLength(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -673,7 +735,7 @@ class TestTEDPolicyLowRankingLength(TestTEDPolicy):
         assert trained_policy.config[RANKING_LENGTH] == 3
 
 
-class TestTEDPolicyHighRankingLength(TestTEDPolicy):
+class TestTEDPolicyHighRankingLength(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -684,7 +746,8 @@ class TestTEDPolicyHighRankingLength(TestTEDPolicy):
         assert trained_policy.config[RANKING_LENGTH] == 11
 
 
-class TestTEDPolicyWithStandardFeaturizer(TestTEDPolicy):
+class TestTEDPolicyWithStandardFeaturizer(TestTEDPolicyConfigurationOptions,
+                                          TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -733,7 +796,7 @@ class TestTEDPolicyWithStandardFeaturizer(TestTEDPolicy):
         assert isinstance(loaded.featurizer.state_featurizer, SingleStateFeaturizer)
 
 
-class TestTEDPolicyWithMaxHistory(TestTEDPolicy):
+class TestTEDPolicyWithMaxHistory(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -763,7 +826,8 @@ class TestTEDPolicyWithMaxHistory(TestTEDPolicy):
         )
 
 
-class TestTEDPolicyWithRelativeAttention(TestTEDPolicy):
+class TestTEDPolicyWithRelativeAttention(TestTEDPolicyConfigurationOptions,
+                                         TestTEDPolicy):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -777,7 +841,8 @@ class TestTEDPolicyWithRelativeAttention(TestTEDPolicy):
         }
 
 
-class TestTEDPolicyWithRelativeAttentionMaxHistoryOne(TestTEDPolicy):
+class TestTEDPolicyWithRelativeAttentionMaxHistoryOne(TestTEDPolicyConfigurationOptions,
+                                                      TestTEDPolicy):
     max_history = 1
 
     def _config(

--- a/tests/core/policies/test_ted_policy.py
+++ b/tests/core/policies/test_ted_policy.py
@@ -580,6 +580,7 @@ class TestTEDPolicy(PolicyTestCollection):
 
 class TestTEDPolicyConfigurationOptions:
     """Helper class to skip redundant and long-running tests in subclasses."""
+
     @pytest.mark.parametrize("should_finetune", [False])
     @pytest.mark.skip()
     def test_persist_and_load(
@@ -597,7 +598,7 @@ class TestTEDPolicyConfigurationOptions:
 
     @pytest.mark.skip()
     def test_train_model_checkpointing(
-            self, tmp_path: Path, tmp_path_factory: TempPathFactory
+        self, tmp_path: Path, tmp_path_factory: TempPathFactory
     ):
         """This takes long and does not need to be tested for every config change."""
         pass
@@ -611,7 +612,7 @@ class TestTEDPolicyConfigurationOptions:
 
     @pytest.mark.skip()
     def test_doesnt_checkpoint_with_zero_eval_num_examples(
-            self, tmp_path: Path, tmp_path_factory: TempPathFactory
+        self, tmp_path: Path, tmp_path_factory: TempPathFactory
     ):
         """This takes long and does not need to be tested for every config change."""
 
@@ -619,25 +620,26 @@ class TestTEDPolicyConfigurationOptions:
         "should_finetune, epoch_override, expected_epoch_value",
         [
             (
-                    True,
-                    TEDPolicy.get_default_config()[EPOCHS] + 1,
-                    TEDPolicy.get_default_config()[EPOCHS] + 1,
+                True,
+                TEDPolicy.get_default_config()[EPOCHS] + 1,
+                TEDPolicy.get_default_config()[EPOCHS] + 1,
             )
-        ]
+        ],
     )
     @pytest.mark.skip()
     def test_epoch_override_when_loaded(
-            self,
-            trained_policy: TEDPolicy,
-            should_finetune: bool,
-            epoch_override: int,
-            expected_epoch_value: int,
-            resource: Resource,
-            model_storage: ModelStorage,
-            execution_context: ExecutionContext,
+        self,
+        trained_policy: TEDPolicy,
+        should_finetune: bool,
+        epoch_override: int,
+        expected_epoch_value: int,
+        resource: Resource,
+        model_storage: ModelStorage,
+        execution_context: ExecutionContext,
     ):
         """This takes long and does not need to be tested for every config change."""
         pass
+
 
 class TestTEDPolicyMargin(TestTEDPolicyConfigurationOptions, TestTEDPolicy):
     def _config(
@@ -746,8 +748,9 @@ class TestTEDPolicyHighRankingLength(TestTEDPolicyConfigurationOptions, TestTEDP
         assert trained_policy.config[RANKING_LENGTH] == 11
 
 
-class TestTEDPolicyWithStandardFeaturizer(TestTEDPolicyConfigurationOptions,
-                                          TestTEDPolicy):
+class TestTEDPolicyWithStandardFeaturizer(
+    TestTEDPolicyConfigurationOptions, TestTEDPolicy
+):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -826,8 +829,9 @@ class TestTEDPolicyWithMaxHistory(TestTEDPolicyConfigurationOptions, TestTEDPoli
         )
 
 
-class TestTEDPolicyWithRelativeAttention(TestTEDPolicyConfigurationOptions,
-                                         TestTEDPolicy):
+class TestTEDPolicyWithRelativeAttention(
+    TestTEDPolicyConfigurationOptions, TestTEDPolicy
+):
     def _config(
         self, config_override: Optional[Dict[Text, Any]] = None
     ) -> Dict[Text, Any]:
@@ -841,8 +845,9 @@ class TestTEDPolicyWithRelativeAttention(TestTEDPolicyConfigurationOptions,
         }
 
 
-class TestTEDPolicyWithRelativeAttentionMaxHistoryOne(TestTEDPolicyConfigurationOptions,
-                                                      TestTEDPolicy):
+class TestTEDPolicyWithRelativeAttentionMaxHistoryOne(
+    TestTEDPolicyConfigurationOptions, TestTEDPolicy
+):
     max_history = 1
 
     def _config(

--- a/tests/core/policies/test_unexpected_intent_policy.py
+++ b/tests/core/policies/test_unexpected_intent_policy.py
@@ -635,14 +635,11 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         tmp_path: Path,
     ):
         """Skips predictions to prevent loop."""
-        loaded_policy = self.persist_and_load_policy(
-            trained_policy, model_storage, resource, execution_context
-        )
         precomputations = None
         tracker = DialogueStateTracker(sender_id="init", slots=default_domain.slots)
         tracker.update_with_events(tracker_events, default_domain)
         with caplog.at_level(logging.DEBUG):
-            prediction = loaded_policy.predict_action_probabilities(
+            prediction = trained_policy.predict_action_probabilities(
                 tracker, default_domain, precomputations
             )
 
@@ -651,7 +648,7 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         ) == should_skip
 
         if should_skip:
-            assert prediction.probabilities == loaded_policy._default_predictions(
+            assert prediction.probabilities == trained_policy._default_predictions(
                 default_domain
             )
 
@@ -691,20 +688,17 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         tracker_events: List[Event],
     ):
         """Skips predictions if there's a new intent created."""
-        loaded_policy = self.persist_and_load_policy(
-            trained_policy, model_storage, resource, execution_context
-        )
         tracker = DialogueStateTracker(sender_id="init", slots=default_domain.slots)
         tracker.update_with_events(tracker_events, default_domain)
 
         with caplog.at_level(logging.DEBUG):
-            prediction = loaded_policy.predict_action_probabilities(
+            prediction = trained_policy.predict_action_probabilities(
                 tracker, default_domain, precomputations=None
             )
 
         assert "Skipping predictions for UnexpecTEDIntentPolicy" in caplog.text
 
-        assert prediction.probabilities == loaded_policy._default_predictions(
+        assert prediction.probabilities == trained_policy._default_predictions(
             default_domain
         )
 
@@ -779,9 +773,6 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         tracker_events_without_action: List[Event],
         tmp_path: Path,
     ):
-        loaded_policy = self.persist_and_load_policy(
-            trained_policy, model_storage, resource, execution_context
-        )
         precomputations = None
         tracker_with_action = DialogueStateTracker.from_events(
             "test 1", evts=tracker_events_with_action
@@ -789,10 +780,10 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         tracker_without_action = DialogueStateTracker.from_events(
             "test 2", evts=tracker_events_without_action
         )
-        prediction_with_action = loaded_policy.predict_action_probabilities(
+        prediction_with_action = trained_policy.predict_action_probabilities(
             tracker_with_action, default_domain, precomputations
         )
-        prediction_without_action = loaded_policy.predict_action_probabilities(
+        prediction_without_action = trained_policy.predict_action_probabilities(
             tracker_without_action, default_domain, precomputations
         )
 

--- a/tests/core/policies/test_unexpected_intent_policy.py
+++ b/tests/core/policies/test_unexpected_intent_policy.py
@@ -66,6 +66,17 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         )
         return featurizer
 
+    @staticmethod
+    def persist_and_load_policy(
+        trained_policy: UnexpecTEDIntentPolicy,
+        model_storage: ModelStorage,
+        resource: Resource,
+        execution_context: ExecutionContext,
+    ):
+        return trained_policy.__class__.load(
+            trained_policy.config, model_storage, resource, execution_context
+        )
+
     def test_ranking_length(self, trained_policy: UnexpecTEDIntentPolicy):
         assert trained_policy.config[RANKING_LENGTH] == LABEL_RANKING_LENGTH
 

--- a/tests/core/policies/test_unexpected_intent_policy.py
+++ b/tests/core/policies/test_unexpected_intent_policy.py
@@ -66,17 +66,6 @@ class TestUnexpecTEDIntentPolicy(TestTEDPolicy):
         )
         return featurizer
 
-    @staticmethod
-    def persist_and_load_policy(
-        trained_policy: UnexpecTEDIntentPolicy,
-        model_storage: ModelStorage,
-        resource: Resource,
-        execution_context: ExecutionContext,
-    ):
-        return trained_policy.__class__.load(
-            trained_policy.config, model_storage, resource, execution_context
-        )
-
     def test_ranking_length(self, trained_policy: UnexpecTEDIntentPolicy):
         assert trained_policy.config[RANKING_LENGTH] == LABEL_RANKING_LENGTH
 


### PR DESCRIPTION
**Proposed changes**:
- Testing ted policy is currently a fairly complex, entangled test matrix with multiple levels of subclassing. Through this subclassing, a lot of long-running tests were executed multiple times with little benefit. I made sure that small config tests only trigger one training for this config but not 5 or 6 trainings as of now.
- reusing trained model in UnexpecTED testing when the model isn't altered during the test
- takes pure testing time down from ~30 min to 12-15min

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
