### PR TITLE
[ATO-797] Port of rasa data validate does not catch domain loading as an error

### DIFF
--- a/changelog/12549.bugfix.md
+++ b/changelog/12549.bugfix.md
@@ -1,0 +1,1 @@
+Introduce a validation step in `rasa data validate` command to identify non-existent paths and empty domains.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -98,6 +98,20 @@ def run_in_simple_project(testdir: Testdir) -> Callable[..., RunResult]:
 
 
 @pytest.fixture
+def run_in_simple_project_with_no_domain(testdir: Testdir) -> Callable[..., RunResult]:
+    os.environ["LOG_LEVEL"] = "WARNING"
+
+    create_simple_project(testdir.tmpdir)
+    Path(testdir.tmpdir / "domain.yml").unlink()
+
+    def do_run(*args):
+        args = [shutil.which(RASA_EXE)] + list(args)
+        return testdir.run(*args)
+
+    return do_run
+
+
+@pytest.fixture
 def run_in_simple_project_with_model(
     testdir: Testdir, trained_simple_project: Text
 ) -> Callable[..., RunResult]:

--- a/tests/cli/test_rasa_data.py
+++ b/tests/cli/test_rasa_data.py
@@ -183,6 +183,8 @@ def test_data_validate_stories_with_max_history_zero(monkeypatch: MonkeyPatch):
             "data",
             "validate",
             "stories",
+            "-d",
+            "data/test_moodbot/domain.yml",
             "--data",
             "data/test_moodbot/data",
             "--max-history",
@@ -199,6 +201,20 @@ def test_data_validate_stories_with_max_history_zero(monkeypatch: MonkeyPatch):
 
     with pytest.raises(argparse.ArgumentTypeError):
         data.validate_files(args)
+
+
+def test_data_validate_failed_to_load_domain(
+    run_in_simple_project_with_no_domain: Callable[..., RunResult]
+):
+    result = run_in_simple_project_with_no_domain(
+        "data",
+        "validate",
+        "--domain",
+        "not-existing-domain.yml",
+    )
+
+    assert "The path 'not-existing-domain.yml' does not exist." in str(result.outlines)
+    assert result.ret == 1
 
 
 @pytest.mark.parametrize(
@@ -220,6 +236,7 @@ def test_validate_files_action_not_found_invalid_domain(
     )
     args = {
         "domain": "data/test_moodbot/domain.yml",
+        "fail_on_warnings": False,
         "data": [file_name],
         "max_history": None,
         "config": "data/test_config/config_defaults.yml",
@@ -248,6 +265,7 @@ def test_validate_files_form_not_found_invalid_domain(
     )
     args = {
         "domain": "data/test_restaurantbot/domain.yml",
+        "fail_on_warnings": False,
         "data": [file_name],
         "max_history": None,
         "config": "data/test_config/config_defaults.yml",
@@ -324,6 +342,7 @@ def test_validate_files_form_slots_not_matching(tmp_path: Path):
     )
     args = {
         "domain": domain_file_name,
+        "fail_on_warnings": False,
         "data": None,
         "max_history": None,
         "config": "data/test_config/config_defaults.yml",
@@ -336,6 +355,7 @@ def test_validate_files_exit_early():
     with pytest.raises(SystemExit) as pytest_e:
         args = {
             "domain": "data/test_domains/duplicate_intents.yml",
+            "fail_on_warnings": False,
             "data": None,
             "max_history": None,
             "config": "data/test_config/config_defaults.yml",
@@ -349,6 +369,7 @@ def test_validate_files_exit_early():
 def test_validate_files_invalid_domain():
     args = {
         "domain": "data/test_domains/default_with_mapping.yml",
+        "fail_on_warnings": False,
         "data": None,
         "max_history": None,
         "config": "data/test_config/config_defaults.yml",


### PR DESCRIPTION
**Proposed changes**:
- Port of [PR](https://github.com/RasaHQ/rasa/pull/12521)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
