### PR TITLE
add username in RedisLockStore

### DIFF
--- a/docs/docs/lock-stores.mdx
+++ b/docs/docs/lock-stores.mdx
@@ -156,6 +156,8 @@ The `ConcurrentRedisLockStore` recreates the `TicketLock` from the persisted `Ti
   - `key_prefix` (default: `None`): The prefix to prepend to lock store keys. Must
     be alphanumeric
 
+  -  `username` (default: `None`): Username used for authentication
+
   - `password` (default: `None`): Password used for authentication
     (`None` equals no authentication)
 

--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -200,6 +200,7 @@ class RedisLockStore(LockStore):
         host: Text = "localhost",
         port: int = 6379,
         db: int = 1,
+        username: Optional[Text] = None,
         password: Optional[Text] = None,
         use_ssl: bool = False,
         ssl_certfile: Optional[Text] = None,
@@ -215,6 +216,8 @@ class RedisLockStore(LockStore):
             port: The port of the redis server.
             db: The name of the database within Redis which should be used by Rasa
                 Open Source.
+            username: The username which should be used for authentication with the
+                Redis database.
             password: The password which should be used for authentication with the
                 Redis database.
             use_ssl: `True` if SSL should be used for the connection to Redis.
@@ -232,6 +235,7 @@ class RedisLockStore(LockStore):
             host=host,
             port=int(port),
             db=int(db),
+            username=username,
             password=password,
             ssl=use_ssl,
             ssl_certfile=ssl_certfile,

--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -243,15 +243,6 @@ class RedisLockStore(LockStore):
             ssl_ca_certs=ssl_ca_certs,
             socket_timeout=socket_timeout,
         )
-        
-        # test connection
-        try:
-            self.red.ping()
-        except redis.exceptions.ConnectionError as e:
-            raise Exception(
-                "Could not connect to Redis. Please make sure Redis is running and "
-                f"configured correctly. Error: {e}"
-            )
 
         self.key_prefix = DEFAULT_REDIS_LOCK_STORE_KEY_PREFIX
         if key_prefix:

--- a/rasa/core/lock_store.py
+++ b/rasa/core/lock_store.py
@@ -243,6 +243,15 @@ class RedisLockStore(LockStore):
             ssl_ca_certs=ssl_ca_certs,
             socket_timeout=socket_timeout,
         )
+        
+        # test connection
+        try:
+            self.red.ping()
+        except redis.exceptions.ConnectionError as e:
+            raise Exception(
+                "Could not connect to Redis. Please make sure Redis is running and "
+                f"configured correctly. Error: {e}"
+            )
 
         self.key_prefix = DEFAULT_REDIS_LOCK_STORE_KEY_PREFIX
         if key_prefix:

--- a/tests/integration_tests/core/test_lock_store.py
+++ b/tests/integration_tests/core/test_lock_store.py
@@ -23,14 +23,6 @@ def test_create_lock_store(redis_lock_store: RedisLockStore):
     assert lock.conversation_id == conversation_id
 
 
-def test_lock_store_with_username():
-    """connect to a redis instance with username"""
-    redis = RedisLockStore(
-        host="localhost", port=6380, username="username1", password="password"
-    )
-    assert redis.red.ping()
-
-
 def test_serve_ticket(redis_lock_store: RedisLockStore):
     conversation_id = "my id 1"
 

--- a/tests/integration_tests/core/test_lock_store.py
+++ b/tests/integration_tests/core/test_lock_store.py
@@ -22,6 +22,10 @@ def test_create_lock_store(redis_lock_store: RedisLockStore):
     assert lock
     assert lock.conversation_id == conversation_id
 
+def test_lock_store_with_username():
+    """ connect to a redis instance with username """
+    redis = RedisLockStore(host="localhost", port=6380, username="username1", password="password")
+    assert redis.ping()
 
 def test_serve_ticket(redis_lock_store: RedisLockStore):
     conversation_id = "my id 1"

--- a/tests/integration_tests/core/test_lock_store.py
+++ b/tests/integration_tests/core/test_lock_store.py
@@ -28,7 +28,7 @@ def test_lock_store_with_username():
     redis = RedisLockStore(
         host="localhost", port=6380, username="username1", password="password"
     )
-    assert redis.ping()
+    assert redis.red.ping()
 
 
 def test_serve_ticket(redis_lock_store: RedisLockStore):

--- a/tests/integration_tests/core/test_lock_store.py
+++ b/tests/integration_tests/core/test_lock_store.py
@@ -22,10 +22,14 @@ def test_create_lock_store(redis_lock_store: RedisLockStore):
     assert lock
     assert lock.conversation_id == conversation_id
 
+
 def test_lock_store_with_username():
-    """ connect to a redis instance with username """
-    redis = RedisLockStore(host="localhost", port=6380, username="username1", password="password")
+    """connect to a redis instance with username"""
+    redis = RedisLockStore(
+        host="localhost", port=6380, username="username1", password="password"
+    )
     assert redis.ping()
+
 
 def test_serve_ticket(redis_lock_store: RedisLockStore):
     conversation_id = "my id 1"

--- a/tests_deployment/docker-compose.integration.yml
+++ b/tests_deployment/docker-compose.integration.yml
@@ -13,6 +13,12 @@ services:
     ports:
       - 6379:6379
 
+  redis1:
+    image: redis:6
+    command: "--requirepass password --user username1 on >password ~* allcommands --user default off nopass nocommands"
+    ports:
+      - "6379:6380"
+
   postgres:
     image: postgres:13
     # Set health checks to wait until postgres has started

--- a/tests_deployment/docker-compose.integration.yml
+++ b/tests_deployment/docker-compose.integration.yml
@@ -11,16 +11,7 @@ services:
       retries: 5
 
     ports:
-      - 6379:6379
-
-  redis1:
-    image: redis/redis-stack:6.2.6-v7
-    restart: always
-    environment:
-      REDIS_ARGS: "--requirepass password --user username1 on >password ~* allcommands --user default off nopass nocommands"
-    ports:
-      - "8001:8001"
-      - "6380:6379"
+    - 6379:6379
 
   postgres:
     image: postgres:13

--- a/tests_deployment/docker-compose.integration.yml
+++ b/tests_deployment/docker-compose.integration.yml
@@ -14,9 +14,12 @@ services:
       - 6379:6379
 
   redis1:
-    image: redis:6
-    command: "--requirepass password --user username1 on >password ~* allcommands --user default off nopass nocommands"
+    image: redis/redis-stack:6.2.6-v7
+    restart: always
+    environment:
+      REDIS_ARGS: "--requirepass password --user username1 on >password ~* allcommands --user default off nopass nocommands"
     ports:
+      - "8001:8001"
       - "6380:6379"
 
   postgres:

--- a/tests_deployment/docker-compose.integration.yml
+++ b/tests_deployment/docker-compose.integration.yml
@@ -17,7 +17,7 @@ services:
     image: redis:6
     command: "--requirepass password --user username1 on >password ~* allcommands --user default off nopass nocommands"
     ports:
-      - "6379:6380"
+      - "6380:6379"
 
   postgres:
     image: postgres:13


### PR DESCRIPTION
**Proposed changes**:
- Works on https://rasahq.atlassian.net/browse/ATO-1520
- Add `username` to the connection arguments of `RedisLockStore`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
