### PR TITLE
Modify LLMCommandGenerator prompt to include possible categorical slot values - [ENG 607]

### DIFF
--- a/rasa/dialogue_understanding/generator/command_prompt_template.jinja2
+++ b/rasa/dialogue_understanding/generator/command_prompt_template.jinja2
@@ -4,7 +4,7 @@ These are the flows that can be started, with their description and slots:
 {% for flow in available_flows %}
 {{ flow.name }}: {{ flow.description }}
     {% for slot in flow.slots -%}
-    slot: {{ slot.name }}{% if slot.description %} ({{ slot.description }}){% endif %}
+    slot: {{ slot.name }}{% if slot.description %} ({{ slot.description }}){% endif %}{% if slot.allowed_values %}, allowed values: {{ slot.allowed_values }}{% endif %}
     {% endfor %}
 {%- endfor %}
 

--- a/rasa/dialogue_understanding/generator/llm_command_generator.py
+++ b/rasa/dialogue_understanding/generator/llm_command_generator.py
@@ -330,9 +330,8 @@ class LLMCommandGenerator(GraphComponent, CommandGenerator):
         else:
             return nullable_value
 
-    @classmethod
     def prepare_flows_for_template(
-        cls, flows: FlowsList, tracker: DialogueStateTracker
+        self, flows: FlowsList, tracker: DialogueStateTracker
     ) -> List[Dict[str, Any]]:
         """Format data on available flows for insertion into the prompt template.
 
@@ -346,9 +345,15 @@ class LLMCommandGenerator(GraphComponent, CommandGenerator):
         result = []
         for flow in flows.user_flows:
             slots_with_info = [
-                {"name": q.collect, "description": q.description}
+                {
+                    "name": q.collect,
+                    "description": q.description,
+                    "allowed_values": self.allowed_values_for_slot(
+                        tracker.slots[q.collect]
+                    ),
+                }
                 for q in flow.get_collect_steps()
-                if cls.is_extractable(q, tracker)
+                if LLMCommandGenerator.is_extractable(q, tracker)
             ]
             result.append(
                 {

--- a/rasa/dialogue_understanding/generator/llm_command_generator.py
+++ b/rasa/dialogue_understanding/generator/llm_command_generator.py
@@ -353,7 +353,7 @@ class LLMCommandGenerator(GraphComponent, CommandGenerator):
                     ),
                 }
                 for q in flow.get_collect_steps()
-                if LLMCommandGenerator.is_extractable(q, tracker)
+                if self.is_extractable(q, tracker)
             ]
             result.append(
                 {


### PR DESCRIPTION
**Proposed changes**:
- The `LLMCommandGenerator` currently includes the allowed values of categorical slots only when an active flow is present. Adding the `allowed values` to the slots, at the time of defining the flows helps in the LLM mapping the input to one of the defined categorical values. 
- Added e2e tests - https://github.com/RasaHQ/financial-demo-flows-llms/pull/50

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
