### PR TITLE
Edit docs workflow to release docs for 3.6.x

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -82,7 +82,7 @@ jobs:
             echo "build_docs=true" >> $GITHUB_OUTPUT
           else
             # Get latest tagged Rasa version
-            git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
+            git describe --tags --match="3.6.[0-9]*" --abbrev=0 HEAD
             # Fetch branch history
             TAG_NAME=${GITHUB_REF#refs/tags/}
             git fetch --prune --unshallow


### PR DESCRIPTION
**Proposed changes**:
- Tested successfully with tag 3.6.16 https://github.com/RasaHQ/rasa/actions/runs/7543003070/job/20533046087
Note : This change will only need to remain on 3.6.x, on 3.5.x it will always fail https://github.com/RasaHQ/rasa/actions/runs/7543134913/job/20533450956