### PR TITLE
ATO-554 BlockingIOError in Rasa CLI with large (~1k) utterance length

### DIFF
--- a/changelog/12262.bugfix.md
+++ b/changelog/12262.bugfix.md
@@ -1,0 +1,1 @@
+Fix `BlockingIOError` when running `rasa cli` on utterances with more than 5KB of text.

--- a/rasa/shared/utils/cli.py
+++ b/rasa/shared/utils/cli.py
@@ -12,15 +12,17 @@ def print_color(*args: Any, color: Text) -> None:
         color: A textual representation of the color.
     """
     output = rasa.shared.utils.io.wrap_with_color(*args, color=color)
-    try:
+    stream = sys.stdout
+    if sys.platform == "win32":
         # colorama is used to fix a regression where colors can not be printed on
         # windows. https://github.com/RasaHQ/rasa/issues/7053
         from colorama import AnsiToWin32
 
         stream = AnsiToWin32(sys.stdout).stream
+    try:
         print(output, file=stream)
-    except ImportError:
-        print(output)
+    except BlockingIOError:
+        rasa.shared.utils.io.handle_print_blocking(output)
 
 
 def print_success(*args: Any) -> None:

--- a/tests/shared/utils/test_io.py
+++ b/tests/shared/utils/test_io.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import string
 import textwrap
@@ -9,6 +10,8 @@ import copy
 from pathlib import Path
 import numpy as np
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from unittest.mock import Mock
 
 import rasa.shared
 from rasa.shared.nlu.training_data.features import Features
@@ -620,3 +623,21 @@ def test_deep_container_fingerprint_can_use_instance_fingerprint():
     m1 = np.asarray([[0.5, 3.1, 3.0], [1.1, 1.2, 1.3], [4.7, 0.3, 2.7]])
     f = Features(m1, "sentence", "text", "CountVectorsFeaturizer")
     assert rasa.shared.utils.io.deep_container_fingerprint(f) == f.fingerprint()
+
+
+# Can't manipulate the STDOUT file descriptor in pytest (it's a io.StringIO instance not a file)
+def test_handle_print_blocking(monkeypatch: MonkeyPatch):
+    def mock_print(*args, **kwargs):
+        raise BlockingIOError()
+
+    mock = Mock()
+    monkeypatch.setattr(builtins, "print", mock_print)
+    monkeypatch.setattr(rasa.shared.utils.io, "handle_print_blocking", mock)
+
+    # Sanity checks that the prints are actually raising the exception
+    rasa.shared.utils.cli.print_info("Test BlockingIOError")
+    rasa.shared.utils.cli.print_success("Test BlockingIOError")
+    rasa.shared.utils.cli.print_warning("Test BlockingIOError")
+    rasa.shared.utils.cli.print_error("Test BlockingIOError")
+
+    assert mock.call_count == 4


### PR DESCRIPTION
**Proposed changes**:
- Fix [ATO-554](https://rasahq.atlassian.net/browse/ATO-554) by manipulating STDOUT to unblock it, as it blocks only half way on utterances with more than ~5KB of text.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-554]: https://rasahq.atlassian.net/browse/ATO-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ