### PR TITLE
Fix endoding issues

### DIFF
--- a/rasa/shared/nlu/training_data/formats/readerwriter.py
+++ b/rasa/shared/nlu/training_data/formats/readerwriter.py
@@ -192,7 +192,7 @@ class TrainingDataWriter:
                 [(k, v) for k, v in entity_dict.items() if v is not None]
             )
 
-            return f"{json.dumps(entity_dict)}"
+            return f"{json.dumps(entity_dict, ensure_ascii=False)}"
 
     @staticmethod
     def generate_entity(


### PR DESCRIPTION
Fixes encoding issues referenced in [issue OSS-781](https://rasa-open-source.atlassian.net/browse/OSS-781) while running `rasa data split nlu` with entities containing non-english characters

**Proposed changes**:
- Add `ensure_ascii=False` for `json.dumps` in TrainingDataWriter in order to properly encode non-ascii chatacters, e.g. Polish letters as referenced in [issue OSS-781](https://rasa-open-source.atlassian.net/browse/OSS-781)

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
