### PR TITLE
Get Full Retrieval Intent Name

### DIFF
--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -66,7 +66,11 @@ from rasa.shared.nlu.constants import (
     ENTITIES,
     INTENT,
     INTENT_NAME_KEY,
+    INTENT_RESPONSE_KEY,
     PREDICTED_CONFIDENCE_KEY,
+    FULL_RETRIEVAL_INTENT_NAME_KEY,
+    RESPONSE_SELECTOR,
+    RESPONSE,
     TEXT,
 )
 from rasa.utils.endpoints import EndpointConfig
@@ -721,6 +725,7 @@ class MessageProcessor:
                 message, tracker, only_output_properties
             )
 
+        self._update_full_retrieval_intent(parse_data)
         structlogger.debug(
             "processor.message.parse",
             parse_data_text=copy.deepcopy(parse_data["text"]),
@@ -731,6 +736,19 @@ class MessageProcessor:
         self._check_for_unseen_features(parse_data)
 
         return parse_data
+
+    def _update_full_retrieval_intent(self, parse_data: Dict[Text, Any]) -> None:
+        """Update the parse data with the full retrieval intent.
+
+        Args:
+            parse_data: Message parse data to update.
+        """
+        intent_name = parse_data.get(INTENT, {}).get(INTENT_NAME_KEY)
+        response_selector = parse_data.get(RESPONSE_SELECTOR, {})
+        all_retrieval_intents = response_selector.get("all_retrieval_intents", [])
+        if intent_name and intent_name in all_retrieval_intents:
+            retrieval_intent = response_selector.get(intent_name, {}).get(RESPONSE, {}).get(INTENT_RESPONSE_KEY)
+            parse_data[INTENT][FULL_RETRIEVAL_INTENT_NAME_KEY] = retrieval_intent
 
     def _parse_message_with_graph(
         self,

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -747,7 +747,11 @@ class MessageProcessor:
         response_selector = parse_data.get(RESPONSE_SELECTOR, {})
         all_retrieval_intents = response_selector.get("all_retrieval_intents", [])
         if intent_name and intent_name in all_retrieval_intents:
-            retrieval_intent = response_selector.get(intent_name, {}).get(RESPONSE, {}).get(INTENT_RESPONSE_KEY)
+            retrieval_intent = (
+                response_selector.get(intent_name, {})
+                .get(RESPONSE, {})
+                .get(INTENT_RESPONSE_KEY)
+            )
             parse_data[INTENT][FULL_RETRIEVAL_INTENT_NAME_KEY] = retrieval_intent
 
     def _parse_message_with_graph(

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -1943,46 +1943,44 @@ async def test_update_full_retrieval_intent(
         "intent": {"name": "chitchat", "confidence": 0.9},
         "entities": [],
         "response_selector": {
-            {
-                "all_retrieval_intents": ["faq", "chitchat"],
-                "faq": {
-                    "response": {
-                        "responses": [{"text": "Our return policy lasts 30 days."}],
+            "all_retrieval_intents": ["faq", "chitchat"],
+            "faq": {
+                "response": {
+                    "responses": [{"text": "Our return policy lasts 30 days."}],
+                    "confidence": 1.0,
+                    "intent_response_key": "faq/what_is_return_policy",
+                    "utter_action": "utter_faq/what_is_return_policy",
+                },
+                "ranking": [
+                    {
                         "confidence": 1.0,
                         "intent_response_key": "faq/what_is_return_policy",
-                        "utter_action": "utter_faq/what_is_return_policy",
                     },
-                    "ranking": [
+                    {
+                        "confidence": 2.3378809862799945e-19,
+                        "intent_response_key": "faq/how_can_i_track_my_order",
+                    },
+                ],
+            },
+            "chitchat": {
+                "response": {
+                    "responses": [
                         {
-                            "confidence": 1.0,
-                            "intent_response_key": "faq/what_is_return_policy",
-                        },
-                        {
-                            "confidence": 2.3378809862799945e-19,
-                            "intent_response_key": "faq/how_can_i_track_my_order",
+                            "text": "The sun is out today! Isn't that great?",
                         },
                     ],
+                    "confidence": 1.0,
+                    "intent_response_key": "chitchat/ask_weather",
+                    "utter_action": "utter_chitchat/ask_weather",
                 },
-                "chitchat": {
-                    "response": {
-                        "responses": [
-                            {
-                                "text": "The sun is out today! Isn't that great?",
-                            },
-                        ],
+                "ranking": [
+                    {
                         "confidence": 1.0,
                         "intent_response_key": "chitchat/ask_weather",
-                        "utter_action": "utter_chitchat/ask_weather",
                     },
-                    "ranking": [
-                        {
-                            "confidence": 1.0,
-                            "intent_response_key": "chitchat/ask_weather",
-                        },
-                        {"confidence": 0.0, "intent_response_key": "chitchat/ask_name"},
-                    ],
-                },
-            }
+                    {"confidence": 0.0, "intent_response_key": "chitchat/ask_name"},
+                ],
+            },
         },
     }
 

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -70,7 +70,12 @@ from rasa.shared.core.events import (
 from rasa.core.http_interpreter import RasaNLUHttpInterpreter
 from rasa.core.processor import MessageProcessor
 from rasa.shared.core.trackers import DialogueStateTracker
-from rasa.shared.nlu.constants import INTENT_NAME_KEY, METADATA_MODEL_ID
+from rasa.shared.nlu.constants import (
+    INTENT,
+    INTENT_NAME_KEY,
+    FULL_RETRIEVAL_INTENT_NAME_KEY,
+    METADATA_MODEL_ID,
+)
 from rasa.shared.nlu.training_data.message import Message
 from rasa.utils.endpoints import EndpointConfig
 from rasa.shared.core.constants import (
@@ -83,11 +88,6 @@ from rasa.shared.core.constants import (
     EXTERNAL_MESSAGE_PREFIX,
     IS_EXTERNAL,
     SESSION_START_METADATA_SLOT,
-)
-from rasa.shared.nlu.constants import (
-    INTENT,
-    INTENT_NAME_KEY,
-    FULL_RETRIEVAL_INTENT_NAME_KEY,
 )
 
 import logging
@@ -1967,7 +1967,7 @@ async def test_update_full_retrieval_intent(
                     "response": {
                         "responses": [
                             {
-                                "text": "I am not sure of the whole week but I can see the sun is out today."
+                                "text": "The sun is out today! Isn't that great?",
                             },
                         ],
                         "confidence": 1.0,

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -84,6 +84,11 @@ from rasa.shared.core.constants import (
     IS_EXTERNAL,
     SESSION_START_METADATA_SLOT,
 )
+from rasa.shared.nlu.constants import (
+    INTENT,
+    INTENT_NAME_KEY,
+    FULL_RETRIEVAL_INTENT_NAME_KEY,
+)
 
 import logging
 
@@ -1928,3 +1933,62 @@ async def test_run_anonymization_pipeline_mocked_pipeline(
     await processor.run_anonymization_pipeline(tracker)
 
     event_diff.assert_called_once()
+
+
+async def test_update_full_retrieval_intent(
+    default_processor: MessageProcessor,
+) -> None:
+    parse_data = {
+        "text": "I like sunny days in berlin",
+        "intent": {"name": "chitchat", "confidence": 0.9},
+        "entities": [],
+        "response_selector": {
+            {
+                "all_retrieval_intents": ["faq", "chitchat"],
+                "faq": {
+                    "response": {
+                        "responses": [{"text": "Our return policy lasts 30 days."}],
+                        "confidence": 1.0,
+                        "intent_response_key": "faq/what_is_return_policy",
+                        "utter_action": "utter_faq/what_is_return_policy",
+                    },
+                    "ranking": [
+                        {
+                            "confidence": 1.0,
+                            "intent_response_key": "faq/what_is_return_policy",
+                        },
+                        {
+                            "confidence": 2.3378809862799945e-19,
+                            "intent_response_key": "faq/how_can_i_track_my_order",
+                        },
+                    ],
+                },
+                "chitchat": {
+                    "response": {
+                        "responses": [
+                            {
+                                "text": "I am not sure of the whole week but I can see the sun is out today."
+                            },
+                        ],
+                        "confidence": 1.0,
+                        "intent_response_key": "chitchat/ask_weather",
+                        "utter_action": "utter_chitchat/ask_weather",
+                    },
+                    "ranking": [
+                        {
+                            "confidence": 1.0,
+                            "intent_response_key": "chitchat/ask_weather",
+                        },
+                        {"confidence": 0.0, "intent_response_key": "chitchat/ask_name"},
+                    ],
+                },
+            }
+        },
+    }
+
+    default_processor._update_full_retrieval_intent(parse_data)
+
+    assert parse_data[INTENT][INTENT_NAME_KEY] == "chitchat"
+    # assert that parse_data["intent"] has a key called response
+    assert FULL_RETRIEVAL_INTENT_NAME_KEY in parse_data[INTENT]
+    assert parse_data[INTENT][FULL_RETRIEVAL_INTENT_NAME_KEY] == "chitchat/ask_weather"


### PR DESCRIPTION
**Proposed changes**:
- Adds `FULL_RETRIEVAL_INTENT_NAME_KEY` to the intent dictionary. This has downstream effects and fixes a bug in the Analytics pipeline that expects this key
- Works on [ATO-1956](https://rasahq.atlassian.net/browse/ATO-1956)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-1956]: https://rasahq.atlassian.net/browse/ATO-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ