### PR TITLE
Update requests to 2.31.0 on 3.3.x

### DIFF
--- a/changelog/12650.misc.md
+++ b/changelog/12650.misc.md
@@ -1,0 +1,1 @@
+Update requests to 2.31.0 to fix CVE-2023-32681.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2429,17 +2429,17 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
-version = "2.28.1"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.7"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<3"
+charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -2719,7 +2719,7 @@ numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
 name = "sentencepiece"
-version = "0.1.98"
+version = "0.1.99"
 description = "SentencePiece python wrapper"
 category = "main"
 optional = true
@@ -3743,7 +3743,7 @@ transformers = ["transformers", "sentencepiece"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "537867afc31910dfe6a20c0719856ab22126fedf14c8fca3008038e2f97c3e50"
+content-hash = "16e6cafa15e425460e6774121a15c6a67653e5f7dece871554abae0b586cd98a"
 
 [metadata.files]
 absl-py = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ showcontent = false
 [tool.poetry.dependencies]
 python = ">=3.7,<3.10"
 boto3 = "^1.12"
-requests = "^2.23"
+requests = "^2.31"
 matplotlib = ">=3.1,<3.6"
 attrs = ">=19.3,<22.2"
 jsonpickle = ">=1.3,<2.3"


### PR DESCRIPTION
Update requests to 2.31.0 to fix CVE-2023-32681.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
