### PR TITLE
Update slack release notifications channels

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -1264,10 +1264,9 @@ jobs:
           sentry-cli releases set-commits --auto "rasa-$GITHUB_TAG"
           sentry-cli releases finalize "rasa-$GITHUB_TAG"
 
-      - name: Notify Slack & Publish Release Notes 🗞
+      - name: Publish Release Notes 🗞
         env:
           GH_RELEASE_NOTES_TOKEN: ${{ secrets.GH_RELEASE_NOTES_TOKEN }}
-          SLACK_WEBHOOK_TOKEN: ${{ secrets.SLACK_WEBHOOK_TOKEN }}
           GITHUB_TAG: ${{ github.ref }}
           GITHUB_REPO_SLUG: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1275,7 +1274,16 @@ jobs:
           GITHUB_TAG=${GITHUB_TAG/refs\/tags\//}
           pip install -U github3.py pep440-version-utils
           python3 scripts/publish_gh_release_notes.py
-          ./scripts/ping_slack_about_package_release.sh
+
+      - name: Notify Slack of successful release
+        # notification will be sent to the #product channel on slack, webhook url is added as repository secret
+        if: success()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ASSISTANT_RELEASE_WEBHOOK }}
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a
+        with:
+          args: "💥 New *Rasa Open Source * version `${{ github.ref_name }}` has been released!"
+
 
   send_slack_notification_for_release_on_failure:
     name: Notify Slack & Publish Release Notes
@@ -1290,7 +1298,7 @@ jobs:
         # send notification if 'deploy' is skipped (previous needed job failed) or failed
         if: needs.deploy.result != 'success'
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ASSISTANT_DEV_TRIBE_WEBHOOK }}
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a
         with:
           args: "⛔️ *Rasa Open Source* version `${{ github.ref_name }}` could not be released 😱! Please check out GitHub Actions: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
**Proposed changes**:
- Release success notifications will be sent to channel #release and failure on #dev-tribe
