### PR TITLE
Adding a timeout of 60mins for the test steps

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -228,6 +228,7 @@ jobs:
     name: Run Tests
     if: github.ref_type != 'tag'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     needs: [changes]
     strategy:
       fail-fast: false
@@ -376,6 +377,7 @@ jobs:
     name: Run Flaky Tests
     if: github.ref_type != 'tag'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     needs: [changes]
     strategy:
       fail-fast: false
@@ -567,6 +569,7 @@ jobs:
     name: Run Non-Sequential Integration Tests
     if: github.ref_type != 'tag'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     needs: [changes]
     env:
       REDIS_HOST: localhost
@@ -702,6 +705,7 @@ jobs:
   sequential_integration_test:
     name: Run Sequential Integration Tests
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs: [changes]
     env:
       POSTGRES_HOST: localhost


### PR DESCRIPTION
**Proposed changes**:
- The default timeout for jobs on github actions is 360mins which means failing jobs especially for the tests keep running for hours. So restricting the timeout for the test steps in the workflow to 60mins, after which GithubActions should terminate the job.
- Needs to be ported to 3.5.x,3.4.x,3.3.x
