### PR TITLE
Add an example on how to setup integration tests for Redis tracker store

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+import pytest
+
+
+# def pytest_collection_modifyitems(items: Any) -> None:
+#     """Add the ``integration_tests`` marker to all tests in this directory."""
+#     for item in items:
+#         mark = getattr(pytest.mark, "integration_tests")
+#         item.add_marker(mark)

--- a/tests/integration_tests/core/conftest.py
+++ b/tests/integration_tests/core/conftest.py
@@ -1,5 +1,7 @@
 import os
-from typing import Iterator, Text
+from docker import DockerClient
+from docker.models.containers import Container
+from typing import Iterator, Text, Optional, Callable, List
 
 import pytest
 import sqlalchemy as sa
@@ -9,6 +11,7 @@ from rasa.core.lock_store import RedisLockStore
 
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = os.getenv("REDIS_PORT", 6379)
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "1")
 POSTGRES_HOST = os.getenv("POSTGRES_HOST", "localhost")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", 5432)
 POSTGRES_USER = os.getenv("POSTGRES_USER", "")
@@ -53,6 +56,80 @@ def postgres_login_db_connection() -> Iterator[sa.engine.Connection]:
         _drop_db(conn, POSTGRES_TRACKER_STORE_DB)
         conn.close()
         engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def docker_client() -> DockerClient:
+    docker_client = DockerClient.from_env()
+    return docker_client
+
+
+@pytest.fixture(scope="session")
+def redis_image(docker_client: DockerClient) -> None:
+    docker_client.images.pull("redis:latest")
+
+
+@pytest.fixture(scope="session")
+def _clean_test_containers() -> None:
+    docker_client = DockerClient.from_env()
+    containers: List[Container] = docker_client.containers.list(
+        all=True, filters={"label": "rasa"}
+    )
+    print("Cleaning up test containers")
+    for container in containers:
+        print(f"Removing container {container.name}")
+        if container.status == "running":
+            container.stop()
+        container.remove(force=True)
+
+
+CreateRedisContainer = Callable[[Optional[Text]], Container]
+
+
+@pytest.mark.usefixtures("_clean_test_containers", "redis_image")
+@pytest.fixture(scope="session")
+def create_docker_redis_container(
+    docker_client,
+) -> CreateRedisContainer:
+    created_containers = []
+
+    def _create_redis_container(redis_password: Optional[Text] = None) -> Container:
+        entrypoint = "redis-server"
+
+        if redis_password is not None:
+            entrypoint += f" --requirepass {redis_password}"
+
+        redis_container = docker_client.containers.create(
+            "redis:latest",
+            name="rasa_test_redis",
+            ports={"6379/tcp": REDIS_PORT},
+            detach=True,
+            labels=["rasa", "redis"],
+            entrypoint=entrypoint,
+        )
+
+        created_containers.append(redis_container)
+
+        return redis_container
+
+    yield _create_redis_container
+
+    for container in created_containers:
+        print(f"Removing container {container.name}")
+        container.remove(force=True)
+
+
+@pytest.fixture(scope="session")
+def docker_redis_with_password(
+    create_docker_redis_container: CreateRedisContainer,
+) -> None:
+    redis_container = create_docker_redis_container(REDIS_PASSWORD)
+    redis_container.start()
+    try:
+        yield redis_container
+    finally:
+        print(f"Stopping container {redis_container.name}")
+        redis_container.stop()
 
 
 def _create_login_db(connection: sa.engine.Connection) -> None:

--- a/tests/integration_tests/core/test_tracker_store.py
+++ b/tests/integration_tests/core/test_tracker_store.py
@@ -1,4 +1,5 @@
 import logging
+from docker.models.containers import Container
 from typing import List
 from unittest.mock import Mock
 
@@ -22,6 +23,7 @@ from .conftest import (
     POSTGRES_TRACKER_STORE_DB,
     POSTGRES_USER,
     POSTGRES_PASSWORD,
+    REDIS_PASSWORD,
 )
 
 # NOTE about the timeouts in this file. We want to fail fast
@@ -213,11 +215,12 @@ async def test_postgres_tracker_store_retrieve(
     tracker_store.engine.dispose()
 
 
+@pytest.mark.usefixtures("docker_redis_with_password")
 async def test_redis_tracker_store_retrieve_full_tracker(
     domain: Domain,
     tracker_with_restarted_event: DialogueStateTracker,
 ) -> None:
-    tracker_store = RedisTrackerStore(domain)
+    tracker_store = RedisTrackerStore(domain, password=REDIS_PASSWORD)
     sender_id = tracker_with_restarted_event.sender_id
 
     await tracker_store.save(tracker_with_restarted_event)


### PR DESCRIPTION
This is an example on how to setup outward facing integration test.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
