### PR TITLE
Fix error when customizing `action_session_start` via a custom action

### DIFF
--- a/changelog/12295.bugfix.md
+++ b/changelog/12295.bugfix.md
@@ -1,0 +1,2 @@
+Fix `AttributeError: 'NoneType' object has no attribute 'send_response'` caused by retrieving tracker via `GET /conversations/{conversation_id}/tracker` endpoint when `action_session_start` is customized in a custom action.
+This was addressed by passing an instance of `CollectingOutputChannel` to the method retrieving the tracker from the `MessageProcessor`.

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -721,7 +721,8 @@ def create_app(
         until_time = rasa.utils.endpoints.float_arg(request, "until")
 
         tracker = await app.ctx.agent.processor.fetch_full_tracker_with_initial_session(
-            conversation_id
+            conversation_id,
+            output_channel=CollectingOutputChannel(),
         )
 
         try:


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-604](https://rasahq.atlassian.net/browse/ATO-604) and [OSS-129](https://rasa-open-source.atlassian.net/browse/OSS-129). These two tickets share the same root cause that an instance of an `output_channel` is not given in the API function handling endpoint GET `/conversations/{conversation_id}/tracker` [here](https://github.com/RasaHQ/rasa/blob/756d1c02aba002f1b79b8eb4894c8acd0be1e9ae/rasa/server.py#L723).

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-604]: https://rasahq.atlassian.net/browse/ATO-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ