### PR TITLE
Add setting no user prediction flag to give flow priority in ensemble

### DIFF
--- a/rasa/core/policies/flow_policy.py
+++ b/rasa/core/policies/flow_policy.py
@@ -201,6 +201,10 @@ class FlowPolicy(Policy):
             prediction.score,
             prediction.events,
             prediction.metadata,
+            is_no_user_prediction=(
+                prediction.action_name is not None
+                and prediction.action_name != ACTION_LISTEN_NAME
+            ),
         )
 
     def _create_prediction_result(
@@ -210,6 +214,7 @@ class FlowPolicy(Policy):
         score: float = 1.0,
         events: Optional[List[Event]] = None,
         action_metadata: Optional[Dict[Text, Any]] = None,
+        is_no_user_prediction: bool = False,
     ) -> PolicyPrediction:
         """Creates a prediction result.
 
@@ -225,7 +230,10 @@ class FlowPolicy(Policy):
         if action_name:
             result[domain.index_for_action(action_name)] = score
         return self._prediction(
-            result, optional_events=events, action_metadata=action_metadata
+            result,
+            optional_events=events,
+            action_metadata=action_metadata,
+            is_no_user_prediction=is_no_user_prediction,
         )
 
 

--- a/rasa/nlu/classifiers/flow_prompt_template.jinja2
+++ b/rasa/nlu/classifiers/flow_prompt_template.jinja2
@@ -4,6 +4,7 @@ These are the flows that can be started, with their description and slots:
 {% for flow in available_flows %}
 - {{ flow.name }}: {{ flow.description }} (slots: {{ flow.slots }})
 {%- endfor %}
+- noflow: no flow can be started (slots: [])
 
 Here is what happened previously in the conversation:
 {{ current_conversation }}


### PR DESCRIPTION
**Proposed changes**:
In ensemble we give priority to `active_loop` runners by setting flag `no_user_prediction`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
