### PR TITLE
fix link to Studio docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -86,7 +86,7 @@ module.exports = {
           target: "_self",
           label: "Rasa Studio",
           position: "left",
-          href: `${SITE_URL}/docs/rasa-studio/`,
+          href: `${SITE_URL}/docs/studio/`,
         },
         {
           label: "Rasa Open Source",


### PR DESCRIPTION
Changes the link to Studio docs from incorrect https://rasa.com/docs/rasa-studio/ to correct https://rasa.com/docs/studio/