### PR TITLE
[ATO-1152] Port of Add license hashes to telemetry

### DIFF
--- a/changelog/12512.misc.md
+++ b/changelog/12512.misc.md
@@ -1,0 +1,1 @@
+Add plugin hook for getting the license hash from Rasa Plus and add the hash to telemetry context.

--- a/changelog/12512.misc.md
+++ b/changelog/12512.misc.md
@@ -1,1 +1,0 @@
-Add plugin hook for getting the license hash from Rasa Plus and add the hash to telemetry context.

--- a/docs/docs/telemetry/telemetry.mdx
+++ b/docs/docs/telemetry/telemetry.mdx
@@ -119,7 +119,7 @@ Here is an example report that shows the data reported to Rasa after running
     "python": "3.7.5",
     "rasa_open_source": "2.0.0",
     "cpu": 16,
-    "license_hash": "a0a7178e6e5f9e6484c5cfa3ea4497ffc0c96a0ad3f3ad8e9399adadd88e3cf4"
+    "license_hash": "t1a7170e6e5f9e6484c5cfa3ea4497ffc0c96a0ad3f3ad8e9399adadd88e3cf5"
   }
 }
 ```

--- a/docs/docs/telemetry/telemetry.mdx
+++ b/docs/docs/telemetry/telemetry.mdx
@@ -81,6 +81,7 @@ Specifically, we collect the following information for all telemetry events:
 - General OS level information (operating system, number of CPUs, number of
   GPUs and whether the command is run inside a CI)
 - Current Rasa and Python version
+- Hash of the license (if you are using Rasa Pro)
 
 Here is an example report that shows the data reported to Rasa after running
 `rasa train`:
@@ -117,7 +118,8 @@ Here is an example report that shows the data reported to Rasa after running
     "project": "a0a7178e6e5f9e6484c5cfa3ea4497ffc0c96d0ad3f3ad8e9399a1edd88e3cf4",
     "python": "3.7.5",
     "rasa_open_source": "2.0.0",
-    "cpu": 16
+    "cpu": 16,
+    "license_hash": "a0a7178e6e5f9e6484c5cfa3ea4497ffc0c96a0ad3f3ad8e9399adadd88e3cf4"
   }
 }
 ```

--- a/docs/docs/telemetry/telemetry.mdx
+++ b/docs/docs/telemetry/telemetry.mdx
@@ -81,6 +81,7 @@ Specifically, we collect the following information for all telemetry events:
 - General OS level information (operating system, number of CPUs, number of
   GPUs and whether the command is run inside a CI)
 - Current Rasa and Python version
+- Whether the command is run inside a Docker container
 - Hash of the license (if you are using Rasa Pro)
 
 Here is an example report that shows the data reported to Rasa after running
@@ -119,6 +120,7 @@ Here is an example report that shows the data reported to Rasa after running
     "python": "3.7.5",
     "rasa_open_source": "2.0.0",
     "cpu": 16,
+    "docker": false,
     "license_hash": "t1a7170e6e5f9e6484c5cfa3ea4497ffc0c96a0ad3f3ad8e9399adadd88e3cf5"
   }
 }

--- a/rasa/plugin.py
+++ b/rasa/plugin.py
@@ -143,3 +143,8 @@ def init_anonymization_pipeline(endpoints_file: Optional[Text]) -> None:
 @hookspec(firstresult=True)  # type: ignore[misc]
 def get_anonymization_pipeline() -> Optional[Any]:
     """Hook specification for getting the anonymization pipeline."""
+
+
+@hookspec  # type: ignore[misc]
+def get_license_hash() -> Optional[Text]:
+    """Hook specification for getting the license hash."""

--- a/rasa/plugin.py
+++ b/rasa/plugin.py
@@ -145,6 +145,6 @@ def get_anonymization_pipeline() -> Optional[Any]:
     """Hook specification for getting the anonymization pipeline."""
 
 
-@hookspec  # type: ignore[misc]
+@hookspec(firstresult=True)  # type: ignore[misc]
 def get_license_hash() -> Optional[Text]:
     """Hook specification for getting the license hash."""

--- a/rasa/telemetry.py
+++ b/rasa/telemetry.py
@@ -26,6 +26,7 @@ from rasa.constants import (
     CONFIG_TELEMETRY_ID,
 )
 from rasa.engine.storage.local_model_storage import LocalModelStorage
+from rasa.plugin import plugin_manager
 from rasa.shared.constants import DOCS_URL_TELEMETRY
 from rasa.shared.exceptions import RasaException
 import rasa.shared.utils.io
@@ -488,6 +489,7 @@ def _default_context_fields() -> Dict[Text, Any]:
             "python": sys.version.split(" ")[0],
             "rasa_open_source": rasa.__version__,
             "cpu": multiprocessing.cpu_count(),
+            "license_hash": plugin_manager().hook.get_license_hash(),
             "docker": _is_docker(),
         }
 

--- a/rasa/telemetry.py
+++ b/rasa/telemetry.py
@@ -489,9 +489,11 @@ def _default_context_fields() -> Dict[Text, Any]:
             "python": sys.version.split(" ")[0],
             "rasa_open_source": rasa.__version__,
             "cpu": multiprocessing.cpu_count(),
-            "license_hash": plugin_manager().hook.get_license_hash(),
             "docker": _is_docker(),
         }
+        license_hash = plugin_manager().hook.get_license_hash()
+        if license_hash:
+            TELEMETRY_CONTEXT["license_hash"] = license_hash
 
     # avoid returning the cached dict --> caller could modify the dictionary...
     # usually we would use `lru_cache`, but that doesn't return a dict copy and

--- a/rasa/telemetry.py
+++ b/rasa/telemetry.py
@@ -492,6 +492,7 @@ def _default_context_fields() -> Dict[Text, Any]:
             "docker": _is_docker(),
         }
         license_hash = plugin_manager().hook.get_license_hash()
+        print("LLLLLLLLLLLLLLL",license_hash)
         if license_hash:
             TELEMETRY_CONTEXT["license_hash"] = license_hash
 

--- a/rasa/telemetry.py
+++ b/rasa/telemetry.py
@@ -492,7 +492,6 @@ def _default_context_fields() -> Dict[Text, Any]:
             "docker": _is_docker(),
         }
         license_hash = plugin_manager().hook.get_license_hash()
-        print("LLLLLLLLLLLLLLL",license_hash)
         if license_hash:
             TELEMETRY_CONTEXT["license_hash"] = license_hash
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -34,6 +34,15 @@ def patch_global_config_path(tmp_path: Path) -> Generator[None, None, None]:
     rasa.constants.GLOBAL_USER_CONFIG_PATH = default_location
 
 
+@pytest.fixture(autouse=True)
+def patch_telemetry_context() -> Generator[None, None, None]:
+    """Use a new telemetry context for each test to avoid tests influencing each other."""
+    defaut_context = telemetry.TELEMETRY_CONTEXT
+    telemetry.TELEMETRY_CONTEXT = None
+    yield
+    telemetry.TELEMETRY_CONTEXT = defaut_context
+
+
 async def test_events_schema(
     monkeypatch: MonkeyPatch, default_agent: Agent, config_path: Text
 ):
@@ -489,7 +498,6 @@ def test_context_contains_os():
 
 def test_context_contains_license_hash(monkeypatch: MonkeyPatch) -> None:
     mock = MagicMock()
-    telemetry.TELEMETRY_CONTEXT = None # make sure we don't use the cached value
     mock.return_value.hook.get_license_hash.return_value = "1234567890"
     monkeypatch.setattr("rasa.telemetry.plugin_manager", mock)
     context = telemetry._default_context_fields()
@@ -505,7 +513,6 @@ def test_context_contains_license_hash(monkeypatch: MonkeyPatch) -> None:
 
 def test_context_does_not_contain_license_hash(monkeypatch: MonkeyPatch) -> None:
     mock = MagicMock()
-    telemetry.TELEMETRY_CONTEXT = None # make sure we don't use the cached value
     mock.return_value.hook.get_license_hash.return_value = None
     monkeypatch.setattr("rasa.telemetry.plugin_manager", mock)
     context = telemetry._default_context_fields()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -485,3 +485,13 @@ def test_context_contains_os():
     context.pop("os")
 
     assert "os" in telemetry._default_context_fields()
+
+
+def test_context_contains_license_hash():
+    context = telemetry._default_context_fields()
+
+    assert "license_hash" in context
+
+    context.pop("license_hash")
+
+    assert "license_hash" in telemetry._default_context_fields()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -489,6 +489,7 @@ def test_context_contains_os():
 
 def test_context_contains_license_hash(monkeypatch: MonkeyPatch):
     mock = MagicMock()
+    telemetry.TELEMETRY_CONTEXT = None # make sure we don't use the cached value
     mock.return_value.hook.get_license_hash.return_value = "1234567890"
     monkeypatch.setattr("rasa.telemetry.plugin_manager", mock)
     context = telemetry._default_context_fields()
@@ -504,6 +505,7 @@ def test_context_contains_license_hash(monkeypatch: MonkeyPatch):
 
 def test_context_does_not_contain_license_hash(monkeypatch: MonkeyPatch):
     mock = MagicMock()
+    telemetry.TELEMETRY_CONTEXT = None # make sure we don't use the cached value
     mock.return_value.hook.get_license_hash.return_value = None
     monkeypatch.setattr("rasa.telemetry.plugin_manager", mock)
     context = telemetry._default_context_fields()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -487,7 +487,7 @@ def test_context_contains_os():
     assert "os" in telemetry._default_context_fields()
 
 
-def test_context_contains_license_hash(monkeypatch: MonkeyPatch):
+def test_context_contains_license_hash(monkeypatch: MonkeyPatch) -> None:
     mock = MagicMock()
     telemetry.TELEMETRY_CONTEXT = None # make sure we don't use the cached value
     mock.return_value.hook.get_license_hash.return_value = "1234567890"
@@ -503,7 +503,7 @@ def test_context_contains_license_hash(monkeypatch: MonkeyPatch):
     assert "license_hash" in telemetry._default_context_fields()
 
 
-def test_context_does_not_contain_license_hash(monkeypatch: MonkeyPatch):
+def test_context_does_not_contain_license_hash(monkeypatch: MonkeyPatch) -> None:
     mock = MagicMock()
     telemetry.TELEMETRY_CONTEXT = None # make sure we don't use the cached value
     mock.return_value.hook.get_license_hash.return_value = None


### PR DESCRIPTION
**Proposed changes**:
- Port fix to [ATO-1152](https://github.com/RasaHQ/rasa/pull/12512)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-1152]: https://rasahq.atlassian.net/browse/ATO-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ