### PR TITLE
[ATO 1529] Port fix to 3.6.x

### DIFF
--- a/changelog/12790.bugfix.md
+++ b/changelog/12790.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `KeyError` which resulted when `domain_responses` doesn't exist as a keyword argument while using a custom action dispatcher with nlg server. 

--- a/rasa/core/nlg/callback.py
+++ b/rasa/core/nlg/callback.py
@@ -73,7 +73,7 @@ class CallbackNaturalLanguageGenerator(NaturalLanguageGenerator):
         **kwargs: Any,
     ) -> Dict[Text, Any]:
         """Retrieve a named response from the domain using an endpoint."""
-        domain_responses = kwargs.pop("domain_responses")
+        domain_responses = kwargs.pop("domain_responses", None)
         response_id = self.fetch_response_id(
             utter_action, tracker, output_channel, domain_responses
         )


### PR DESCRIPTION
**Proposed changes**:
- Port #12790 to `3.6.x` to fix [ATO-1529](https://rasahq.atlassian.net/browse/ATO-1529)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-1529]: https://rasahq.atlassian.net/browse/ATO-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ