### PR TITLE
Set docker as default driver for buildx

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -843,6 +843,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@ecf95283f03858871ff00b787d79c419715afc34  # v2.7.0
+        with:
+          driver: docker
 
       - name: Read Poetry Version 🔢
         run: |
@@ -1028,6 +1030,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@ecf95283f03858871ff00b787d79c419715afc34  # v2.7.0
+        with:
+          driver: docker
 
       - name: Free disk space
         if: needs.changes.outputs.docker == 'true'


### PR DESCRIPTION
Set docker as default driver for buildx. This makes images available from local image store.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
