### PR TITLE
Port dnspython dependency fix to 3.6.x

### DIFF
--- a/changelog/12737.bugfix.md
+++ b/changelog/12737.bugfix.md
@@ -1,0 +1,1 @@
+Resolve dependency incompatibility: Pin  version of `dnspython` to ==2.3.0.

--- a/poetry.lock
+++ b/poetry.lock
@@ -7200,4 +7200,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "eb7807284ae7f284df22386ffeb2db8c6ef80e2f73f1ea4f50c26957173dba6d"
+content-hash = "8d5bc8b9f1bbf342c9c7486825519d2a4beb2244c15729600d17d8f284c3b1e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,10 @@ confluent-kafka = ">=1.9.2,<3.0.0"
 portalocker = "^2.7.0"
 structlog = "^23.1.0"
 structlog-sentry = "^2.0.2"
+# pin dnspython to avoid dependency incompatibility
+# in order to fix https://rasahq.atlassian.net/browse/ATO-1419
+dnspython = "2.3.0"
+
 [[tool.poetry.dependencies.tensorflow-io-gcs-filesystem]]
 version = "==0.31"
 markers = "sys_platform == 'win32'"


### PR DESCRIPTION
**Proposed changes**:
- Ports Fixe for [ATO-1419](https://rasahq.atlassian.net/browse/ATO-1419)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-1419]: https://rasahq.atlassian.net/browse/ATO-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ