### PR TITLE
ATO-779 Add a note to documentation for fixing Windows character encoding or text colour 

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -197,5 +197,6 @@ excluded_words:
   - rustup-init
   - rustc
   - conftest
+  - winpty
 
 spellcheck_filenames: false

--- a/changelog/12290.doc.md
+++ b/changelog/12290.doc.md
@@ -1,0 +1,1 @@
+Added note to CLI documentation to address encoding and color issues on certain Windows terminals

--- a/docs/docs/command-line-interface.mdx
+++ b/docs/docs/command-line-interface.mdx
@@ -31,6 +31,12 @@ import RasaProBanner from "@theme/RasaProBanner";
 |`rasa evaluate markers` |Extracts markers from an existing tracker store.                                                                                          |
 |`rasa -h`               |Shows all available commands.                                                                                                             |
 
+:::note
+If you run into character encoding issues on Windows like: `UnicodeEncodeError: 'charmap' codec can't encode character ...` or
+the terminal is not displaying colored messages properly, prepend `winpty` to the command you would like to run.
+For example `winpty rasa init` instead of `rasa init`
+:::
+
 ## Log Level
 
 Rasa produces log messages at several different levels (eg. warning, info, error and so on). You can control which level of logs you would like to see with `--verbose` (same as `-v`) or `--debug` (same as `-vv`) as optional command line arguments. See each command below for more explanation on what these arguments mean.


### PR DESCRIPTION
**Proposed changes**:
- Add a note to the CLI documentation page to address encoding/colour issues on certain windows terminals (git bash)
- Only way to fix [ATO-779](https://rasahq.atlassian.net/browse/ATO-779) (comments for info)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-779]: https://rasahq.atlassian.net/browse/ATO-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ