### PR TITLE
Fix Await issue in Python > 5.10 when session_persistence is set to True

### DIFF
--- a/rasa/core/channels/socketio.py
+++ b/rasa/core/channels/socketio.py
@@ -227,7 +227,7 @@ class SocketIOInput(InputChannel):
             if "session_id" not in data or data["session_id"] is None:
                 data["session_id"] = uuid.uuid4().hex
             if self.session_persistence:
-                sio.enter_room(sid, data["session_id"])
+                await sio.enter_room(sid, data["session_id"])
             await sio.emit("session_confirm", data["session_id"], room=sid)
             logger.debug(f"User {sid} connected to socketIO endpoint.")
 


### PR DESCRIPTION
This fixes this https://forum.rasa.com/t/event-sent-by-socketio-channel-when-session-persistence-is-set-to-true/41988/3

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
