### PR TITLE
Add Docs For Latest Security Patch Image Tag

### DIFF
--- a/docs/docs/deploy/deploy-rasa.mdx
+++ b/docs/docs/deploy/deploy-rasa.mdx
@@ -202,7 +202,7 @@ and [specify a pull secret for the image](#step-1-image-pull-secret).
 
 #### Security Patch Releases
 Beginning with Rasa Plus 3.4.0, we release a new Docker image for supported versions each day at 0800 UTC. These images have OS security patches applied and include the date of generation in their tag in the format `YYYYMMDD`. 
-For example, to use the 3.4.2 image generated on the 1st of February 2023, use the tag `3.4.2-20230201`. These images can optionally be used as a drop-in replacement for the same version of Rasa Plus, but with all OS security updates up to that date applied.
+For example, to use the 3.4.2 image generated on the 1st of February 2023, use the tag `3.4.2-20230201`. Alternatively, you can also ensure that you always fetch the most recent security patch release using the tag format `[release]-latest` eg `3.4.2-latest`. These images can optionally be used as a drop-in replacement for the same version of Rasa Plus, but with all OS security updates up to that date applied.
 
 #### Step 1: image pull secret
 

--- a/docs/docs/rasa-pro.mdx
+++ b/docs/docs/rasa-pro.mdx
@@ -53,3 +53,5 @@ Enhance security with our seamless Vault integration, enabling dynamic credentia
 ### Security Scanning for Vulnerability Protection
 
 Nightly and proactive security patches on your docker image to make sure dependencies are always up to date.
+
+[Read more here](./deploy/deploy-rasa.mdx#security-patch-release).

--- a/docs/docs/rasa-pro.mdx
+++ b/docs/docs/rasa-pro.mdx
@@ -54,4 +54,4 @@ Enhance security with our seamless Vault integration, enabling dynamic credentia
 
 Nightly and proactive security patches on your docker image to make sure dependencies are always up to date.
 
-[Read more here](./deploy/deploy-rasa.mdx#security-patch-release).
+[Read more here](./deploy/deploy-rasa.mdx#security-patch-releases).


### PR DESCRIPTION
**Proposed changes**:
- Add docs line to explain the addition of a new `[release]-latest` tag to the security patched images for Rasa Plus.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
