### PR TITLE
[ATO-1138] Port of getctime does not select the latest model

### DIFF
--- a/changelog/12640.bugfix.md
+++ b/changelog/12640.bugfix.md
@@ -1,0 +1,1 @@
+Fix the issue with the most recent model not being selected if the owner or permissions where modified on the model file.

--- a/rasa/model.py
+++ b/rasa/model.py
@@ -70,7 +70,7 @@ def get_latest_model(model_path: Text = DEFAULT_MODELS_PATH) -> Optional[Text]:
     if len(list_of_files) == 0:
         return None
 
-    return max(list_of_files, key=os.path.getctime)
+    return max(list_of_files, key=os.path.getmtime)
 
 
 def get_model_for_finetuning(


### PR DESCRIPTION
**Proposed changes**:
- Port of [PR](https://github.com/RasaHQ/rasa/pull/12638)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
