### PR TITLE
Fix unicode handling in JSON serialization for SQLTrackerStore

### DIFF
--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1349,7 +1349,7 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
                         timestamp=timestamp,
                         intent_name=intent,
                         action_name=action,
-                        data=json.dumps(data),
+                        data=json.dumps(data, ensure_ascii=False),
                     )
                 )
             session.commit()


### PR DESCRIPTION
This pull request updates the JSON serialization within the SQLTrackerStore to preserve non-ASCII characters such as Cyrillic script. By setting ensure_ascii=False in json.dumps, the data is now stored in its original representation, allowing for proper storage and retrieval of non-ASCII characters. This change addresses issues with Unicode encoding in the database, ensuring that intent and action names containing Cyrillic characters are correctly represented.

**Proposed changes**:
- Set ensure_ascii=False in json.dumps to preserve non-ASCII characters in the database.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
