### PR TITLE
Update Chat Widget documentation to use new @rasahq/chat-widget-ui package

### DIFF
--- a/docs/docs/connectors/your-own-website.mdx
+++ b/docs/docs/connectors/your-own-website.mdx
@@ -171,16 +171,33 @@ as a JSON object under the key `token`:
 
 ### Chat Widget
 
-Once you've set up your SocketIO channel, you can use the official Rasa Chat Widget on any webpage.
-Just paste the following into your site HTML and paste the URL of your Rasa instance into
-the `data-websocket-url` attribute
+Once you've set up your SocketIO channel, you can use the [official Rasa Chat Widget](https://github.com/RasaHQ/chat-widget) on any webpage. Use the example HTML below and paste the URL of your Rasa instance into the `server-url` attribute:
 
 ```html
-<div id="rasa-chat-widget" data-websocket-url="https://your-rasa-url-here/"></div>
-<script src="https://unpkg.com/@rasahq/rasa-chat" type="application/javascript"></script>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HTML Example</title>
+    <script
+      type="module"
+      src="https://unpkg.com/@rasahq/chat-widget-ui/dist/rasa-chatwidget/rasa-chatwidget.esm.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@rasahq/chat-widget-ui/dist/rasa-chatwidget/rasa-chatwidget.css"
+    />
+  </head>
+  <body>
+    <rasa-chatbot-widget server-url="https://example.com"></rasa-chatbot-widget>
+  </body>
+</html>
 ```
 
-For more information, including how to fully customize the widget for your website, you can check out the [full documentation](https://chat-widget-docs.rasa.com/).
+For more information, including how to fully customize the widget for your website, you can check out the [full documentation](https://chatwidget.rasa.com/).
 
-Alternatively, if you want to embed the widget in a React app, there is
-[a library in the NPM package repository](https://www.npmjs.com/package/@rasahq/rasa-chat).
+Alternatively, if you want to embed the widget in a React app, there is [a library in the NPM package repository](https://www.npmjs.com/package/@rasahq/chat-widget-react).
+
+:::note Deprecated Chat Widget
+For information on the deprecated chat widget, [rasa-chat](https://www.npmjs.com/package/@rasahq/rasa-chat), documentation can be found [here](https://chat-widget-docs.rasa.com/).:::


### PR DESCRIPTION
## Update Chat Widget documentation to use new `@rasahq/chat-widget-ui` package

**Proposed changes**:
- Replaced the outdated `@rasahq/rasa-chat` embed snippet with the new `@rasahq/chat-widget-ui` web component (`<rasa-chatbot-widget>`).
- Updated the HTML example to reflect the new package's script/stylesheet imports and `server-url` attribute.
- Updated the "full documentation" link to point to the new docs at `https://chatwidget.rasa.com/`.
- Updated the React NPM package link to `@rasahq/chat-widget-react`.
- Added a deprecation note pointing users to the old `rasa-chat` widget docs for reference.

**Motivation**:
The previously documented `@rasahq/rasa-chat` package is deprecated. The new `@rasahq/chat-widget-ui` package is the current officially supported widget and is already documented in Rasa Pro. This change brings the Rasa OSS documentation in line with the current recommended approach.

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)