### PR TITLE
SQL event.timestamp is not always unique 

### DIFF
--- a/changelog/13019.bugfix.md
+++ b/changelog/13019.bugfix.md
@@ -1,0 +1,1 @@
+Changed the ordering of returned events to order by ID (previously timestamp) in SQL Tracker Store

--- a/rasa/core/exporter.py
+++ b/rasa/core/exporter.py
@@ -160,7 +160,7 @@ class Exporter:
         self, conversation_ids_in_tracker_store: Set[Text]
     ) -> None:
         """Warn user if `self.requested_conversation_ids` contains IDs not found in
-        `conversation_ids_in_tracker_store`
+        `conversation_ids_in_tracker_store`.
 
         Args:
             conversation_ids_in_tracker_store: Set of conversation IDs contained in

--- a/rasa/core/exporter.py
+++ b/rasa/core/exporter.py
@@ -243,6 +243,7 @@ class Exporter:
             events = self._get_events_for_conversation_id(_events, conversation_id)
 
             # the order of events was changed after ATO-2192
+            # more context: https://github.com/RasaHQ/rasa/pull/13019
             # we should sort the events by timestamp to keep the order
             events.sort(key=lambda x: x["timestamp"])
 

--- a/rasa/core/exporter.py
+++ b/rasa/core/exporter.py
@@ -241,6 +241,11 @@ class Exporter:
                 continue
 
             events = self._get_events_for_conversation_id(_events, conversation_id)
+
+            # the order of events was changed after ATO-2192
+            # we should sort the events by timestamp to keep the order
+            events.sort(key=lambda x: x["timestamp"])
+
             # the conversation IDs are needed in the event publishing
             for event in events:
                 if (

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1325,7 +1325,7 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
                 )
             )
 
-        return event_query.order_by(self.SQLEvent.id)
+        return event_query.order_by(self.SQLEvent.timestamp, self.SQLEvent.id)
 
     async def save(self, tracker: DialogueStateTracker) -> None:
         """Update database with events from the current conversation."""

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1325,7 +1325,7 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
                 )
             )
 
-        return event_query.order_by(self.SQLEvent.timestamp)
+        return event_query.order_by(self.SQLEvent.id)
 
     async def save(self, tracker: DialogueStateTracker) -> None:
         """Update database with events from the current conversation."""

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1325,7 +1325,7 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
                 )
             )
 
-        return event_query.order_by(self.SQLEvent.timestamp, self.SQLEvent.id)
+        return event_query.order_by(self.SQLEvent.id)
 
     async def save(self, tracker: DialogueStateTracker) -> None:
         """Update database with events from the current conversation."""

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -1291,6 +1291,9 @@ class SQLTrackerStore(TrackerStore, SerializedTrackerAsText):
         self, session: "Session", sender_id: Text, fetch_events_from_all_sessions: bool
     ) -> "Query":
         """Provide the query to retrieve the conversation events for a specific sender.
+        The events are ordered by ID to ensure correct sequence of events.
+        As `timestamp` is not guaranteed to be unique and low-precision (float), it
+        cannot be used to order the events.
 
         Args:
             session: Current database session.

--- a/tests/core/test_exporter.py
+++ b/tests/core/test_exporter.py
@@ -73,9 +73,9 @@ async def test_fetch_events_within_time_range():
     conversation_ids = ["some-id", "another-id"]
 
     # prepare events from different senders and different timestamps
-    event_1 = random_user_uttered_event(3)
-    event_2 = random_user_uttered_event(2)
-    event_3 = random_user_uttered_event(1)
+    event_1 = random_user_uttered_event(1)
+    event_2 = random_user_uttered_event(3)
+    event_3 = random_user_uttered_event(2)
     events = {conversation_ids[0]: [event_1, event_2], conversation_ids[1]: [event_3]}
 
     def _get_tracker(conversation_id: Text) -> DialogueStateTracker:

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -671,7 +671,7 @@ async def test_tracker_store_retrieve_with_session_started_events(
     # Retrieve tracker with events since latest SessionStarted
     tracker = await tracker_store.retrieve(sender_id)
 
-    assert len(tracker.events) == 3
+    assert len(tracker.events) == 2
     assert all((event == tracker.events[i] for i, event in enumerate(events[2:])))
 
 

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -614,6 +614,36 @@ async def test_sql_additional_events_with_session_start(domain: Domain):
         assert isinstance(additional_events[0], UserUttered)
 
 
+async def test_tracker_store_retrieve_ordered_by_id(
+    domain: Domain,
+):
+    tracker_store_kwargs = {"host": "sqlite:///"}
+    tracker_store = SQLTrackerStore(domain, **tracker_store_kwargs)
+    events = [
+        SessionStarted(timestamp=1),
+        UserUttered("Hola", {"name": "greet"}, timestamp=2),
+        BotUttered("Hi", timestamp=2),
+        UserUttered("How are you?", {"name": "greet"}, timestamp=2),
+        BotUttered("I am good, whats up", timestamp=2),
+        UserUttered("Ciao", {"name": "greet"}, timestamp=2),
+        BotUttered("Bye", timestamp=2),
+    ]
+    sender_id = "test_sql_tracker_store_events_order"
+    tracker = DialogueStateTracker.from_events(sender_id, events)
+    await tracker_store.save(tracker)
+
+    # Save other tracker to ensure that we don't run into problems with other senders
+    other_tracker = DialogueStateTracker.from_events("other-sender", [SessionStarted()])
+    await tracker_store.save(other_tracker)
+
+    # Retrieve tracker with events since latest SessionStarted
+    tracker = await tracker_store.retrieve(sender_id)
+
+    assert len(tracker.events) == 7
+    # assert the order of events is same as the order in which they were added
+    assert all((event == tracker.events[i] for i, event in enumerate(events)))
+
+
 @pytest.mark.parametrize(
     "tracker_store_type,tracker_store_kwargs",
     [(MockedMongoTrackerStore, {}), (SQLTrackerStore, {"host": "sqlite:///"})],
@@ -641,7 +671,7 @@ async def test_tracker_store_retrieve_with_session_started_events(
     # Retrieve tracker with events since latest SessionStarted
     tracker = await tracker_store.retrieve(sender_id)
 
-    assert len(tracker.events) == 2
+    assert len(tracker.events) == 3
     assert all((event == tracker.events[i] for i, event in enumerate(events[2:])))
 
 


### PR DESCRIPTION
**Proposed changes**:
- Works on https://rasahq.atlassian.net/browse/ATO-2192
- The timestamps are being set by [events.py](https://github.com/RasaHQ/rasa/blob/3.6.x/rasa/shared/core/events.py#L284) when the events are created. There seem to be two losses at play here,
  - [documentation](https://docs.python.domainunion.de/3/library/time.html#time.time) of time.time() notes that "not all systems provide time with a better precision than 1 second". This is a little wild to me!
  - precision loss due to timestamp being a float type: Given that timestamp is created during event object creation. The case of (ev1.id > ev2.id) && (ev1.timestamp < ev2.timestamp) don't seem to be possible here. I also can't think of why sorting by timestamp would be good idea at all (possibility of collisions even in high-precision systems).

While the original query is quite complicated,
```
SELECT *
FROM events
WHERE sender_id = :sender_id
  AND (
    timestamp >= (
      SELECT max(events.timestamp) AS session_start
      FROM events
      WHERE events.sender_id = :sender_id
        AND events.type_name = :type_name
    )
    OR (
      (
        SELECT max(events.timestamp) AS session_start
        FROM events
        WHERE events.sender_id = :sender_id
          AND events.type_name = :type_name
      ) IS NULL
    )
  )
ORDER BY timestamp, id;
```

I've some quick results on the performance of this query. Order by ID understandably is the best option for performance.

Order by `timestamp`
```
zi=# explain select * from events order by timestamp;                                                       QUERY PLAN                             
-------------------------------------------------------------------
 Sort  (cost=544.08..553.94 rows=3945 width=490)
   Sort Key: "timestamp"
   ->  Seq Scan on events  (cost=0.00..308.45 rows=3945 width=490)
(3 rows)
```

Order by `id`
```
----------------------------------------------------------------------------------
 Index Scan using events_pkey on events  (cost=0.29..543.61 rows=10088 width=177)
(1 row)
```

Order by `timestamp` and `id`
```
zi=# explain select * from events order by timestamp, id;
                             QUERY PLAN                             
--------------------------------------------------------------------
 Sort  (cost=1040.75..1065.97 rows=10088 width=177)
   Sort Key: "timestamp", id
   ->  Seq Scan on events  (cost=0.00..369.88 rows=10088 width=177)
(3 rows)
```

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
