### PR TITLE
[ATO-1139] add an optional description key in the markers yaml format in rasa oss

### DIFF
--- a/rasa/core/evaluation/marker_base.py
+++ b/rasa/core/evaluation/marker_base.py
@@ -161,7 +161,12 @@ class Marker(ABC):
     # from a dictionary of configs. For more details, see `from_config_dict`.
     ANY_MARKER = "<any_marker>"
 
-    def __init__(self, name: Optional[Text] = None, negated: bool = False, description: Optional[Text] = None) -> None:
+    def __init__(
+        self,
+        name: Optional[Text] = None,
+        negated: bool = False,
+        description: Optional[Text] = None,
+    ) -> None:
         """Instantiates a marker.
 
         Args:
@@ -568,11 +573,17 @@ class Marker(ABC):
         tag, _ = MarkerRegistry.get_non_negated_tag(tag_or_negated_tag=tag)
         if tag in MarkerRegistry.operator_tag_to_marker_class:
             return OperatorMarker.from_tag_and_sub_config(
-                tag=tag, sub_config=sub_marker_config, name=name, description=description
+                tag=tag,
+                sub_config=sub_marker_config,
+                name=name,
+                description=description,
             )
         elif tag in MarkerRegistry.condition_tag_to_marker_class:
             return ConditionMarker.from_tag_and_sub_config(
-                tag=tag, sub_config=sub_marker_config, name=name, description=description
+                tag=tag,
+                sub_config=sub_marker_config,
+                name=name,
+                description=description,
             )
 
         raise InvalidMarkerConfig(
@@ -774,7 +785,10 @@ class OperatorMarker(Marker, ABC):
 
     @staticmethod
     def from_tag_and_sub_config(
-        tag: Text, sub_config: Any, name: Optional[Text] = None, description: Optional[Text] = None,
+        tag: Text,
+        sub_config: Any,
+        name: Optional[Text] = None,
+        description: Optional[Text] = None,
     ) -> OperatorMarker:
         """Creates an operator marker from the given config.
 
@@ -861,7 +875,10 @@ class ConditionMarker(Marker, ABC):
 
     @staticmethod
     def from_tag_and_sub_config(
-        tag: Text, sub_config: Any, name: Optional[Text] = None, description: Optional[Text] = None,
+        tag: Text,
+        sub_config: Any,
+        name: Optional[Text] = None,
+        description: Optional[Text] = None,
     ) -> ConditionMarker:
         """Creates an atomic marker from the given config.
 

--- a/tests/core/evaluation/test_marker.py
+++ b/tests/core/evaluation/test_marker.py
@@ -736,6 +736,7 @@ def test_split_sessions(tmp_path):
     assert len(sessions) == 1
     assert len(sessions[0][0]) == len(events)
 
+
 def test_marker_with_description():
     marker = SlotSetMarker("s1", description="This is a description")
     assert marker.description == "This is a description"

--- a/tests/core/evaluation/test_marker.py
+++ b/tests/core/evaluation/test_marker.py
@@ -735,3 +735,8 @@ def test_split_sessions(tmp_path):
     sessions = Marker._split_sessions(events)
     assert len(sessions) == 1
     assert len(sessions[0][0]) == len(events)
+
+def test_marker_with_description():
+    marker = SlotSetMarker("s1", description="This is a description")
+    assert marker.description == "This is a description"
+    assert marker.negated_tag() is None


### PR DESCRIPTION
**Proposed changes**:
- Add an optional `description` key in the markers YAML config. This can be used for documentation of the marker

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
