### PR TITLE
fix typo: use model_name everywhere

### DIFF
--- a/docs/docs/llms/llm-setup.mdx
+++ b/docs/docs/llms/llm-setup.mdx
@@ -244,7 +244,7 @@ Additionally, requires the `COHERE_API_KEY` environment variable to be set.
 ```yaml
 llm:
   type: "cohere"
-  model: "gptd-instruct-tft"
+  model_name: "gptd-instruct-tft"
   temperature: 0.7
 ```
 
@@ -325,7 +325,7 @@ The model cam be configured as an optional parameter
 ```yaml
 embeddings:
   type: "openai"
-  model: "text-embedding-ada-002"
+  model_name: "text-embedding-ada-002"
 ```
 
 #### Cohere
@@ -338,7 +338,7 @@ can be configured as an optional parameter.
 ```yaml
 embeddings:
   type: "cohere"
-  model: "embed-english-v2.0"
+  model_name: "embed-english-v2.0"
 ```
 
 #### spaCy


### PR DESCRIPTION
**Proposed changes**:
- fix typo and use `model_name` everywhere in docs for llm/embeddings config

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
