### PR TITLE
Revert "Flow branching based on action output - [ENG 372]" as part of [ENG 449]

### DIFF
--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -39,7 +39,6 @@
     "rasa_corrected_slots": null,
     "rasa_previous_flow": null,
     "requested_slot": null,
-    "return_value": null,
     "session_started_metadata": null
   },
   "latest_input_channel": null,

--- a/rasa/shared/core/constants.py
+++ b/rasa/shared/core/constants.py
@@ -83,14 +83,12 @@ FLOW_STACK_SLOT = "flow_stack"
 PREVIOUS_FLOW_SLOT = "rasa_previous_flow"
 CANCELLED_FLOW_SLOT = "rasa_cancelled_flow"
 CORRECTED_SLOTS_SLOT = "rasa_corrected_slots"
-RETURN_VALUE_SLOT = "return_value"
 
 FLOW_SLOT_NAMES = [
     FLOW_STACK_SLOT,
     PREVIOUS_FLOW_SLOT,
     CANCELLED_FLOW_SLOT,
     CORRECTED_SLOTS_SLOT,
-    RETURN_VALUE_SLOT,
 ]
 
 # slots for knowledge base

--- a/tests/core/test_actions.py
+++ b/tests/core/test_actions.py
@@ -95,7 +95,6 @@ from rasa.shared.core.constants import (
     CANCELLED_FLOW_SLOT,
     PREVIOUS_FLOW_SLOT,
     CORRECTED_SLOTS_SLOT,
-    RETURN_VALUE_SLOT,
 )
 from rasa.shared.core.trackers import DialogueStateTracker
 from rasa.shared.exceptions import RasaException
@@ -248,7 +247,6 @@ async def test_remote_action_runs(
                     CANCELLED_FLOW_SLOT: None,
                     CORRECTED_SLOTS_SLOT: None,
                     PREVIOUS_FLOW_SLOT: None,
-                    RETURN_VALUE_SLOT: None,
                 },
                 "events": [],
                 "latest_input_channel": None,
@@ -315,7 +313,6 @@ async def test_remote_action_logs_events(
                     CANCELLED_FLOW_SLOT: None,
                     CORRECTED_SLOTS_SLOT: None,
                     PREVIOUS_FLOW_SLOT: None,
-                    RETURN_VALUE_SLOT: None,
                 },
                 "events": [],
                 "latest_input_channel": None,

--- a/tests/shared/core/test_domain.py
+++ b/tests/shared/core/test_domain.py
@@ -918,7 +918,6 @@ def test_domain_from_multiple_files():
         "rasa_corrected_slots",
         "rasa_previous_flow",
         "requested_slot",
-        "return_value",
         "session_started_metadata",
     ]
 

--- a/tests/shared/importers/test_rasa.py
+++ b/tests/shared/importers/test_rasa.py
@@ -16,7 +16,6 @@ from rasa.shared.core.constants import (
     PREVIOUS_FLOW_SLOT,
     CANCELLED_FLOW_SLOT,
     CORRECTED_SLOTS_SLOT,
-    RETURN_VALUE_SLOT,
 )
 from rasa.shared.core.domain import Domain
 from rasa.shared.core.slots import AnySlot
@@ -38,7 +37,6 @@ def test_rasa_file_importer(project: Text):
         AnySlot(PREVIOUS_FLOW_SLOT, mappings=[{}]),
         AnySlot(CANCELLED_FLOW_SLOT, mappings=[{}]),
         AnySlot(CORRECTED_SLOTS_SLOT, mappings=[{}]),
-        AnySlot(RETURN_VALUE_SLOT, mappings=[{}]),
         AnySlot(SESSION_START_METADATA_SLOT, mappings=[{}]),
     ]
     assert domain.entities == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -59,7 +59,6 @@ from rasa.shared.core.constants import (
     CANCELLED_FLOW_SLOT,
     CORRECTED_SLOTS_SLOT,
     PREVIOUS_FLOW_SLOT,
-    RETURN_VALUE_SLOT,
 )
 from rasa.shared.core.domain import Domain, SessionConfig
 from rasa.shared.core.events import (
@@ -1125,7 +1124,6 @@ async def test_requesting_non_existent_tracker(rasa_app: SanicASGITestClient):
         CANCELLED_FLOW_SLOT: None,
         CORRECTED_SLOTS_SLOT: None,
         PREVIOUS_FLOW_SLOT: None,
-        RETURN_VALUE_SLOT: None,
     }
     assert content["sender_id"] == "madeupid"
     assert content["events"] == [


### PR DESCRIPTION
**Proposed changes**:
- Reverts RasaHQ/rasa#12669
- As slot mappings are not needed anymore in DM2.0, the `return_value` default slot does not make any improvements to the system.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation (opened documentation PR in [rasaHQ/rasa](https://github.com/rasaHQ/rasa))
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-plus/tree/main/changelog) for instructions)
