### PR TITLE
missing config option should error out with user prompt

### DIFF
--- a/rasa/cli/data.py
+++ b/rasa/cli/data.py
@@ -147,7 +147,7 @@ def _add_data_validate_parsers(
 
 def _build_training_data_importer(args: argparse.Namespace) -> "TrainingDataImporter":
     config = rasa.cli.utils.get_validated_path(
-        args.config, "config", DEFAULT_CONFIG_PATH, none_is_valid=True
+        args.config, "config", DEFAULT_CONFIG_PATH, none_is_valid=False
     )
 
     # Exit the validation if the domain path is invalid


### PR DESCRIPTION
In the current releases of 3.8.x, when running `rasa data validate` if `config.yml` does not exist, failing to specify the path to the config file with `--config` results in a stack trace:

```
Traceback (most recent call last):
  File "/.../python-3.10/bin/rasa", line 8, in <module>
    sys.exit(main())
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/__main__.py", line 133, in main
2024-04-05 12:40:25 DEBUG    urllib3.connectionpool  - Starting new HTTPS connection (1): o251570.ingest.sentry.io:443
    cmdline_arguments.func(cmdline_arguments)
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/cli/data.py", line 124, in <lambda>
    args.fail_on_warnings, args.max_history, _build_training_data_importer(args)
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/cli/data.py", line 175, in _build_training_data_importer
    return TrainingDataImporter.load_from_config(
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/shared/importers/importer.py", line 119, in load_from_config
    config = read_config_file(config_path)
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/shared/utils/yaml.py", line 400, in read_config_file
    return read_validated_yaml(filename, CONFIG_SCHEMA_FILE, reader_type)
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/shared/utils/yaml.py", line 530, in read_validated_yaml
    content = read_file(filename)
  File "/.../python-3.10/lib/python3.10/site-packages/rasa/shared/utils/io.py", line 113, in read_file
    with open(filename, encoding=encoding) as f:
TypeError: expected str, bytes or os.PathLike object, not NoneType
```


**Proposed changes**:
- change the value of `none_is_valid` to `False` in the call to `get_validated_path()`

**Status (please check what you already did)**:
- [ ] added some tests for the functionality 
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
