### PR TITLE
[Reviewing CLA] Adding note about returning on `extract_` methods

### DIFF
--- a/docs/docs/forms.mdx
+++ b/docs/docs/forms.mdx
@@ -320,6 +320,19 @@ The following example shows the implementation of a form which extracts a slot
 The method `extract_outdoor_seating` sets the slot `outdoor_seating` based on whether
 the keyword `outdoor` was present in the last user message.
 
+:::note
+Always return a value from the `extract_` methods. If you didn't found a match or you can't
+be sure that there is a new value, you can return the previous value using:
+
+```python
+return {"outdoor_seating": tracker.slots.get("outdoor_seating")}
+```
+
+If you don't return the slot value (i.e. returning `{}`) Rasa will continue processing the
+message as other intent. This might be useful if you want to process an intent to break
+from the conversation.
+:::
+
 ```python
 from typing import Dict, Text, List, Optional, Any
 


### PR DESCRIPTION

**Proposed changes**:
Adding additional information i saw by observing/trying Rasa actions when validating forms.

This is something I saw by observing, I'm not enterly sure that this is the default behavior, but when I return only `{}` the message was processed as other intent e.g.

```
Bot: Where are you hosting your applications?
Me: I don't know
Bot: Bye! # <--- This is what I wanted to avoid and did so by returning {"the-slot": None}
Bot: You can be hosting your applications on-premise or the cloud.
Bot: Where are you hosting your applications?
```

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

