### PR TITLE
Implement bugfix for custom form validation during form activation in `3.4.x`

### DIFF
--- a/changelog/12467.bugfix.md
+++ b/changelog/12467.bugfix.md
@@ -1,0 +1,2 @@
+Fix running custom form validation to update required slots at form activation when prefilled slots consist only of slots
+that are not requested by the form.

--- a/rasa/core/actions/forms.py
+++ b/rasa/core/actions/forms.py
@@ -605,9 +605,21 @@ class FormAction(LoopAction):
 
         if not prefilled_slots:
             logger.debug("No pre-filled required slots to validate.")
-            return [e for e in extraction_events if isinstance(e, SlotSet)]
+        else:
+            logger.debug(f"Validating pre-filled required slots: {prefilled_slots}.")
 
-        logger.debug(f"Validating pre-filled required slots: {prefilled_slots}")
+        validate_name = f"validate_{self.name()}"
+
+        if validate_name not in domain.action_names_or_texts:
+            logger.debug(
+                f"There is no validation action '{validate_name}' "
+                f"to execute at form activation."
+            )
+            return [event for event in extraction_events if isinstance(event, SlotSet)]
+
+        logger.debug(
+            f"Executing validation action '{validate_name}' at form activation."
+        )
 
         validated_events = await self.validate_slots(
             prefilled_slots, tracker, domain, output_channel, nlg


### PR DESCRIPTION
* run custom form validation on form activation

* add changelog entry

* update tests, rename var

(cherry picked from commit db0f81d6d009f17a715f56972da45537d25d35ee)

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
