### PR TITLE
[ATO-1122] Add response_ids to domain

### DIFF
--- a/changelog/11222.improvement.md
+++ b/changelog/11222.improvement.md
@@ -1,0 +1,3 @@
+Add optional property `id` to response variations.
+IDs will be transmitted to the NLG server and can be used to identify the response variation that should be used.
+Response variation's condition is evaluated to determine if the ID should be transmitted to the NLG server.

--- a/changelog/11222.improvement.md
+++ b/changelog/11222.improvement.md
@@ -1,3 +1,3 @@
-Add optional property `id` to response variations.
+Add optional property `ids` to response variations.
 IDs will be transmitted to the NLG server and can be used to identify the response variation that should be used.
 Response variation's condition is evaluated to determine if the ID should be transmitted to the NLG server.

--- a/changelog/11222.improvement.md
+++ b/changelog/11222.improvement.md
@@ -1,3 +1,2 @@
-Add optional property `ids` to response variations.
+Add optional property `ids` to the nlg server request body.
 IDs will be transmitted to the NLG server and can be used to identify the response variation that should be used.
-Response variation's condition is evaluated to determine if the ID should be transmitted to the NLG server.

--- a/docs/docs/nlg.mdx
+++ b/docs/docs/nlg.mdx
@@ -26,6 +26,13 @@ required to select or generate a response.
 The body of the `POST` request sent to your NLG endpoint will be structured
 like this:
 
+:::info New in 3.6
+We have added an `ids` field to the request body.
+This field contains a list of response variation IDs.
+You can use this information to compose/select a proper response variation on you NLG server.
+
+:::
+
 ```json
 {
   "response":"utter_what_can_do",

--- a/docs/docs/nlg.mdx
+++ b/docs/docs/nlg.mdx
@@ -32,6 +32,7 @@ like this:
   "arguments":{
     
   },
+  "ids": ["<response_variation_id_1>", "<response_variation_id_2>"],
   "tracker":{
     "sender_id":"user_0",
     "slots":{
@@ -171,6 +172,7 @@ Here is an overview of the high-level keys in the post request:
 Key | Description
 ---|---
 `response` | The name of the response predicted by Rasa.
+`ids` | A list of response variation IDs.
 `arguments` | Optional keyword arguments that can be provided by custom actions.
 `tracker` | A dictionary containing the entire conversation history.
 `channel` | The output channel this message will be sent to.

--- a/docs/docs/nlg.mdx
+++ b/docs/docs/nlg.mdx
@@ -29,7 +29,10 @@ like this:
 :::info New in 3.6
 We have added an `ids` field to the request body.
 This field contains a list of response variation IDs.
-You can use this information to compose/select a proper response variation on you NLG server.
+You can use this information to compose/select a proper response variation on your NLG server.
+In case you are using responses with Conditional Response Variations,
+on the NLG server side, you must implement the logic which will use content of the slots from
+`tracker['slots']` along side the IDs from `ids` field to select the proper response variation.
 
 :::
 

--- a/docs/docs/responses.mdx
+++ b/docs/docs/responses.mdx
@@ -21,7 +21,6 @@ responses:
   - text: "See you!"
 ```
 
-
 If you are using [retrieval intents](glossary.mdx#retrieval-intent) in your assistant, you also need to add responses
 for your assistant's replies to these intents:
 
@@ -102,6 +101,25 @@ responses:
 In this example, when `utter_greet` gets predicted as the next action, Rasa will randomly pick one 
 of the two response variations to use.
 
+#### IDs for Responses
+
+:::note New in Rasa 3.6
+You can now set an ID for any response.
+This is useful when you want to use the [NLG server](./nlg.mdx) to generate the response.
+
+Type for ID is string.
+
+:::
+
+Example of response variations with ID:
+```yaml-rasa {3-4} title="domain.yml"
+responses:
+  utter_greet:
+  - id: "greet_1"
+    text: "Hey, {name}. How are you?"
+  - id: "greet_2"
+    text: "Hey, {name}. How is your day going?"
+```
 
 ### Channel-Specific Response Variations
 

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -305,12 +305,14 @@ class ActionBotResponse(Action):
         domain: "Domain",
     ) -> List[Event]:
         """Simple run implementation uttering a (hopefully defined) response."""
-        utter_action_response_ids = self._extract_response_ids(domain, tracker)
+        response_ids_for_response = domain.response_ids_per_response.get(
+            self.utter_action, set()
+        )
         message = await nlg.generate(
             self.utter_action,
             tracker,
             output_channel.name(),
-            response_ids=utter_action_response_ids,
+            response_ids=response_ids_for_response,
         )
         if message is None:
             if not self.silent_fail:
@@ -326,36 +328,6 @@ class ActionBotResponse(Action):
     def name(self) -> Text:
         """Returns action name."""
         return self.utter_action
-
-    @staticmethod
-    def _is_response_condition_satisfied(
-        conditions: List[Dict[Text, Text]], tracker: "DialogueStateTracker"
-    ) -> bool:
-
-        if len(conditions) > 0:
-            for condition in conditions:
-                if condition.get("type") == "slot":
-                    slot_name = condition.get("name")
-                    value = condition.get("value")
-                    if slot_name and tracker.get_slot(slot_name) != value:
-                        return False
-
-        return True
-
-    def _extract_response_ids(
-        self, domain: "Domain", tracker: "DialogueStateTracker"
-    ) -> List[Text]:
-        response_collection = domain.responses.get(self.utter_action, [])
-
-        utter_action_response_ids: List[Text] = []
-        for response in response_collection:
-            if response.get("id"):
-                conditions = response.get("condition") or []
-
-                if self._is_response_condition_satisfied(conditions, tracker):
-                    utter_action_response_ids.append(response["id"])
-
-        return utter_action_response_ids
 
 
 class ActionEndToEndResponse(Action):

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -312,7 +312,7 @@ class ActionBotResponse(Action):
             self.utter_action,
             tracker,
             output_channel.name(),
-            response_ids=response_ids_for_response,
+            response_ids=list(response_ids_for_response),
         )
         if message is None:
             if not self.silent_fail:

--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -21,6 +21,7 @@ from rasa.core.constants import (
     COMPRESS_ACTION_SERVER_REQUEST_ENV_NAME,
     DEFAULT_COMPRESS_ACTION_SERVER_REQUEST,
 )
+from rasa.core.nlg.callback import RESPONSE_ID_KEY
 from rasa.core.policies.policy import PolicyPrediction
 from rasa.nlu.constants import (
     RESPONSE_SELECTOR_DEFAULT_INTENT,
@@ -308,11 +309,19 @@ class ActionBotResponse(Action):
         response_ids_for_response = domain.response_ids_per_response.get(
             self.utter_action, set()
         )
+
+        response_id_list = list(response_ids_for_response)
+        response_id_list.sort()
+
+        kwargs = {
+            RESPONSE_ID_KEY: response_id_list,
+        }
+
         message = await nlg.generate(
             self.utter_action,
             tracker,
             output_channel.name(),
-            response_ids=list(response_ids_for_response),
+            **kwargs,
         )
         if message is None:
             if not self.silent_fail:

--- a/rasa/core/nlg/callback.py
+++ b/rasa/core/nlg/callback.py
@@ -27,6 +27,9 @@ def nlg_response_format_spec() -> Dict[Text, Any]:
     }
 
 
+RESPONSE_ID_KEY = "response_ids"
+
+
 def nlg_request_format(
     utter_action: Text,
     tracker: DialogueStateTracker,
@@ -35,9 +38,11 @@ def nlg_request_format(
 ) -> Dict[Text, Any]:
     """Create the json body for the NLG json body for the request."""
     tracker_state = tracker.current_state(EventVerbosity.ALL)
+    response_ids = kwargs.pop(RESPONSE_ID_KEY, [])
 
     return {
         "response": utter_action,
+        "ids": response_ids,
         "arguments": kwargs,
         "tracker": tracker_state,
         "channel": {"name": output_channel},

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1959,7 +1959,7 @@ class Domain:
     def _collect_response_ids_for_response_variations(
         response_variations: List[Dict[Text, Any]]
     ) -> Set[Text]:
-        """Collects all response ids for response variations.
+        """Collects all response ids of a particular response key name
 
         Args:
             response_variations: The responses variations to collect the ids from.

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -239,6 +239,7 @@ class Domain:
             warn_about_duplicates_found_during_domain_merging(duplicates)
 
         responses = data.get(KEY_RESPONSES, {})
+        cls._validate_response_ids(responses)
 
         domain_slots = data.get(KEY_SLOTS, {})
         if domain_slots:
@@ -1915,6 +1916,25 @@ class Domain:
                 action_names += [action]
 
         return action_names
+
+    @staticmethod
+    def _validate_response_ids(responses: Dict[Text, List[Dict[Text, Any]]]) -> None:
+        """Validates that all response ids are unique.
+
+        Raises:
+            ValueError: if there are any non-unique response ids.
+        """
+        response_ids = set()
+        for _, response_variations in responses.items():
+            for response_variation in response_variations:
+                response_variation_id = response_variation.get("id")
+                if response_variation_id:
+                    if response_variation_id in response_ids:
+                        raise RasaException(
+                            f"Duplicate response id "
+                            f"'{response_variation_id}' defined in domain."
+                        )
+                    response_ids.add(response_variation_id)
 
 
 def warn_about_duplicates_found_during_domain_merging(

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1945,7 +1945,7 @@ class Domain:
             )
 
             if len(already_present_response_ids) > 0:
-                raise RasaException(
+                rasa.shared.utils.io.raise_warning(
                     f"Duplicate response ids "
                     f"'{already_present_response_ids}' "
                     f"defined in domain."
@@ -1972,7 +1972,7 @@ class Domain:
             response_variation_id = response_variation.get("id")
             if response_variation_id:
                 if response_variation_id in response_ids:
-                    raise RasaException(
+                    rasa.shared.utils.io.raise_warning(
                         f"Duplicate response id '{response_variation_id}' "
                         f"defined in domain."
                     )

--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -1931,7 +1931,7 @@ class Domain:
         Returns:
             A dictionary mapping the response names to the set of response ids.
         """
-        response_ids = set()
+        response_ids: Set[Text] = set()
         response_ids_per_response: Dict[Text, Set[Text]] = {}
         for response_name, response_variations in responses.items():
             response_ids_for_response = (
@@ -1959,7 +1959,7 @@ class Domain:
     def _collect_response_ids_for_response_variations(
         response_variations: List[Dict[Text, Any]]
     ) -> Set[Text]:
-        """Collects all response ids of a particular response key name
+        """Collects all response ids of a particular response key name.
 
         Args:
             response_variations: The responses variations to collect the ids from.

--- a/rasa/shared/nlu/training_data/schemas/responses.yml
+++ b/rasa/shared/nlu/training_data/schemas/responses.yml
@@ -12,6 +12,9 @@ schema;responses:
         required: True
         allowempty: False
         mapping:
+          id:
+            type: "str"
+            required: False
           text:
             type: "str"
           image:

--- a/tests/core/nlg/callback.py
+++ b/tests/core/nlg/callback.py
@@ -1,0 +1,52 @@
+from rasa.core.nlg.callback import nlg_request_format
+from rasa.shared.core.trackers import DialogueStateTracker, EventVerbosity
+
+
+def test_nlg_request_format(
+    default_tracker: DialogueStateTracker,
+) -> None:
+    assert nlg_request_format(
+        utter_action="utter_one_id",
+        tracker=default_tracker,
+        output_channel="test",
+    ) == {
+        "response": "utter_one_id",
+        "ids": [],
+        "arguments": {},
+        "channel": {"name": "test"},
+        "tracker": default_tracker.current_state(EventVerbosity.ALL),
+    }
+
+
+def test_nlg_request_format_with_arguments(
+    default_tracker: DialogueStateTracker,
+) -> None:
+    assert nlg_request_format(
+        utter_action="utter_one_id",
+        tracker=default_tracker,
+        output_channel="test",
+        some_arg="some_value",
+    ) == {
+        "response": "utter_one_id",
+        "ids": [],
+        "arguments": {"some_arg": "some_value"},
+        "channel": {"name": "test"},
+        "tracker": default_tracker.current_state(EventVerbosity.ALL),
+    }
+
+
+def test_nlg_request_format_with_response_ids(
+    default_tracker: DialogueStateTracker,
+) -> None:
+    assert nlg_request_format(
+        utter_action="utter_one_id",
+        tracker=default_tracker,
+        output_channel="test",
+        response_ids=["1"],
+    ) == {
+        "response": "utter_one_id",
+        "ids": ["1"],
+        "arguments": {},
+        "channel": {"name": "test"},
+        "tracker": default_tracker.current_state(EventVerbosity.ALL),
+    }

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -851,7 +851,7 @@ async def test_action_bot_response_with_one_response_id(
     )
 
     mock_nlg.generate.assert_called_once_with(
-        "utter_one_id", default_tracker, output_channel.name(), response_ids={"1"}
+        "utter_one_id", default_tracker, output_channel.name(), response_ids=["1"]
     )
 
     assert len(events) == 1
@@ -875,7 +875,7 @@ async def test_action_bot_response_with_multiple_response_id(
         "utter_multiple_ids",
         default_tracker,
         output_channel.name(),
-        response_ids={"2", "3"},
+        response_ids=["2", "3"],
     )
 
     assert len(events) == 1
@@ -899,7 +899,7 @@ async def test_action_bot_response_with_empty_response_id_set(
         "utter_no_id",
         default_tracker,
         output_channel.name(),
-        response_ids=set(),
+        response_ids=[],
     )
 
     assert len(events) == 1
@@ -923,7 +923,7 @@ async def test_action_bot_response_with_non_existing_id_mapping(
         "utter_non_existing",
         default_tracker,
         output_channel.name(),
-        response_ids=set(),
+        response_ids=[],
     )
 
     assert len(events) == 1

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -1,8 +1,10 @@
+import asyncio
+
 import logging
 import textwrap
 from datetime import datetime
 from typing import List, Text, Any, Dict, Optional
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 from pytest import MonkeyPatch
@@ -28,6 +30,7 @@ from rasa.core.actions.action import (
 )
 from rasa.core.actions.forms import FormAction
 from rasa.core.channels import CollectingOutputChannel, OutputChannel
+from rasa.core.channels.slack import SlackBot
 from rasa.core.constants import COMPRESS_ACTION_SERVER_REQUEST_ENV_NAME
 from rasa.core.nlg import NaturalLanguageGenerator
 from rasa.shared.constants import (
@@ -89,6 +92,7 @@ from rasa.shared.core.constants import (
     SESSION_START_METADATA_SLOT,
     ACTION_EXTRACT_SLOTS,
 )
+from rasa.shared.core.slots import TextSlot
 from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.shared.exceptions import RasaException
 from rasa.utils.endpoints import ClientResponseError, EndpointConfig
@@ -783,7 +787,6 @@ async def test_response_invalid_response(
 
 
 async def test_response_channel_specific(default_nlg, default_tracker, domain: Domain):
-    from rasa.core.channels.slack import SlackBot
 
     output_channel = SlackBot("DummyToken", "General")
 
@@ -797,6 +800,174 @@ async def test_response_channel_specific(default_nlg, default_tracker, domain: D
             metadata={"channel": "slack", "utter_action": "utter_channel"},
         )
     ]
+
+
+@pytest.fixture
+def default_tracker_with_slots(
+    default_tracker: DialogueStateTracker,
+) -> DialogueStateTracker:
+    return DialogueStateTracker(
+        "my-sender",
+        [
+            TextSlot(name="name", mappings=[], initial_value="rasa"),
+            TextSlot(name="last_name", mappings=[], initial_value="rasic"),
+        ],
+    )
+
+
+@pytest.fixture
+def domain_with_response_ids(domain: Domain) -> Domain:
+    domain.responses = {
+        "utter_one_id": [{"text": "this is a default channel", "id": "1"}],
+        "utter_multiple_ids": [
+            {
+                "text": "button message",
+                "id": "2",
+            },
+            {
+                "text": "another button message",
+                "id": "3",
+            },
+        ],
+        "utter_no_ids": [{"text": "I am a bot."}],
+        "utter_ids_with_one_condition": [
+            {
+                "text": "I am a bot.",
+                "id": "4",
+                "condition": [
+                    {
+                        "type": "slot",
+                        "name": "name",
+                        "value": "rasa",
+                    }
+                ],
+            }
+        ],
+        "utter_ids_with_multiple_conditions": [
+            {
+                "text": "I am a bot bot.",
+                "id": "5",
+                "condition": [
+                    {
+                        "type": "slot",
+                        "name": "name",
+                        "value": "rasa",
+                    },
+                    {
+                        "type": "slot",
+                        "name": "last_name",
+                        "value": "rasic",
+                    },
+                ],
+            }
+        ],
+        "utter_ids_with_unsatisfied_conditions": [
+            {
+                "text": "I am a bot bot.",
+                "id": "5",
+                "condition": [
+                    {
+                        "type": "slot",
+                        "name": "name",
+                        "value": "not_satisfied",
+                    },
+                ],
+            }
+        ],
+    }
+    return domain
+
+
+def test_action_bot_response_ids(
+    domain_with_response_ids: Domain, default_tracker: DialogueStateTracker
+) -> None:
+    response_ids = ActionBotResponse("utter_one_id")._extract_response_ids(
+        domain_with_response_ids, default_tracker
+    )
+    assert response_ids == ["1"]
+
+
+def test_action_bot_with_multiple_response_ids(
+    domain_with_response_ids: Domain, default_tracker: DialogueStateTracker
+) -> None:
+    response_ids = ActionBotResponse("utter_multiple_ids")._extract_response_ids(
+        domain_with_response_ids, default_tracker
+    )
+    assert response_ids == ["2", "3"]
+
+
+def test_action_bot_with_no_response_ids(
+    domain_with_response_ids: Domain, default_tracker: DialogueStateTracker
+) -> None:
+    response_ids = ActionBotResponse("utter_no_ids")._extract_response_ids(
+        domain_with_response_ids, default_tracker
+    )
+    assert response_ids == []
+
+
+def test_action_bot_with_response_ids_and_one_condition(
+    domain_with_response_ids: Domain, default_tracker_with_slots: DialogueStateTracker
+) -> None:
+    response_ids = ActionBotResponse(
+        "utter_ids_with_one_condition"
+    )._extract_response_ids(domain_with_response_ids, default_tracker_with_slots)
+    assert response_ids == ["4"]
+
+
+def test_action_bot_with_response_ids_and_multiple_conditions(
+    domain_with_response_ids: Domain, default_tracker_with_slots: DialogueStateTracker
+) -> None:
+    response_ids = ActionBotResponse(
+        "utter_ids_with_multiple_conditions"
+    )._extract_response_ids(domain_with_response_ids, default_tracker_with_slots)
+    assert response_ids == ["5"]
+
+
+def test_action_bot_with_response_ids_and_unsatisfied_conditions(
+    domain_with_response_ids: Domain, default_tracker_with_slots: DialogueStateTracker
+) -> None:
+    response_ids = ActionBotResponse(
+        "utter_ids_with_unsatisfied_conditions"
+    )._extract_response_ids(domain_with_response_ids, default_tracker_with_slots)
+    assert response_ids == []
+
+
+@pytest.fixture
+def mock_message() -> Dict[Text, Any]:
+    return {"text": "test", "response_ids": ["1"]}
+
+
+@pytest.fixture
+def mock_nlg(mock_message, monkeypatch: MonkeyPatch) -> MagicMock:
+    _mock_nlg = MagicMock()
+
+    future = asyncio.Future()
+    future.set_result(mock_message)
+
+    _mock_nlg.generate = MagicMock()
+    _mock_nlg.generate.return_value = future
+    return _mock_nlg
+
+
+async def test_action_bot_response_with_response_ids(
+    mock_message: Dict[Text, Any],
+    mock_nlg: MagicMock,
+    default_channel,
+    default_tracker,
+    domain_with_response_ids: Domain,
+) -> None:
+    output_channel = SlackBot("DummyToken", "General")
+
+    events = await ActionBotResponse("utter_one_id").run(
+        output_channel, mock_nlg, default_tracker, domain_with_response_ids
+    )
+
+    mock_nlg.generate.assert_called_once_with(
+        "utter_one_id", default_tracker, output_channel.name(), response_ids=["1"]
+    )
+
+    assert len(events) == 1
+    assert events[0].metadata == mock_message
 
 
 async def test_action_back(

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -844,7 +844,7 @@ async def test_action_bot_response_with_one_response_id(
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = SlackBot("DummyToken", "General")
+    output_channel = CollectingOutputChannel()
 
     events = await ActionBotResponse("utter_one_id").run(
         output_channel, mock_nlg, default_tracker, domain_with_response_ids
@@ -865,7 +865,7 @@ async def test_action_bot_response_with_multiple_response_id(
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = SlackBot("DummyToken", "General")
+    output_channel = CollectingOutputChannel()
 
     events = await ActionBotResponse("utter_multiple_ids").run(
         output_channel, mock_nlg, default_tracker, domain_with_response_ids
@@ -889,7 +889,7 @@ async def test_action_bot_response_with_empty_response_id_set(
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = SlackBot("DummyToken", "General")
+    output_channel = CollectingOutputChannel()
 
     events = await ActionBotResponse("utter_no_id").run(
         output_channel, mock_nlg, default_tracker, domain_with_response_ids
@@ -913,7 +913,7 @@ async def test_action_bot_response_with_non_existing_id_mapping(
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = SlackBot("DummyToken", "General")
+    output_channel = CollectingOutputChannel()
 
     events = await ActionBotResponse("utter_non_existing").run(
         output_channel, mock_nlg, default_tracker, domain_with_response_ids

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -838,96 +838,72 @@ def mock_nlg(mock_message, monkeypatch: MonkeyPatch) -> MagicMock:
 
 
 async def test_action_bot_response_with_one_response_id(
-    mock_message: Dict[Text, Any],
     mock_nlg: MagicMock,
     default_channel,
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = CollectingOutputChannel()
-
-    events = await ActionBotResponse("utter_one_id").run(
-        output_channel, mock_nlg, default_tracker, domain_with_response_ids
+    await ActionBotResponse("utter_one_id").run(
+        default_channel, mock_nlg, default_tracker, domain_with_response_ids
     )
 
     mock_nlg.generate.assert_called_once_with(
-        "utter_one_id", default_tracker, output_channel.name(), response_ids=["1"]
+        "utter_one_id", default_tracker, default_channel.name(), response_ids=["1"]
     )
-
-    assert len(events) == 1
-    assert events[0].metadata == mock_message
 
 
 async def test_action_bot_response_with_multiple_response_id(
-    mock_message: Dict[Text, Any],
     mock_nlg: MagicMock,
     default_channel,
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = CollectingOutputChannel()
-
-    events = await ActionBotResponse("utter_multiple_ids").run(
-        output_channel, mock_nlg, default_tracker, domain_with_response_ids
+    await ActionBotResponse("utter_multiple_ids").run(
+        default_channel, mock_nlg, default_tracker, domain_with_response_ids
     )
 
     mock_nlg.generate.assert_called_once_with(
         "utter_multiple_ids",
         default_tracker,
-        output_channel.name(),
+        default_channel.name(),
         response_ids=["2", "3"],
     )
 
-    assert len(events) == 1
-    assert events[0].metadata == mock_message
-
 
 async def test_action_bot_response_with_empty_response_id_set(
-    mock_message: Dict[Text, Any],
     mock_nlg: MagicMock,
     default_channel,
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = CollectingOutputChannel()
-
-    events = await ActionBotResponse("utter_no_id").run(
-        output_channel, mock_nlg, default_tracker, domain_with_response_ids
+    await ActionBotResponse("utter_no_id").run(
+        default_channel, mock_nlg, default_tracker, domain_with_response_ids
     )
 
     mock_nlg.generate.assert_called_once_with(
         "utter_no_id",
         default_tracker,
-        output_channel.name(),
+        default_channel.name(),
         response_ids=[],
     )
 
-    assert len(events) == 1
-    assert events[0].metadata == mock_message
-
 
 async def test_action_bot_response_with_non_existing_id_mapping(
-    mock_message: Dict[Text, Any],
     mock_nlg: MagicMock,
     default_channel,
     default_tracker,
     domain_with_response_ids: Domain,
 ) -> None:
-    output_channel = CollectingOutputChannel()
-
-    events = await ActionBotResponse("utter_non_existing").run(
-        output_channel, mock_nlg, default_tracker, domain_with_response_ids
+    await ActionBotResponse("utter_non_existing").run(
+        default_channel, mock_nlg, default_tracker, domain_with_response_ids
     )
 
     mock_nlg.generate.assert_called_once_with(
         "utter_non_existing",
         default_tracker,
-        output_channel.name(),
+        default_channel.name(),
         response_ids=[],
     )
-
-    assert len(events) == 1
-    assert events[0].metadata == mock_message
 
 
 async def test_action_back(

--- a/tests/integration_tests/core/actions/conftest.py
+++ b/tests/integration_tests/core/actions/conftest.py
@@ -1,0 +1,85 @@
+from typing import Text
+import copy
+import pytest
+
+from rasa.shared.core.domain import Domain
+from rasa.shared.core.trackers import DialogueStateTracker
+
+
+@pytest.fixture(scope="session")
+def domain_yaml_content() -> Text:
+    return """
+intents:
+ - greet
+ - default
+ - goodbye
+ - affirm
+ - thank_you
+ - change_bank_details
+ - simple
+ - hello
+ - why
+ - next_intent
+
+entities:
+ - name
+
+slots:
+  name:
+    type: text
+    mappings:
+      - type: from_entity
+        entity: name
+
+responses:
+  utter_greet:
+    - text: "hey there {name}!"
+  utter_channel:
+    - text: "this is a default channel"
+    - text: "you're talking to me on slack!"
+      channel: "slack"
+  utter_goodbye:
+    - text: "goodbye 😢"
+    - text: "bye bye 😢"
+  utter_default:
+    - text: "sorry, I didn't get that, can you rephrase it?"
+
+forms:
+  some_form:
+    required_slots:
+      - name
+"""
+
+
+@pytest.fixture(scope="session")
+def _domain(domain_yaml_content: Text) -> Domain:
+    return Domain.from_yaml(domain_yaml_content)
+
+
+@pytest.fixture()
+def domain(_domain: Domain) -> Domain:
+    return copy.deepcopy(_domain)
+
+
+@pytest.fixture
+def default_tracker(domain: Domain) -> DialogueStateTracker:
+    return DialogueStateTracker("my-sender", domain.slots)
+
+
+@pytest.fixture
+def domain_with_response_ids() -> Domain:
+    domain_yaml = """
+    responses:
+        utter_one_id:
+            - text: test
+              id: '1'
+        utter_multiple_ids:
+            - text: test
+              id: '2'
+            - text: test
+              id: '3'
+        utter_no_id:
+            - text: test
+    """
+    domain = Domain.from_yaml(domain_yaml)
+    return domain

--- a/tests/integration_tests/core/actions/test_action.py
+++ b/tests/integration_tests/core/actions/test_action.py
@@ -39,7 +39,7 @@ async def test_action_bot_response_callback_nlg(
     )
 
     body = nlg_request_format(
-        "utter_one_id", default_tracker, output_channel.name(), response_ids={"1"}
+        "utter_one_id", default_tracker, output_channel.name(), response_ids=["1"]
     )
 
     mock_nlg_endpoint.request.assert_called_once_with(

--- a/tests/integration_tests/core/actions/test_action.py
+++ b/tests/integration_tests/core/actions/test_action.py
@@ -1,0 +1,50 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from rasa.core.actions.action import ActionBotResponse
+from rasa.core.channels.slack import SlackBot
+from rasa.core.constants import DEFAULT_REQUEST_TIMEOUT
+from rasa.core.nlg import CallbackNaturalLanguageGenerator
+from rasa.core.nlg.callback import nlg_request_format
+from rasa.shared.core.domain import Domain
+from rasa.shared.core.trackers import DialogueStateTracker
+
+
+@pytest.fixture
+def mock_nlg_endpoint() -> MagicMock:
+    _mock_nlg_endpoint = MagicMock()
+
+    future = asyncio.Future()
+    future.set_result({})
+
+    _mock_nlg_endpoint.request = MagicMock()
+    _mock_nlg_endpoint.request.return_value = future
+    return _mock_nlg_endpoint
+
+
+async def test_action_bot_response_callback_nlg(
+    domain_with_response_ids: Domain,
+    default_tracker: DialogueStateTracker,
+    mock_nlg_endpoint: MagicMock,
+):
+    """Test the response returned by the callback NLG endpoint."""
+    callback_nlg = CallbackNaturalLanguageGenerator(mock_nlg_endpoint)
+
+    output_channel = SlackBot("DummyToken", "General")
+
+    events = await ActionBotResponse("utter_one_id").run(
+        output_channel, callback_nlg, default_tracker, domain_with_response_ids
+    )
+
+    body = nlg_request_format(
+        "utter_one_id", default_tracker, output_channel.name(), response_ids={"1"}
+    )
+
+    mock_nlg_endpoint.request.assert_called_once_with(
+        method="post", json=body, timeout=DEFAULT_REQUEST_TIMEOUT
+    )
+
+    assert len(events) == 1
+    assert events[0].metadata == {"utter_action": "utter_one_id"}

--- a/tests/integration_tests/core/actions/test_action.py
+++ b/tests/integration_tests/core/actions/test_action.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from rasa.core.actions.action import ActionBotResponse
-from rasa.core.channels.slack import SlackBot
+from rasa.core.channels import CollectingOutputChannel
 from rasa.core.constants import DEFAULT_REQUEST_TIMEOUT
 from rasa.core.nlg import CallbackNaturalLanguageGenerator
 from rasa.core.nlg.callback import nlg_request_format
@@ -32,7 +32,7 @@ async def test_action_bot_response_callback_nlg(
     """Test the response returned by the callback NLG endpoint."""
     callback_nlg = CallbackNaturalLanguageGenerator(mock_nlg_endpoint)
 
-    output_channel = SlackBot("DummyToken", "General")
+    output_channel = CollectingOutputChannel()
 
     events = await ActionBotResponse("utter_one_id").run(
         output_channel, callback_nlg, default_tracker, domain_with_response_ids

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -2350,19 +2350,79 @@ def test_merge_yaml_domains_loads_actions_which_explicitly_need_domain():
         ),
     ],
 )
-def test_domain_responses_with_ids(domain_yaml, expected) -> None:
+def test_domain_responses_with_ids_are_loaded(domain_yaml, expected) -> None:
     domain = Domain.from_yaml(domain_yaml)
     assert domain.responses == expected
 
 
-def test_domain_responses_with_same_ids_are_not_allowed() -> None:
-    domain_yaml = """
+@pytest.mark.parametrize(
+    "domain_yaml, expected",
+    [
+        (
+            """
             responses:
                 utter_greet:
                 - text: hey there!
-                  id: '1234'
+                  id: '1233'
                 - text: hey ho!
                   id: '1234'
+            """,
+            {
+                "utter_greet": {"1233", "1234"},
+            },
+        ),
+        (
             """
+            responses:
+                utter_greet:
+                - text: hey there!
+                - text: hey ho!
+                  id: '1234'
+            """,
+            {
+                "utter_greet": {"1234"},
+            },
+        ),
+        (
+            """
+            responses:
+                utter_greet:
+                - text: hey there!
+                - text: hey ho!
+            """,
+            {
+                "utter_greet": set(),
+            },
+        ),
+    ],
+)
+def test_domain_responses_ids_per_response_is_collected(domain_yaml, expected) -> None:
+    domain = Domain.from_yaml(domain_yaml)
+    assert domain.response_ids_per_response == expected
+
+
+@pytest.mark.parametrize(
+    "domain_yaml",
+    [
+        """
+        responses:
+            utter_greet:
+            - text: hey there!
+              id: '1234'
+            - text: hey ho!
+              id: '1234'
+        """,
+        """
+        responses:
+            utter_greet:
+            - text: hey there!
+              id: '1234'
+            utter_goodbye:
+            - text: bye!
+              id: '1234'
+        """,
+    ],
+)
+def test_domain_responses_with_same_ids_are_not_allowed(domain_yaml: Text) -> None:
     with pytest.raises(RasaException):
         Domain.from_yaml(domain_yaml)

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -7,7 +7,6 @@ import random
 from typing import Dict, List, Text, Any, Union, Set, Optional
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from pytest import WarningsRecorder
 
 from rasa.shared.exceptions import YamlSyntaxException, YamlException

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -2433,10 +2433,6 @@ def test_domain_responses_ids_per_response_is_collected(domain_yaml, expected) -
 def test_domain_responses_with_same_ids_are_not_allowed(
     domain_yaml: Text,
     expected_message: Text,
-    caplog: LogCaptureFixture,
 ) -> None:
-    caplog.clear()
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UserWarning, match=expected_message):
         Domain.from_yaml(domain_yaml)
-    assert len(record) == 1
-    assert record[0].message.args[0] == expected_message


### PR DESCRIPTION
Adding capability to set id for response variations in `domain.yml`.
Ids will be transmitted to the NLG so that NLG can make more informed decision when choosing appropriate response.
If response has a condition set then it will be examined before ID is transmitted to the NLG. 

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
