### PR TITLE
3.6.x fix http_interpreter data, it should be `message.message_id` not `message.sender_id`

### DIFF
--- a/rasa/core/http_interpreter.py
+++ b/rasa/core/http_interpreter.py
@@ -37,7 +37,7 @@ class RasaNLUHttpInterpreter:
             "text": "",
         }
 
-        result = await self._rasa_http_parse(message.text, message.sender_id)
+        result = await self._rasa_http_parse(message.text, message.message_id)
         return result if result is not None else default_return
 
     async def _rasa_http_parse(


### PR DESCRIPTION
it should be message.message_id not message.sender_id

https://rasa-open-source.atlassian.net/jira/software/c/projects/OSS/issues/OSS-766

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
