### PR TITLE
Removed multi processing from ci tests

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -336,10 +336,9 @@ jobs:
         if: needs.changes.outputs.backend == 'true'
         run: poetry run pip install -U ddtrace
 
-      - name: Test Code 🔍 (multi-process)
+      - name: Test Code 🔍
         if: needs.changes.outputs.backend == 'true'
         env:
-          JOBS: 2
           PYTHONIOENCODING: "utf-8"
           DD_ENV: ${{ matrix.test }}
           DD_SERVICE: rasa
@@ -475,10 +474,9 @@ jobs:
         if: needs.changes.outputs.backend == 'true'
         run: poetry run pip install -U ddtrace
 
-      - name: Test Code 🔍 (multi-process)
+      - name: Test Code 🔍
         if: needs.changes.outputs.backend == 'true'
         env:
-          JOBS: 2
           PYTHONIOENCODING: "utf-8"
           DD_ENV: test-flaky
           DD_SERVICE: rasa

--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,8 @@ test-gh-actions:
 	OMP_NUM_THREADS=1 TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest .github/tests --cov .github/scripts
 
 test-marker: clean
-    # OMP_NUM_THREADS can improve overall performance using one thread by process (on tensorflow), avoiding overload
 	# TF_CPP_MIN_LOG_LEVEL=2 sets C code log level for tensorflow to error suppressing lower log events
-	OMP_NUM_THREADS=1 TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest tests -n $(JOBS) --dist loadscope -m "$(PYTEST_MARKER)" --cov rasa --ignore $(INTEGRATION_TEST_FOLDER) $(DD_ARGS)
+	TF_CPP_MIN_LOG_LEVEL=2 poetry run pytest tests -m "$(PYTEST_MARKER)" --cov rasa --ignore $(INTEGRATION_TEST_FOLDER) $(DD_ARGS)
 
 generate-pending-changelog:
 	poetry run python -c "from scripts import release; release.generate_changelog('major.minor.patch')"


### PR DESCRIPTION
**Proposed changes**:
- branch is wrongly named 😵‍💫 
- Removed multi processing from ci tests as some failures are related to workers crashing going unnoticed. We also currently limit the threads of tensorflow to 1. So instead, we might just run everything in the main process and let tf tests make use of their normal multi threading.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
