### PR TITLE
[ENG-597] Increase minimum model compatible version

### DIFF
--- a/rasa/constants.py
+++ b/rasa/constants.py
@@ -18,7 +18,7 @@ CONFIG_TELEMETRY_ID = "rasa_user_id"
 CONFIG_TELEMETRY_ENABLED = "enabled"
 CONFIG_TELEMETRY_DATE = "date"
 
-MINIMUM_COMPATIBLE_VERSION = "3.5.0"
+MINIMUM_COMPATIBLE_VERSION = "3.7.0b3"
 
 GLOBAL_USER_CONFIG_PATH = os.path.expanduser("~/.config/rasa/global.yml")
 

--- a/rasa/engine/runner/dask.py
+++ b/rasa/engine/runner/dask.py
@@ -100,6 +100,10 @@ class DaskGraphRunner(GraphRunner):
         try:
             dask_result = dask.get(run_graph, run_targets)
             return dict(dask_result)
+        except KeyError as e:
+            raise GraphRunError(
+                f"Could not find key {e} in the graph. Error running runner."
+            ) from e
         except RuntimeError as e:
             raise GraphRunError("Error running runner.") from e
 


### PR DESCRIPTION
**Proposed changes**:
- Increase the `MINIMUM_COMPATIBLE_VERSION` to `3.7.0b3`: Models, trained on DM1, would fail running on DM2 as the graph does not contain any `command_processor` component. Increasing the minimum compatible version does not allow those models to run on DM2.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
