### PR TITLE
[POC][ATO-1415] Conversation tracking

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3892,6 +3892,39 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "polars"
+version = "0.18.15"
+description = "Blazingly fast DataFrame library"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "polars-0.18.15-cp38-abi3-macosx_10_7_x86_64.whl", hash = "sha256:f7a4e4108efd2ab728249f792c89d2e7baffd65e0d6cd9f09b6c395363e3fbea"},
+    {file = "polars-0.18.15-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:7dee57ecc6f6151f1f9b960f6baa5032ba5e967d3a0dc0cda830be20745be58c"},
+    {file = "polars-0.18.15-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c713610c7c144f41987092e2ab2372937933fbdc494a65c08eea251af91b60f"},
+    {file = "polars-0.18.15-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c48d248891cfe62ee58f852dabf54c6bd85d4fc83b3b61b759534be0d3b6ec81"},
+    {file = "polars-0.18.15-cp38-abi3-win_amd64.whl", hash = "sha256:a2f1e3ad546b98601d06340606e90a8788c35e064b4d82d27301069ce744086e"},
+    {file = "polars-0.18.15.tar.gz", hash = "sha256:0c483fc1cfb25d07443c0d51eff9a18b94ccdbf6b252212767524412667ca870"},
+]
+
+[package.extras]
+adbc = ["adbc_driver_sqlite"]
+all = ["polars[adbc,cloudpickle,connectorx,deltalake,fsspec,matplotlib,numpy,pandas,pyarrow,pydantic,sqlalchemy,timezone,xlsx2csv,xlsxwriter]"]
+cloudpickle = ["cloudpickle"]
+connectorx = ["connectorx"]
+deltalake = ["deltalake (>=0.10.0)"]
+fsspec = ["fsspec"]
+matplotlib = ["matplotlib"]
+numpy = ["numpy (>=1.16.0)"]
+pandas = ["pandas", "pyarrow (>=7.0.0)"]
+pyarrow = ["pyarrow (>=7.0.0)"]
+pydantic = ["pydantic"]
+sqlalchemy = ["pandas", "sqlalchemy"]
+timezone = ["backports.zoneinfo", "tzdata"]
+xlsx2csv = ["xlsx2csv (>=0.8.0)"]
+xlsxwriter = ["xlsxwriter"]
+
+[[package]]
 name = "portalocker"
 version = "2.7.0"
 description = "Wraps the portalocker recipe for easy usage"
@@ -7468,4 +7501,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "5bbbeae731ee8efc8dc24a5c5b1b7f8d05b222e025f13ec43e25ba1e0d4ef499"
+content-hash = "57f7d1c9f2968dae8d417628cdf518fe0ab4463865bbc632c8ddf0beb02300d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ confluent-kafka = ">=1.9.2,<3.0.0"
 portalocker = "^2.7.0"
 structlog = "^23.1.0"
 structlog-sentry = "^2.0.2"
+polars = "^0.18.15"
 [[tool.poetry.dependencies.tensorflow-io-gcs-filesystem]]
 version = "==0.31"
 markers = "sys_platform == 'win32'"

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -858,10 +858,14 @@ def create_app(
         start_date = request.args.get("start_date")
         end_date = request.args.get("end_date")
         try:
-            billable = await app.ctx.agent.tracker_store.get_events(start_date, end_date)
+            print(start_date, end_date, type(start_date), type(end_date), type(app.ctx.agent.tracker_store))
+            billable = await app.ctx.agent.tracker_store.get_events(
+                start_date,
+                end_date
+            )
             return response.json({"billable": billable})
         except Exception as e:
-            logger.debug(traceback.format_exc())
+            logger.info(traceback.format_exc())
             raise ErrorResponse(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 "ConversationError",

--- a/rasa/server.py
+++ b/rasa/server.py
@@ -852,6 +852,23 @@ def create_app(
                 f"An unexpected error occurred. Error: {e}",
             )
 
+    @app.get("/billable_conversations")
+    async def billable_conversations(request: Request) -> HTTPResponse:
+        """Get the number of billable conversations."""
+        start_date = request.args.get("start_date")
+        end_date = request.args.get("end_date")
+        try:
+            billable = await app.ctx.agent.tracker_store.get_events(start_date, end_date)
+            return response.json({"billable": billable})
+        except Exception as e:
+            logger.debug(traceback.format_exc())
+            raise ErrorResponse(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "ConversationError",
+                f"An unexpected error occurred. Error: {e}",
+            )
+
+
     @app.post("/conversations/<conversation_id:path>/execute")
     @requires_auth(app, auth_token)
     @ensure_loaded_agent(app)


### PR DESCRIPTION
## POC Limitations
 - Only works with SQL tracker stores
 - Sends data with the telemetry implementation (not separately)
 
## Local setup
Any bot will do just has to have SQL tracker store
```
tracker_store:
    type: SQL
    dialect: "postgresql"  # the dialect used to interact with the db
    url: "localhost"  # (optional) host of the sql db, e.g. "localhost"
    db: "rasa"  # path to your db
    username: user # username used for authentication
    password: admin # password used for authentication
```
To add events t o the tracker store use any channel to interact with the bot. Easiest way is just the `rest` channel. (`rasa shell` does not save events in the tracker store 😃)

## Screenshots
Example request to the endpoint

![Screenshot 2023-08-16 at 18 56 36](https://github.com/RasaHQ/rasa/assets/17255854/b9186559-a214-4ccc-bbd8-4db5995881b9)

Example payload in segment (with current telemetry implementation)

<img width="637" alt="Screenshot 2023-08-16 at 18 55 04" src="https://github.com/RasaHQ/rasa/assets/17255854/6da3e1f6-2920-462a-aa27-897781aa46a9">

