### PR TITLE
Fix RabbitMQ url parsing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,9 @@ test-integration:
 	# OMP_NUM_THREADS can improve overall performance using one thread by process (on tensorflow), avoiding overload
 	# TF_CPP_MIN_LOG_LEVEL=2 sets C code log level for tensorflow to error suppressing lower log events
 ifeq (,$(wildcard tests_deployment/.env))
-	OMP_NUM_THREADS=1 TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest $(INTEGRATION_TEST_FOLDER) -n $(JOBS) -m $(INTEGRATION_TEST_PYTEST_MARKERS)
+	OMP_NUM_THREADS=1 TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest $(INTEGRATION_TEST_FOLDER) -n $(JOBS) -m $(INTEGRATION_TEST_PYTEST_MARKERS) --dist loadgroup
 else
-	set -o allexport; source tests_deployment/.env && OMP_NUM_THREADS=1 TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest $(INTEGRATION_TEST_FOLDER) -n $(JOBS) -m $(INTEGRATION_TEST_PYTEST_MARKERS) && set +o allexport
+	set -o allexport; source tests_deployment/.env && OMP_NUM_THREADS=1 TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest $(INTEGRATION_TEST_FOLDER) -n $(JOBS) -m $(INTEGRATION_TEST_PYTEST_MARKERS) --dist loadgroup && set +o allexport
 endif
 
 test-cli: PYTEST_MARKER=category_cli and (not flaky)

--- a/changelog/12325.bugfix.md
+++ b/changelog/12325.bugfix.md
@@ -1,2 +1,2 @@
 Fix parsing of RabbitMQ URL provided in `endpoints.yml` file to include vhost path and query parameters.
-Re-allows inclusion of username and hostname in the URL as a regression fix (this was supported in 2.x).
+Re-allows inclusion of credentials in the URL as a regression fix (this was supported in 2.x).

--- a/changelog/12325.bugfix.md
+++ b/changelog/12325.bugfix.md
@@ -1,0 +1,2 @@
+Fix parsing of RabbitMQ URL provided in `endpoints.yml` file to include vhost path and query parameters.
+Re-allows inclusion of username and hostname in the URL as a regression fix (this was supported in 2.x).

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -159,24 +159,35 @@ class PikaEventBroker(EventBroker):
 
         self._exchange = await self._set_up_exchange(channel)
 
-    async def _connect(self) -> aio_pika.abc.AbstractRobustConnection:
+    def configure_url(self) -> Optional[Text]:
+        """Configures the URL to connect to RabbitMQ."""
         url = None
-        # The `url` parameter will take precedence over parameters like `login` or
-        # `password`.
+
         if self.host.startswith("amqp"):
 
-            if self.username in self.host and self.password in self.host:
-                url = self.host
+            parsed_host = urlparse(self.host)
+
+            amqp_user = f"{self.username}:{self.password}"
+            if amqp_user not in parsed_host.netloc:
+                url = f"{parsed_host.scheme}://{amqp_user}@{parsed_host.netloc}"
             else:
-                parsed_host = urlparse(self.host)
-                amqp_user = f"{self.username}:{self.password}"
-                url = f"{parsed_host.scheme}://{amqp_user}@{parsed_host.netloc}:{self.port}"  # noqa: E501
+                url = f"{parsed_host.scheme}://{parsed_host.netloc}"
 
-                if parsed_host.path:
-                    url = f"{url}{parsed_host.path}"
+            if str(self.port) not in url:
+                url = f"{url}:{self.port}"
 
-                if parsed_host.query:
-                    url = f"{url}?{parsed_host.query}"
+            if parsed_host.path:
+                url = f"{url}{parsed_host.path}"
+
+            if parsed_host.query:
+                url = f"{url}?{parsed_host.query}"
+
+        return url
+
+    async def _connect(self) -> aio_pika.abc.AbstractRobustConnection:
+        # The `url` parameter will take precedence over parameters like `login` or
+        # `password`.
+        url = self.configure_url()
 
         ssl_options = _create_rabbitmq_ssl_options(self.host)
         logger.info("Connecting to RabbitMQ ...")

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -165,15 +165,18 @@ class PikaEventBroker(EventBroker):
         # `password`.
         if self.host.startswith("amqp"):
 
-            parsed_host = urlparse(self.host)
-            amqp_user = f"{self.username}:{self.password}"
-            url = f"{parsed_host.scheme}://{amqp_user}@{parsed_host.netloc}:{self.port}"
+            if self.username in self.host and self.password in self.host:
+                url = self.host
+            else:
+                parsed_host = urlparse(self.host)
+                amqp_user = f"{self.username}:{self.password}"
+                url = f"{parsed_host.scheme}://{amqp_user}@{parsed_host.netloc}:{self.port}"  # noqa: E501
 
-            if parsed_host.path:
-                url = f"{url}{parsed_host.path}"
+                if parsed_host.path:
+                    url = f"{url}{parsed_host.path}"
 
-            if parsed_host.query:
-                url = f"{url}?{parsed_host.query}"
+                if parsed_host.query:
+                    url = f"{url}?{parsed_host.query}"
 
         ssl_options = _create_rabbitmq_ssl_options(self.host)
         logger.info("Connecting to RabbitMQ ...")

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -159,7 +159,7 @@ class PikaEventBroker(EventBroker):
 
         self._exchange = await self._set_up_exchange(channel)
 
-    def configure_url(self) -> Optional[Text]:
+    def _configure_url(self) -> Optional[Text]:
         """Configures the URL to connect to RabbitMQ."""
         url = None
 
@@ -187,7 +187,7 @@ class PikaEventBroker(EventBroker):
     async def _connect(self) -> aio_pika.abc.AbstractRobustConnection:
         # The `url` parameter will take precedence over parameters like `login` or
         # `password`.
-        url = self.configure_url()
+        url = self._configure_url()
 
         ssl_options = _create_rabbitmq_ssl_options(self.host)
         logger.info("Connecting to RabbitMQ ...")

--- a/rasa/core/brokers/pika.py
+++ b/rasa/core/brokers/pika.py
@@ -169,6 +169,12 @@ class PikaEventBroker(EventBroker):
             amqp_user = f"{self.username}:{self.password}"
             url = f"{parsed_host.scheme}://{amqp_user}@{parsed_host.netloc}:{self.port}"
 
+            if parsed_host.path:
+                url = f"{url}{parsed_host.path}"
+
+            if parsed_host.query:
+                url = f"{url}?{parsed_host.query}"
+
         ssl_options = _create_rabbitmq_ssl_options(self.host)
         logger.info("Connecting to RabbitMQ ...")
 

--- a/tests/core/test_broker.py
+++ b/tests/core/test_broker.py
@@ -405,5 +405,5 @@ def test_pika_event_broker_configure_url(
     username = "test_user"
     password = "test_pass"
     broker = PikaEventBroker(host=host, username=username, password=password)
-    url = broker.configure_url()
+    url = broker._configure_url()
     assert url == expected_url

--- a/tests/core/test_broker.py
+++ b/tests/core/test_broker.py
@@ -377,3 +377,33 @@ async def test_sql_connection_error(monkeypatch: MonkeyPatch):
     )
     with pytest.raises(ConnectionException):
         await EventBroker.create(cfg)
+
+
+@pytest.mark.parametrize(
+    "host,expected_url",
+    [
+        ("localhost", None),
+        ("amqp://localhost", "amqp://test_user:test_pass@localhost:5672"),
+        (
+            "amqp://test_user:test_pass@localhost",
+            "amqp://test_user:test_pass@localhost:5672",
+        ),
+        (
+            "amqp://test_user:test_pass@localhost/myvhost?connection_timeout=10",
+            "amqp://test_user:test_pass@localhost:5672/myvhost?connection_timeout=10",
+        ),
+        ("amqp://localhost:5672", "amqp://test_user:test_pass@localhost:5672"),
+        (
+            "amqp://test_user:test_pass@localhost:5672/myvhost?connection_timeout=10",
+            "amqp://test_user:test_pass@localhost:5672/myvhost?connection_timeout=10",
+        ),
+    ],
+)
+def test_pika_event_broker_configure_url(
+    host: Text, expected_url: Optional[Text]
+) -> None:
+    username = "test_user"
+    password = "test_pass"
+    broker = PikaEventBroker(host=host, username=username, password=password)
+    url = broker.configure_url()
+    assert url == expected_url

--- a/tests/integration_tests/core/brokers/test_pika.py
+++ b/tests/integration_tests/core/brokers/test_pika.py
@@ -2,6 +2,7 @@ import logging
 from typing import Text
 
 import docker
+import pytest
 import randomname
 from pytest import LogCaptureFixture
 
@@ -100,8 +101,10 @@ async def test_pika_event_broker_publish_after_restart(
     rabbitmq_container.remove()
 
 
+@pytest.mark.parametrize("host_component", ["localhost", "myuser:mypassword@localhost"])
 async def test_pika_event_broker_connect_with_path_and_query_params_in_url(
     docker_client: docker.DockerClient,
+    host_component: Text,
 ) -> None:
     username = "myuser"
     password = "mypassword"
@@ -128,7 +131,7 @@ async def test_pika_event_broker_connect_with_path_and_query_params_in_url(
     query_param = "heartbeat=5"
 
     broker = PikaEventBroker(
-        host=f"amqp://{RABBITMQ_HOST}/{vhost}?{query_param}",
+        host=f"amqp://{host_component}/{vhost}?{query_param}",
         username=username,
         password=password,
         port=RABBITMQ_PORT,

--- a/tests/integration_tests/core/brokers/test_pika.py
+++ b/tests/integration_tests/core/brokers/test_pika.py
@@ -31,6 +31,7 @@ async def test_pika_event_broker_connect():
         await broker.close()
 
 
+@pytest.mark.xdist_group("rabbitmq")
 async def test_pika_event_broker_publish_after_restart(
     docker_client: docker.DockerClient,
     caplog: LogCaptureFixture,
@@ -101,6 +102,7 @@ async def test_pika_event_broker_publish_after_restart(
     rabbitmq_container.remove()
 
 
+@pytest.mark.xdist_group("rabbitmq")
 @pytest.mark.parametrize("host_component", ["localhost", "myuser:mypassword@localhost"])
 async def test_pika_event_broker_connect_with_path_and_query_params_in_url(
     docker_client: docker.DockerClient,


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-978](https://rasahq.atlassian.net/browse/ATO-978) and [ATO-976](https://rasahq.atlassian.net/browse/ATO-976)
- Adds integration tests for both cases (when credentials are passed in the endpoints url and when they're not)
- Fixes [docker prune conflict issue](https://github.com/RasaHQ/rasa/actions/runs/4789600582/jobs/8517691342#step:13:431) when the integration tests were run in parallel by applying pytest recommendation to use `--dist loadgroup` and `xdist_group` pytest marker

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-978]: https://rasahq.atlassian.net/browse/ATO-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ATO-976]: https://rasahq.atlassian.net/browse/ATO-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ