### PR TITLE
Add upper limit version constraint for scipy on 3.6.x

### DIFF
--- a/changelog/13031.misc.md
+++ b/changelog/13031.misc.md
@@ -1,0 +1,1 @@
+Add upper limit constraint for scipy dependency version in `pyproject.toml`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -6956,4 +6956,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "8e1bef6b78365110ec598219ee747edb505f82a76fd03bdcffcec7a299b39513"
+content-hash = "4c84d994449f859816e48dd00d77f31f6f9d964e29a9f6060300c51d923786e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ version = ">=1.4.1,<1.7.3"
 python = "~=3.7.0"
 
 [[tool.poetry.dependencies.scipy]]
-version = ">=1.10.0"
+version = ">=1.10.0,<1.11.0"
 python = ">=3.8,<3.11"
 
 [[tool.poetry.dependencies.scikit-learn]]


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-2362](https://rasahq.atlassian.net/browse/ATO-2362)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)


[ATO-2362]: https://rasahq.atlassian.net/browse/ATO-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ