### PR TITLE
[ATO-1518] Push multi-platform Docker images directly from buildx's docker-container

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -906,7 +906,7 @@ jobs:
           # Base MITIE image
           BASE_MITIE_IMAGE_HASH=${{ hashFiles('docker/Dockerfile.base-mitie') }}
           MAKEFILE_MITIE_HASH=${{ hashFiles('Makefile') }}
-          echo "base_mitie_image_hash=${BASE_MITIE_IMAGE_HASH:0:50}-${MAKEFILE_MITIE_HASH:0:50}" >> $GITHUB_OUTPUT
+          echo "base_mitie_image_hash=${BASE_MITIE_IMAGE_HASH}" >> $GITHUB_OUTPUT
 
           BASE_IMAGE_MITIE_EXISTS=$((docker manifest inspect rasa/rasa:base-mitie-${BASE_MITIE_IMAGE_HASH:0:50}-${MAKEFILE_MITIE_HASH:0:50} &> /dev/null && echo true || echo false) || true)
           echo "base_mitie_exists=${BASE_IMAGE_MITIE_EXISTS}" >> $GITHUB_OUTPUT
@@ -1095,8 +1095,6 @@ jobs:
           IS_NEWEST_VERSION=${{ needs.build_docker_base_images_and_set_env.outputs.is_newest_version }}
 
           docker buildx bake --set *.platform=linux/amd64,linux/arm64 -f docker/docker-bake.hcl ${{ matrix.image }} --push
-          docker buildx bake --set *.platform=linux/amd64 -f docker/docker-bake.hcl ${{ matrix.image }} --load
-          docker buildx bake --set *.platform=linux/arm64 -f docker/docker-bake.hcl ${{ matrix.image }} --load
 
           # Tag the image as latest
           if [[ "${IS_NEWEST_VERSION}" == "true" ]]; then
@@ -1107,9 +1105,11 @@ jobs:
             fi
 
             LATEST_TAG=$(echo $RELEASE_TAG | sed 's/'$IMAGE_TAG'/latest/g')
-
-            docker tag rasa/rasa:${RELEASE_TAG} rasa/rasa:${LATEST_TAG}
-            docker push rasa/rasa:${LATEST_TAG}
+            
+            # This will not build the image from ground up, but will only tag the existing image with LATEST_TAG
+            IMAGE_TAG=${LATEST_TAG} docker buildx bake --set *.platform=linux/amd64,linux/arm64 -f docker/docker-bake.hcl ${{ matrix.image }}
+            # Push tagged image
+            IMAGE_TAG=${LATEST_TAG} docker buildx bake --set *.platform=linux/amd64,linux/arm64 -f docker/docker-bake.hcl ${{ matrix.image }} --push
           fi
 
   deploy:

--- a/3.7.0b1/main_plain/.config/rasa/global.yml
+++ b/3.7.0b1/main_plain/.config/rasa/global.yml
@@ -1,0 +1,4 @@
+metrics:
+  enabled: true
+  rasa_user_id: 003ff8fbd6e04031b5597b37356022d4
+  date: 2023-09-12 13:20:59.423434


### PR DESCRIPTION
When multi-platform docker images are built push them directly from docker-container's registry.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
