### PR TITLE
Cache `all_subclasses` to reduce `inspect` cost

### DIFF
--- a/rasa/shared/utils/common.py
+++ b/rasa/shared/utils/common.py
@@ -51,6 +51,11 @@ def class_from_module_path(
     return klass
 
 
+# calls to inspect are expensive and the individual types this function sees
+# are limited (basically all possible slot and event classes which are in the
+# order of tens). caching speeds up, for example, tracker copying in the tracker
+# store.
+@functools.lru_cache(maxsize=100)
 def all_subclasses(cls: Any) -> List[Any]:
     """Returns all known (imported) subclasses of a class."""
     classes = cls.__subclasses__() + [


### PR DESCRIPTION
Hey :sunflower: 
We are currently experimenting with using an event broker to also do logging based on tracker contents and found that
`rasa.shared.utils.common.all_subclasses` is having a needlessly large (100%) overhead on our runtime.

Since the parameters variations of these functions are limited to the number of slot and event classes, we can use an LRU cache to cache all calls to this function. It is also very unlikely for the result to change during runtime, so no invalidation is needed.

We think that this will also help overall performance in more common circumstances.

We conducted three tests: a baseline run, using our event broker logging and the event broker logging with the LRU cache 
around `all_subclasses`. Sample size was 10 conversations in succession for each experiment.

Results:
- baseline: 53s
- event broker with logging: 114s
- event broker with logging & LRU cache: 59s

As you can see, `all_subclasses` introduced a ~100% overhead while being essentially a lookup table.
It would be nice and quite helpful if this change could be merged.

**Proposed changes**:
- use LRU cache for `rasa.shared.utils.common.all_subclasses` to reduce overhead cost significantly

**Status (please check what you already did)**:
- [x] added some tests for the functionality (current tests cover this)
- [x] updated the documentation (not necessary)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)

**Profiles of the individual experiments**

Baseline:
![Baseline profile](https://github.com/user-attachments/assets/c8ff75c4-10be-4513-bbbb-37187aacacd5)

Event broker with logging:
![image](https://github.com/user-attachments/assets/90c839cb-0fb6-4dae-9daa-0e5ecdb537e6)

Event broker with logging & LRU cache:
![image](https://github.com/user-attachments/assets/3cede73b-b69f-41d6-a414-b9c6bf2e624a)


