### PR TITLE
allow components to add fingerprints of external data

### DIFF
--- a/changelog/12778.improvement.md
+++ b/changelog/12778.improvement.md
@@ -1,0 +1,1 @@
+Added additional method `fingerprint_addon` to the `GraphComponent` interface to allow inclusion of external data into the fingerprint calculation of a component

--- a/data/test_classes/graph_component_interface.py
+++ b/data/test_classes/graph_component_interface.py
@@ -99,3 +99,12 @@ class GraphComponent(ABC):
     def required_packages() -> List[Text]:
         """Any extra python dependencies required for this component to run."""
         return []
+
+    @classmethod
+    def fingerprint_addon(cls, config: Dict[str, Any]) -> Optional[str]:
+        """Adds additional data to the fingerprint calculation.
+
+        This is useful if a component uses external data that is not provided
+        by the graph.
+        """
+        return None

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -259,7 +259,8 @@ class GraphComponent(ABC):
         """Adds additional data to the fingerprint calculation.
 
         This is useful if a component uses external data that is not provided
-        by the graph."""
+        by the graph.
+        """
         return None
 
 

--- a/rasa/engine/graph.py
+++ b/rasa/engine/graph.py
@@ -254,6 +254,14 @@ class GraphComponent(ABC):
         """Any extra python dependencies required for this component to run."""
         return []
 
+    @classmethod
+    def fingerprint_addon(cls, config: Dict[str, Any]) -> Optional[str]:
+        """Adds additional data to the fingerprint calculation.
+
+        This is useful if a component uses external data that is not provided
+        by the graph."""
+        return None
+
 
 class GraphNodeHook(ABC):
     """Holds functionality to be run before and after a `GraphNode`."""

--- a/rasa/engine/training/fingerprinting.py
+++ b/rasa/engine/training/fingerprinting.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Dict, Text, Type
+from typing import Any, Dict, Text, Type, TypeVar
 from typing_extensions import Protocol, runtime_checkable
 import pkg_resources
 import rasa.utils.common
@@ -19,6 +19,9 @@ class Fingerprintable(Protocol):
     def fingerprint(self) -> Text:
         """Returns a unique stable fingerprint of the data."""
         ...
+
+
+GraphComponentOrSubclass = TypeVar("GraphComponentOrSubclass", bound=GraphComponent)
 
 
 def calculate_fingerprint_key(
@@ -49,6 +52,10 @@ def calculate_fingerprint_key(
         "inputs": inputs,
         "dependency_versions": dependency_versions,
     }
+
+    fingerprint_addon = graph_component_class.fingerprint_addon(config)
+    if fingerprint_addon is not None:
+        fingerprint_data["addon"] = fingerprint_addon
 
     fingerprint_key = rasa.shared.utils.io.deep_container_fingerprint(fingerprint_data)
 

--- a/rasa/engine/training/fingerprinting.py
+++ b/rasa/engine/training/fingerprinting.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Dict, Text, Type, TypeVar
+from typing import Any, Dict, Text, Type
 from typing_extensions import Protocol, runtime_checkable
 import pkg_resources
 import rasa.utils.common
@@ -19,9 +19,6 @@ class Fingerprintable(Protocol):
     def fingerprint(self) -> Text:
         """Returns a unique stable fingerprint of the data."""
         ...
-
-
-GraphComponentOrSubclass = TypeVar("GraphComponentOrSubclass", bound=GraphComponent)
 
 
 def calculate_fingerprint_key(

--- a/tests/engine/training/test_fingerprinting.py
+++ b/tests/engine/training/test_fingerprinting.py
@@ -86,7 +86,7 @@ def test_fingerprint_changes_due_to_changed_source(monkeypatch: MonkeyPatch):
 
 
 def test_fingerprint_changes_when_external_file_changes():
-    _, tmp_file = tempfile.mkstemp()
+    tmp_file = tempfile.mktemp()
 
     class MinimalComponent(GraphComponent):
         @classmethod

--- a/tests/engine/training/test_fingerprinting.py
+++ b/tests/engine/training/test_fingerprinting.py
@@ -1,8 +1,15 @@
 import inspect
+import os.path
+import tempfile
+from typing import Dict, Text, Any, Optional
 from unittest.mock import Mock
 from _pytest.monkeypatch import MonkeyPatch
 
+import rasa.shared.utils.io
 from rasa.core.policies.ted_policy import TEDPolicy
+from rasa.engine.graph import ExecutionContext, GraphComponent
+from rasa.engine.storage.resource import Resource
+from rasa.engine.storage.storage import ModelStorage
 from rasa.engine.training import fingerprinting
 from rasa.nlu.classifiers.diet_classifier import DIETClassifier
 from rasa.nlu.selectors.response_selector import ResponseSelector
@@ -76,3 +83,44 @@ def test_fingerprint_changes_due_to_changed_source(monkeypatch: MonkeyPatch):
     assert key1 != key2
 
     get_source_mock.assert_called_once_with(TEDPolicy)
+
+
+def test_fingerprint_changes_when_external_file_changes():
+    _, tmp_file = tempfile.mkstemp()
+
+    class MinimalComponent(GraphComponent):
+        @classmethod
+        def create(
+            cls,
+            config: Dict[Text, Any],
+            model_storage: ModelStorage,
+            resource: Resource,
+            execution_context: ExecutionContext,
+        ) -> "MinimalComponent":
+            return MinimalComponent()
+
+        @classmethod
+        def fingerprint_addon(cls, config: Dict[str, Any]) -> Optional[str]:
+            if not os.path.exists(tmp_file):
+                return None
+            else:
+                return rasa.shared.utils.io.get_text_hash(open(tmp_file, "r").read())
+
+    with open(tmp_file, "w") as external_data:
+        external_data.write("This is a test.")
+
+    fingerprint_1 = fingerprinting.calculate_fingerprint_key(MinimalComponent, {}, {})
+
+    fingerprint_2 = fingerprinting.calculate_fingerprint_key(MinimalComponent, {}, {})
+
+    assert fingerprint_1 == fingerprint_2
+
+    # overwrite the original external data
+    with open(tmp_file, "w") as external_data:
+        external_data.write("This is a test for changes in external data.")
+
+    fingerprint_3 = fingerprinting.calculate_fingerprint_key(MinimalComponent, {}, {})
+
+    assert fingerprint_3 != fingerprint_1
+
+    os.remove(tmp_file)


### PR DESCRIPTION
**Proposed changes**:
- Added method to `GraphComponent` that allows users to add additional fingerprint data to their component, such as external files, knowledge bases etc. that are not directly in the rasa graph

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
