### PR TITLE
Fix mixed language tokenization in JiebaTokenizer

### DIFF
--- a/rasa/nlu/tokenizers/jieba_tokenizer.py
+++ b/rasa/nlu/tokenizers/jieba_tokenizer.py
@@ -101,7 +101,15 @@ class JiebaTokenizer(Tokenizer):
         text = message.get(attribute)
 
         tokenized = jieba.tokenize(text)
-        tokens = [Token(word, start) for (word, start, end) in tokenized]
+        tokens = []
+        current_position = 0
+        for word, start, end in tokenized:
+            if word.strip() == "":
+                continue
+            word_start = text.find(word, current_position)
+            word_end = word_start + len(word)
+            tokens.append(Token(word, word_start, word_end))
+            current_position = word_end
 
         return self._apply_token_pattern(tokens)
 

--- a/tests/nlu/tokenizers/test_jieba_tokenizer.py
+++ b/tests/nlu/tokenizers/test_jieba_tokenizer.py
@@ -37,6 +37,11 @@ def create_jieba(config: Optional[Dict] = None) -> JiebaTokenizer:
             ["Micheal", "你好", "吗", "？"],
             [(0, 7), (7, 9), (9, 10), (10, 11)],
         ),
+        (
+            "安装 rasa 应用",
+            ["安装", "rasa", "应用"],
+            [(0, 2), (3, 7), (8, 10)],
+        ),
     ],
 )
 def test_jieba(text, expected_tokens, expected_indices):


### PR DESCRIPTION
**Proposed changes**:
- Modify `JiebaTokenizer.tokenize` to correctly process mixed Chinese and English texts. This adjustment is aimed at resolving the issue where additional white space tokens were generated between Chinese and English tokens, which previously led to dimension mismatch errors during model training.

**Detailed explanation**:
- Updated the tokenize method to skip whitespace tokens and accurately find each token's position using the text itself rather than relying solely on Jieba's output. This change helps prevent the dimension mismatch error and is a response to the issues reported in Jira as OSS-275 and OSS-539.

**Benefits**:
- Prevents training errors when training data contains mixed Chinese and English languages.
- Improves the robustness of tokenization in mixed language scenarios.

**Related Jira Issues**:
- [OSS-275](https://rasa-open-source.atlassian.net/browse/OSS-275)
- [OSS-539](https://rasa-open-source.atlassian.net/browse/OSS-539)

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

**Additional notes**:
- Further testing in different operational environments is recommended to ensure compatibility and efficiency.
