### PR TITLE
remove pypric configuration from docs

### DIFF
--- a/docs/docs/installation/rasa-pro/installation.mdx
+++ b/docs/docs/installation/rasa-pro/installation.mdx
@@ -67,23 +67,7 @@ The results should include `ChainerBackend` and `GooglePythonAuth`.
 
 #### Installing with `pip`
 
-Enter the following settings to the `.pypirc` file. This can be found:
-
-- Linux and MacOS: `$HOME/.pypirc`
-- Windows: `%USERPROFILE%\.pypirc`
-
-
-```
-[distutils]
-index-servers =
-    rasa-plus-py
-
-[rasa-plus-py]
-repository: https://europe-west3-python.pkg.dev/rasa-releases/rasa-plus-py/
-
-```
-
-Next, add these specific settings to the pip configuration file. The location for this depends on whether you want to update the per-user file or the file specific to a virtual environment that you are using.
+Add these specific settings to the pip configuration file. The location for this depends on whether you want to update the per-user file or the file specific to a virtual environment that you are using.
 
 For the file associated with your operating system user:
 


### PR DESCRIPTION
**Proposed changes**:
- This removes the pypric configuration which is not needed for installing `rasa-plus`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [x ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
